### PR TITLE
feat(codex-bridge): OMC plugin skill sync to Codex ~/.agents/skills/ (v1.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "YoungjaeDev"
   },
   "metadata": {
-    "description": "Personal Claude Code plugin collection with 21 specialized plugins",
+    "description": "Personal Claude Code plugin collection with 22 specialized plugins",
     "version": "1.7.9"
   },
   "plugins": [
@@ -96,7 +96,7 @@
       "name": "humanizer",
       "source": "./plugins/humanizer",
       "description": "Remove AI writing patterns from text",
-      "version": "2.2.0",
+      "version": "2.1.1",
       "category": "content"
     },
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,8 +4,8 @@
     "name": "YoungjaeDev"
   },
   "metadata": {
-    "description": "Personal Claude Code plugin collection with 20 specialized plugins",
-    "version": "1.7.8"
+    "description": "Personal Claude Code plugin collection with 21 specialized plugins",
+    "version": "1.7.9"
   },
   "plugins": [
     {
@@ -147,6 +147,13 @@
       "description": "Rewrite prompts using Google's TCREI structure for next-session reuse",
       "version": "1.0.0",
       "category": "content"
+    },
+    {
+      "name": "codex-bridge",
+      "source": "./plugins/codex-bridge",
+      "description": "Sync OMC plugin skills to Codex ~/.agents/skills/ with body-only transform and bridge_source provenance",
+      "version": "1.0.0",
+      "category": "integration"
     }
   ]
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -17,7 +17,8 @@
       "./plugins/slidev",
       "./plugins/workflow-viz",
       "./plugins/rules-forge",
-      "./plugins/tcrei-prompt"
+      "./plugins/tcrei-prompt",
+      "./plugins/codex-bridge"
     ]
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 Plugin-based configuration for Claude Code with multi-agent orchestration.
 
-## Plugins (21)
+## Plugins (22)
 
 ### Core
 | Plugin | Description |
@@ -65,6 +65,11 @@ Plugin-based configuration for Claude Code with multi-agent orchestration.
 |--------|-------------|
 | `workflow-viz` | System workflow Mermaid diagrams and ASCII progress tracking |
 
+### Integration
+| Plugin | Description |
+|--------|-------------|
+| `codex-bridge` | Sync OMC plugin skills to Codex `~/.agents/skills/` with body-only transform |
+
 ## Structure
 
 ```
@@ -92,7 +97,8 @@ Plugin-based configuration for Claude Code with multi-agent orchestration.
 │   ├── rules-forge/        # CLAUDE.md rules
 │   ├── slidev/             # Presentation generator
 │   ├── workflow-viz/       # Workflow visualization
-│   └── tcrei-prompt/       # TCREI prompt structuring
+│   ├── tcrei-prompt/       # TCREI prompt structuring
+│   └── codex-bridge/       # OMC → Codex skill sync
 ├── CLAUDE.md               # This file
 └── README.md               # Full documentation
 ```

--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ OMC 플러그인 skill 들 (`plugins/*/skills/**/SKILL.md`)을 Codex CLI 가 네
 - **Body-only transform**: frontmatter 는 불변, body 만 7개 rule 치환
 - **Orphan prune**: `bridge_source` 있고 source 없어진 skill 자동 삭제
 
-**Transform rules (body-only):** `.omc/` → `.omx/`, `CLAUDE.md` → `AGENTS.md`, `/oh-my-claudecode:` → `$`, `~/.claude/` → `~/.codex/`, word-boundary `omc` → `omx`, `OMC` → `OMX`
+**Transform rules (body-only, 7개):** `.omc/` → `.omx/`, `CLAUDE.md` → `AGENTS.md`, `/oh-my-claudecode:` → `$`, `oh-my-claudecode` → `oh-my-codex`, `~/.claude/` → `~/.codex/`, word-boundary `omc` → `omx`, `OMC` → `OMX`
 
 **진입점:**
 - Claude Code: `$codex-sync [options]`

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
 
 # my-claude-plugins
 
-Claude Code를 위한 21개 플러그인 모음 - GitHub 워크플로우부터 AI 이미지 생성까지
+Claude Code를 위한 22개 플러그인 모음 - GitHub 워크플로우부터 AI 이미지 생성까지
 
-[![Plugins](https://img.shields.io/badge/plugins-21-blue.svg)](https://github.com/YoungjaeDev/my-claude-plugins)
+[![Plugins](https://img.shields.io/badge/plugins-22-blue.svg)](https://github.com/YoungjaeDev/my-claude-plugins)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-compatible-purple.svg)](https://docs.anthropic.com/claude-code)
 
@@ -87,6 +87,7 @@ rm -rf ~/.claude/plugins/cache/my-claude-plugins/
 | **Docs** | `docs-forge` | README/CHANGELOG 생성 (CRO 최적화) |
 | | `rules-forge` | CLAUDE.md 생성 및 .claude/rules/ 모듈화 |
 | **Visualization** | `workflow-viz` | 시스템 워크플로우 Mermaid 다이어그램, ASCII 진행 추적 |
+| **Integration** | `codex-bridge` | OMC skill을 Codex `~/.agents/skills/`로 body-only 변환 동기화 |
 | **Orchestration** | `omc` | oh-my-claudecode 멀티 에이전트 오케스트레이션 (marketplace) |
 
 ## 설치 옵션
@@ -329,6 +330,31 @@ Google TCREI 구조(Task, Context, References, Evaluate, Iterate)로 프롬프�
 
 </details>
 
+### Integration
+
+<details>
+<summary><strong>codex-bridge</strong> - OMC → Codex skill 동기화</summary>
+
+OMC 플러그인 skill 들 (`plugins/*/skills/**/SKILL.md`)을 Codex CLI 가 네이티브로 로드하는 `~/.agents/skills/` (OpenAI 공식 USER scope) 로 idempotent 변환·복사.
+
+**핵심 원칙:**
+- **SSOT**: OMC source 는 단일 소스, `~/.agents/skills/` 는 derived artifact (양방향 sync 아님)
+- **Safety**: `bridge_source` 마커 없는 파일은 절대 건드리지 않음 (OMX / 사용자 파일 보호)
+- **Body-only transform**: frontmatter 는 불변, body 만 7개 rule 치환
+- **Orphan prune**: `bridge_source` 있고 source 없어진 skill 자동 삭제
+
+**Transform rules (body-only):** `.omc/` → `.omx/`, `CLAUDE.md` → `AGENTS.md`, `/oh-my-claudecode:` → `$`, `~/.claude/` → `~/.codex/`, word-boundary `omc` → `omx`, `OMC` → `OMX`
+
+**진입점:**
+- Claude Code: `$codex-sync [options]`
+- Direct CLI: `node plugins/codex-bridge/scripts/sync.mjs [options]`
+
+**CLI options:** `--dry-run`, `--verbose`, `--config <path>`, `--plugin <list>`, `--no-prune`, `--report <path>`
+
+**Requirements:** Node 18+, Codex CLI 0.120.0+
+
+</details>
+
 ### Planning & Methodology
 
 <details>
@@ -459,7 +485,8 @@ CLAUDE.md 생성, 기존 파일을 `.claude/rules/`로 분리.
       "./plugins/docs-forge",
       "./plugins/rules-forge",
       "./plugins/workflow-viz",
-      "./plugins/tcrei-prompt"
+      "./plugins/tcrei-prompt",
+      "./plugins/codex-bridge"
     ]
   }
 }
@@ -500,7 +527,8 @@ CLAUDE.md 생성, 기존 파일을 `.claude/rules/`로 분리.
 │   ├── docs-forge/            # README/CHANGELOG 생성
 │   ├── rules-forge/           # CLAUDE.md 규칙 생성
 │   ├── workflow-viz/          # 워크플로우 시각화
-│   └── tcrei-prompt/          # TCREI 프롬프트 구조화
+│   ├── tcrei-prompt/          # TCREI 프롬프트 구조화
+│   └── codex-bridge/          # OMC → Codex skill 동기화
 ├── CLAUDE.md
 └── README.md
 ```

--- a/plugins/codex-bridge/.claude-plugin/plugin.json
+++ b/plugins/codex-bridge/.claude-plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "codex-bridge",
+  "version": "1.0.0",
+  "description": "Sync OMC plugin skills to Codex ~/.agents/skills/ with body-only transform and bridge_source provenance marker"
+}

--- a/plugins/codex-bridge/CLAUDE.md
+++ b/plugins/codex-bridge/CLAUDE.md
@@ -1,0 +1,66 @@
+# Codex Bridge Plugin
+
+OMC 플러그인 skill 들을 Codex CLI 가 네이티브로 로드하는 `~/.agents/skills/` (OpenAI 공식 USER scope) 로 idempotent 하게 변환·복사한다.
+
+## Skill
+
+| Skill | Description |
+|-------|-------------|
+| `codex-sync` | Sync OMC plugin skills to `~/.agents/skills/` |
+
+## 원칙
+
+- **Single Source of Truth**: `plugins/*/skills/**` 이 원본, `~/.agents/skills/` 는 derived artifact. 양방향 sync 아님.
+- **Body-only transform**: frontmatter 는 불변 (`bridge_source` 마커 보존). body 만 7개 rule 로 치환.
+- **Safety guard**: `bridge_source` 없는 파일은 절대 건드리지 않음 (OMX · 사용자 파일 보호).
+- **Orphan prune**: `bridge_source` 있고 원본 사라진 skill 만 자동 삭제.
+
+## 진입점
+
+1. Claude Code skill: `/codex-bridge:codex-sync` (이 플러그인 활성화 시)
+2. Direct CLI: `node plugins/codex-bridge/scripts/sync.mjs [options]`
+3. V2 npm (예정): `npx @youngjaedev/omc-codex-sync`
+
+## CLI Options
+
+```
+--dry-run              파일 변경 없이 계획만 출력
+--verbose              파일별 행위 상세 출력
+--config <path>        커스텀 config 경로
+--plugin <list>        쉼표 구분 플러그인 필터
+--no-prune             auto-prune 비활성화
+--report <path>        JSON 리포트 파일 출력
+--help                 도움말
+```
+
+Exit codes: `0` 성공 · `1` 부분 실패 · `2` 치명적 (config 파싱 실패, 권한 없음)
+
+## Transform Rules (body-only)
+
+| From | To | Mode |
+|------|----|------|
+| `.omc/` | `.omx/` | literal |
+| `CLAUDE.md` | `AGENTS.md` | literal |
+| `/oh-my-claudecode:` | `$` | literal |
+| `oh-my-claudecode` | `oh-my-codex` | literal |
+| `~/.claude/` | `~/.codex/` | literal |
+| `omc` (word-boundary) | `omx` | regex `\bomc\b` |
+| `OMC` (word-boundary) | `OMX` | regex `\bOMC\b` |
+
+## 경로 정설
+
+- Target: `$HOME/.agents/skills/<name>/SKILL.md` — OpenAI 공식 USER scope
+- `~/.codex/skills/` (OMX 관리) 는 **절대 건드리지 않음**
+- `CODEX_HOME` env 는 state/log base 일 뿐, skill 디렉토리와 무관
+
+## Dependencies
+
+- Node 18+ (OMX 이미 요구)
+- OMX 설치 (권장, 필수 아님)
+- Codex CLI 0.120.0+
+
+## 참조
+
+- Spec: `.claude/spec/2026-04-14-codex-bridge-skill-sync.md`
+- OpenAI Codex Skills: https://developers.openai.com/codex/skills
+- OpenAI Codex Customization: https://developers.openai.com/codex/concepts/customization

--- a/plugins/codex-bridge/codex-bridge.config.json
+++ b/plugins/codex-bridge/codex-bridge.config.json
@@ -1,0 +1,25 @@
+{
+  "_comment": "Default config for codex-bridge. Override via --config <path>. scope=user → $HOME/.agents/skills (OpenAI USER scope). Set target.agentsHome to override (testing). CODEX_HOME has no effect on skill directory.",
+  "target": {
+    "scope": "user",
+    "agentsHome": null
+  },
+  "collisionFallbackPrefix": "omc-",
+  "exclude": [
+    "plugins/interactive-review/**",
+    "plugins/midjourney/**"
+  ],
+  "transform": {
+    "bodyOnly": true,
+    "rules": [
+      { "from": ".omc/", "to": ".omx/", "mode": "literal" },
+      { "from": "CLAUDE.md", "to": "AGENTS.md", "mode": "literal" },
+      { "from": "/oh-my-claudecode:", "to": "$", "mode": "literal" },
+      { "from": "oh-my-claudecode", "to": "oh-my-codex", "mode": "literal" },
+      { "from": "~/.claude/", "to": "~/.codex/", "mode": "literal" },
+      { "from": "omc", "to": "omx", "mode": "word-boundary" },
+      { "from": "OMC", "to": "OMX", "mode": "word-boundary" }
+    ],
+    "textExtensions": [".md", ".yml", ".yaml", ".json", ".sh", ".mjs", ".js", ".py", ".ts"]
+  }
+}

--- a/plugins/codex-bridge/scripts/sync.mjs
+++ b/plugins/codex-bridge/scripts/sync.mjs
@@ -294,11 +294,26 @@ export async function syncAll(options) {
     return true;
   });
 
+  const nameToPlugins = new Map();
+  for (const skill of filtered) {
+    const bucket = nameToPlugins.get(skill.skillName) ?? [];
+    bucket.push(skill.pluginName);
+    nameToPlugins.set(skill.skillName, bucket);
+  }
+  const collisions = [];
+  for (const [skillName, plugins] of nameToPlugins) {
+    if (plugins.length > 1) {
+      logger.warn(`[codex-bridge] collision: skill '${skillName}' in plugins [${plugins.join(', ')}] — last-wins after deterministic sort: ${plugins[plugins.length - 1]}`);
+      collisions.push({ skillName, plugins });
+    }
+  }
+
   const report = {
     dryRun,
     targetDir,
     discovered: allSkills.length,
     considered: filtered.length,
+    collisions,
     synced: [],
     skipped: [],
     removed: [],
@@ -553,6 +568,12 @@ export async function discoverSkills(pluginsDir) {
       if (err.code !== 'ENOENT') throw err;
     }
   }
+
+  results.sort((a, b) => {
+    if (a.pluginName !== b.pluginName) return a.pluginName < b.pluginName ? -1 : 1;
+    if (a.skillName !== b.skillName) return a.skillName < b.skillName ? -1 : 1;
+    return 0;
+  });
 
   return results;
 }

--- a/plugins/codex-bridge/scripts/sync.mjs
+++ b/plugins/codex-bridge/scripts/sync.mjs
@@ -1,0 +1,591 @@
+#!/usr/bin/env node
+// codex-bridge — Sync OMC plugin skills to Codex ~/.agents/skills/
+// Zero runtime dependencies. Node 18+.
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { fileURLToPath } from 'node:url';
+
+const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/;
+
+export const DEFAULT_RULES = [
+  { from: '.omc/', to: '.omx/', mode: 'literal' },
+  { from: 'CLAUDE.md', to: 'AGENTS.md', mode: 'literal' },
+  { from: '/oh-my-claudecode:', to: '$', mode: 'literal' },
+  { from: 'oh-my-claudecode', to: 'oh-my-codex', mode: 'literal' },
+  { from: '~/.claude/', to: '~/.codex/', mode: 'literal' },
+  { from: 'omc', to: 'omx', mode: 'word-boundary' },
+  { from: 'OMC', to: 'OMX', mode: 'word-boundary' },
+];
+
+function escapeRegex(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+export function applyTransforms(input, rules) {
+  let out = input;
+  for (const rule of rules) {
+    if (rule.mode === 'literal') {
+      out = out.split(rule.from).join(rule.to);
+    } else if (rule.mode === 'word-boundary') {
+      const re = new RegExp(`\\b${escapeRegex(rule.from)}\\b`, 'g');
+      out = out.replace(re, rule.to);
+    }
+  }
+  return out;
+}
+
+export function transformSkillContent(content, rules) {
+  const match = FRONTMATTER_RE.exec(content);
+  if (!match) {
+    return applyTransforms(content, rules);
+  }
+  const [, raw, body] = match;
+  return `---\n${raw}\n---\n${applyTransforms(body, rules)}`;
+}
+
+const TEXT_EXTENSIONS = new Set(['.md', '.yml', '.yaml', '.json', '.sh', '.mjs', '.js', '.py', '.ts']);
+const BRIDGE_SOURCE_LINE_RE = /^bridge_source:\s*.*$/m;
+
+export function injectBridgeSource(content, marker) {
+  const match = FRONTMATTER_RE.exec(content);
+  if (!match) {
+    return `---\nbridge_source: ${marker}\n---\n${content}`;
+  }
+  const [, raw, body] = match;
+  const newRaw = BRIDGE_SOURCE_LINE_RE.test(raw)
+    ? raw.replace(BRIDGE_SOURCE_LINE_RE, `bridge_source: ${marker}`)
+    : `${raw}\nbridge_source: ${marker}`;
+  return `---\n${newRaw}\n---\n${body}`;
+}
+
+export async function syncOne(source, targetRoot, rules, options = {}) {
+  const logger = options.logger ?? defaultLogger();
+  const sourceContent = await fs.readFile(source.skillPath, 'utf-8');
+  const parsed = parseFrontmatter(sourceContent);
+
+  if (!parsed) {
+    logger.warn(`[codex-bridge] ${source.pluginName}/${source.skillName}: source SKILL.md has no frontmatter, skipping`);
+    return { status: 'skipped', reason: 'source-missing-frontmatter' };
+  }
+
+  const targetSkillDir = path.join(targetRoot, source.skillName);
+  const targetSkillMd = path.join(targetSkillDir, 'SKILL.md');
+  const marker = `${source.pluginName}/${source.skillName}`;
+
+  try {
+    const existing = await fs.readFile(targetSkillMd, 'utf-8');
+    const existingParsed = parseFrontmatter(existing);
+    const hasBridgeMarker = existingParsed && 'bridge_source' in existingParsed.fields;
+    if (!hasBridgeMarker) {
+      logger.warn(`[codex-bridge] skip ${targetSkillMd}: not managed by OMC (missing bridge_source marker). Inspect with 'omx doctor'.`);
+      return { status: 'skipped', reason: 'non-managed-collision' };
+    }
+  } catch (err) {
+    if (err.code !== 'ENOENT') throw err;
+  }
+
+  const transformed = transformSkillContent(sourceContent, rules);
+  const withMarker = injectBridgeSource(transformed, marker);
+
+  await fs.mkdir(targetRoot, { recursive: true });
+  const stagingDir = await fs.mkdtemp(path.join(targetRoot, `.staging-${source.skillName}-`));
+
+  try {
+    await renderSkillTree(source.skillDir, stagingDir, rules, withMarker);
+    await fs.rm(targetSkillDir, { recursive: true, force: true });
+    await moveOrCopy(stagingDir, targetSkillDir);
+  } catch (err) {
+    await fs.rm(stagingDir, { recursive: true, force: true }).catch(() => {});
+    throw err;
+  }
+
+  return { status: 'synced', path: targetSkillMd, bridgeSource: marker };
+}
+
+async function moveOrCopy(from, to) {
+  try {
+    await fs.rename(from, to);
+  } catch (err) {
+    if (err.code !== 'EXDEV') throw err;
+    await fs.cp(from, to, { recursive: true, force: true });
+    await fs.rm(from, { recursive: true, force: true });
+  }
+}
+
+async function renderSkillTree(sourceDir, dstDir, rules, skillMdOverride) {
+  const entries = await fs.readdir(sourceDir, { withFileTypes: true });
+  await fs.mkdir(dstDir, { recursive: true });
+  for (const entry of entries) {
+    const srcPath = path.join(sourceDir, entry.name);
+    const dstPath = path.join(dstDir, entry.name);
+    if (entry.isDirectory()) {
+      await renderSkillTree(srcPath, dstPath, rules, null);
+    } else if (entry.isFile()) {
+      if (entry.name === 'SKILL.md' && skillMdOverride != null) {
+        await fs.writeFile(dstPath, skillMdOverride, 'utf-8');
+      } else {
+        await renderFile(srcPath, dstPath, rules);
+      }
+    }
+  }
+}
+
+async function renderFile(srcPath, dstPath, rules) {
+  const ext = path.extname(srcPath).toLowerCase();
+  if (TEXT_EXTENSIONS.has(ext)) {
+    const content = await fs.readFile(srcPath, 'utf-8');
+    await fs.writeFile(dstPath, applyTransforms(content, rules), 'utf-8');
+  } else {
+    await fs.copyFile(srcPath, dstPath);
+  }
+  if (ext === '.sh' || ext === '.mjs' || ext === '.js' || ext === '.py') {
+    try {
+      const stat = await fs.stat(srcPath);
+      await fs.chmod(dstPath, stat.mode);
+    } catch { /* best-effort */ }
+  }
+}
+
+function defaultLogger() {
+  return {
+    warn: (msg) => process.stderr.write(`${msg}\n`),
+    info: (msg) => process.stderr.write(`${msg}\n`),
+  };
+}
+
+export const DEFAULT_CONFIG = {
+  target: {
+    scope: 'user',
+    agentsHome: null,
+  },
+  collisionFallbackPrefix: 'omc-',
+  exclude: [],
+  transform: {
+    bodyOnly: true,
+    rules: DEFAULT_RULES,
+    textExtensions: [...TEXT_EXTENSIONS],
+  },
+};
+
+export async function loadConfig(configPath) {
+  if (!configPath) return cloneConfig(DEFAULT_CONFIG);
+  let raw;
+  try {
+    raw = await fs.readFile(configPath, 'utf-8');
+  } catch (err) {
+    if (err.code === 'ENOENT') return cloneConfig(DEFAULT_CONFIG);
+    throw err;
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(`Failed to parse config at ${configPath}: ${err.message}`);
+  }
+  return mergeConfig(DEFAULT_CONFIG, parsed);
+}
+
+function cloneConfig(cfg) {
+  return JSON.parse(JSON.stringify(cfg));
+}
+
+function mergeConfig(base, override) {
+  const out = cloneConfig(base);
+  if (override.target && typeof override.target === 'object') {
+    out.target = { ...out.target, ...override.target };
+  }
+  if (typeof override.collisionFallbackPrefix === 'string') {
+    out.collisionFallbackPrefix = override.collisionFallbackPrefix;
+  }
+  if (Array.isArray(override.exclude)) {
+    out.exclude = [...override.exclude];
+  }
+  if (override.transform && typeof override.transform === 'object') {
+    if (typeof override.transform.bodyOnly === 'boolean') out.transform.bodyOnly = override.transform.bodyOnly;
+    if (Array.isArray(override.transform.rules)) out.transform.rules = override.transform.rules.map(r => ({ ...r }));
+    if (Array.isArray(override.transform.textExtensions)) out.transform.textExtensions = [...override.transform.textExtensions];
+  }
+  return out;
+}
+
+export function isExcluded(relPath, patterns) {
+  if (!Array.isArray(patterns) || patterns.length === 0) return false;
+  return patterns.some(pattern => globToRegex(pattern).test(relPath));
+}
+
+function globToRegex(pattern) {
+  const DOUBLESTAR = '__CODEX_BRIDGE_DOUBLESTAR__';
+  const escaped = pattern
+    .replace(/[.+^${}()|[\]\\]/g, '\\$&')
+    .split('**').join(DOUBLESTAR)
+    .split('*').join('[^/]*')
+    .split(DOUBLESTAR).join('.*');
+  return new RegExp(`^${escaped}$`);
+}
+
+const KNOWN_FLAGS = new Set([
+  '--dry-run', '--verbose', '--no-prune', '--help', '-h',
+  '--config', '--plugin', '--report',
+]);
+
+export function parseArgs(argv) {
+  const out = {
+    dryRun: false,
+    verbose: false,
+    noPrune: false,
+    help: false,
+    configPath: null,
+    plugins: null,
+    reportPath: null,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (!KNOWN_FLAGS.has(arg)) {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+    switch (arg) {
+      case '--dry-run': out.dryRun = true; break;
+      case '--verbose': out.verbose = true; break;
+      case '--no-prune': out.noPrune = true; break;
+      case '--help':
+      case '-h':
+        out.help = true;
+        break;
+      case '--config':
+        out.configPath = argv[++i];
+        if (!out.configPath) throw new Error('--config requires a path');
+        break;
+      case '--plugin': {
+        const value = argv[++i];
+        if (!value) throw new Error('--plugin requires a comma-separated list');
+        out.plugins = value.split(',').map(s => s.trim()).filter(Boolean);
+        break;
+      }
+      case '--report':
+        out.reportPath = argv[++i];
+        if (!out.reportPath) throw new Error('--report requires a path');
+        break;
+    }
+  }
+  return out;
+}
+
+export async function syncAll(options) {
+  const {
+    pluginsDir,
+    targetDir,
+    config,
+    dryRun = false,
+    pluginFilter = null,
+    prune = true,
+    logger = defaultLogger(),
+  } = options;
+
+  const allSkills = await discoverSkills(pluginsDir);
+  const pluginsRoot = path.dirname(pluginsDir);
+
+  const filtered = allSkills.filter((skill) => {
+    if (pluginFilter && !pluginFilter.includes(skill.pluginName)) return false;
+    const rel = path.relative(pluginsRoot, skill.skillDir).split(path.sep).join('/');
+    if (isExcluded(rel, config.exclude)) return false;
+    if (isExcluded(`${rel}/SKILL.md`, config.exclude)) return false;
+    return true;
+  });
+
+  const report = {
+    dryRun,
+    targetDir,
+    discovered: allSkills.length,
+    considered: filtered.length,
+    synced: [],
+    skipped: [],
+    removed: [],
+    errors: [],
+  };
+
+  const validSources = new Set();
+  for (const skill of filtered) {
+    const marker = `${skill.pluginName}/${skill.skillName}`;
+    validSources.add(marker);
+
+    if (dryRun) {
+      logger.info(`[dry-run] would sync ${marker}`);
+      report.synced.push({ status: 'dry-run', bridgeSource: marker, skillName: skill.skillName });
+      continue;
+    }
+
+    try {
+      const result = await syncOne(skill, targetDir, config.transform.rules, { logger });
+      if (result.status === 'synced') {
+        logger.info(`[codex-bridge] synced ${marker} → ${result.path}`);
+        report.synced.push(result);
+      } else {
+        report.skipped.push({ ...result, skillName: skill.skillName, bridgeSource: marker });
+      }
+    } catch (err) {
+      logger.warn(`[codex-bridge] error syncing ${marker}: ${err.message}`);
+      report.errors.push({ skillName: skill.skillName, bridgeSource: marker, error: err.message });
+    }
+  }
+
+  if (prune && !dryRun) {
+    const pruneResult = await pruneOrphans(targetDir, validSources);
+    report.removed = pruneResult.removed;
+    for (const r of pruneResult.removed) {
+      logger.info(`[codex-bridge] pruned orphan ${r.skillName} (was ${r.bridgeSource})`);
+    }
+  } else if (prune && dryRun) {
+    const existingEntries = await fs.readdir(targetDir, { withFileTypes: true }).catch((err) => {
+      if (err.code === 'ENOENT') return [];
+      throw err;
+    });
+    for (const entry of existingEntries) {
+      if (!entry.isDirectory() || entry.name.startsWith('.staging-')) continue;
+      try {
+        const content = await fs.readFile(path.join(targetDir, entry.name, 'SKILL.md'), 'utf-8');
+        const parsed = parseFrontmatter(content);
+        if (parsed && 'bridge_source' in parsed.fields && !validSources.has(parsed.fields.bridge_source)) {
+          report.removed.push({ skillName: entry.name, bridgeSource: parsed.fields.bridge_source, dryRun: true });
+          logger.info(`[dry-run] would prune ${entry.name} (orphan ${parsed.fields.bridge_source})`);
+        }
+      } catch { /* skip */ }
+    }
+  }
+
+  return report;
+}
+
+export async function main(argv) {
+  let args;
+  try {
+    args = parseArgs(argv);
+  } catch (err) {
+    process.stderr.write(`${err.message}\n\n`);
+    printHelp();
+    return 2;
+  }
+
+  if (args.help) {
+    printHelp();
+    return 0;
+  }
+
+  const pluginRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+  const pluginsDir = path.resolve(pluginRoot, '..');
+  const configPath = args.configPath ?? path.join(pluginRoot, 'codex-bridge.config.json');
+
+  let config;
+  try {
+    config = await loadConfig(configPath);
+  } catch (err) {
+    process.stderr.write(`[codex-bridge] ${err.message}\n`);
+    return 2;
+  }
+
+  const targetDir = config.target.agentsHome
+    ?? path.join(os.homedir(), '.agents', 'skills');
+
+  const logger = args.verbose ? defaultLogger() : quietLogger();
+
+  const report = await syncAll({
+    pluginsDir,
+    targetDir,
+    config,
+    dryRun: args.dryRun,
+    pluginFilter: args.plugins,
+    prune: !args.noPrune,
+    logger,
+  });
+
+  if (args.reportPath) {
+    await fs.writeFile(args.reportPath, JSON.stringify(report, null, 2), 'utf-8');
+  }
+
+  printSummary(report);
+
+  if (report.errors.length > 0) return 1;
+  return 0;
+}
+
+function quietLogger() {
+  return { warn: (msg) => process.stderr.write(`${msg}\n`), info: () => {} };
+}
+
+function printSummary(report) {
+  const lines = [
+    `[codex-bridge] target: ${report.targetDir}`,
+    `  discovered: ${report.discovered}, considered: ${report.considered}`,
+    `  synced: ${report.synced.length}, skipped: ${report.skipped.length}, removed: ${report.removed.length}, errors: ${report.errors.length}`,
+  ];
+  process.stderr.write(`${lines.join('\n')}\n`);
+}
+
+function printHelp() {
+  const help = `Usage: node sync.mjs [options]
+
+Options:
+  --dry-run              Plan without writing files
+  --verbose              Per-file logs
+  --config <path>        Custom config path (default: codex-bridge.config.json)
+  --plugin <list>        Comma-separated plugin filter (e.g. --plugin github-dev,core-config)
+  --no-prune             Disable auto-prune of orphans
+  --report <path>        Write JSON report to path
+  -h, --help             Show this help
+
+Exit codes:
+  0  all skills processed successfully
+  1  partial failures (some skills errored)
+  2  fatal error (config parse failure, argument error)
+`;
+  process.stdout.write(help);
+}
+
+export async function pruneOrphans(targetDir, validSources) {
+  const report = { removed: [], preserved: [] };
+
+  let entries;
+  try {
+    entries = await fs.readdir(targetDir, { withFileTypes: true });
+  } catch (err) {
+    if (err.code === 'ENOENT') return report;
+    throw err;
+  }
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    if (entry.name.startsWith('.staging-')) continue;
+
+    const skillMd = path.join(targetDir, entry.name, 'SKILL.md');
+    let content;
+    try {
+      content = await fs.readFile(skillMd, 'utf-8');
+    } catch (err) {
+      if (err.code === 'ENOENT') {
+        report.preserved.push({ skillName: entry.name, reason: 'no-skill-md' });
+        continue;
+      }
+      throw err;
+    }
+
+    const parsed = parseFrontmatter(content);
+    const hasMarker = parsed && 'bridge_source' in parsed.fields;
+    if (!hasMarker) {
+      report.preserved.push({ skillName: entry.name, reason: 'no-bridge-source' });
+      continue;
+    }
+
+    const marker = parsed.fields.bridge_source;
+    if (validSources.has(marker)) {
+      report.preserved.push({ skillName: entry.name, reason: 'valid', bridgeSource: marker });
+    } else {
+      await fs.rm(path.join(targetDir, entry.name), { recursive: true, force: true });
+      report.removed.push({ skillName: entry.name, bridgeSource: marker });
+    }
+  }
+
+  return report;
+}
+
+export function parseFrontmatter(content) {
+  const match = FRONTMATTER_RE.exec(content);
+  if (!match) return null;
+
+  const [, raw, body] = match;
+  const fields = parseYamlKeyValues(raw);
+
+  return {
+    name: fields.name ?? null,
+    description: fields.description ?? null,
+    body,
+    raw,
+    fields,
+  };
+}
+
+function parseYamlKeyValues(yamlText) {
+  const out = {};
+  let currentKey = null;
+  for (const line of yamlText.split(/\r?\n/)) {
+    if (!line.trim()) { currentKey = null; continue; }
+    const kv = /^([A-Za-z_][\w.-]*)\s*:\s*(.*)$/.exec(line);
+    if (kv) {
+      currentKey = kv[1];
+      out[currentKey] = stripYamlValue(kv[2]);
+    } else if (currentKey && /^\s/.test(line)) {
+      out[currentKey] = `${out[currentKey]} ${line.trim()}`.trim();
+    } else if (currentKey) {
+      out[currentKey] = `${out[currentKey]} ${line.trim()}`.trim();
+    }
+  }
+  return out;
+}
+
+function stripYamlValue(value) {
+  const trimmed = value.trim();
+  if (trimmed.startsWith('"') && trimmed.endsWith('"') && trimmed.length >= 2) {
+    return trimmed.slice(1, -1);
+  }
+  if (trimmed.startsWith("'") && trimmed.endsWith("'") && trimmed.length >= 2) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
+export async function discoverSkills(pluginsDir) {
+  const results = [];
+
+  let pluginEntries;
+  try {
+    pluginEntries = await fs.readdir(pluginsDir, { withFileTypes: true });
+  } catch (err) {
+    if (err.code === 'ENOENT') return results;
+    throw err;
+  }
+
+  for (const entry of pluginEntries) {
+    if (!entry.isDirectory()) continue;
+    const skillsRoot = path.join(pluginsDir, entry.name, 'skills');
+    try {
+      await walkForSkillMd(skillsRoot, entry.name, results);
+    } catch (err) {
+      if (err.code !== 'ENOENT') throw err;
+    }
+  }
+
+  return results;
+}
+
+async function walkForSkillMd(dir, pluginName, out) {
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      await walkForSkillMd(full, pluginName, out);
+    } else if (entry.isFile() && entry.name === 'SKILL.md') {
+      const skillDir = path.dirname(full);
+      out.push({
+        pluginName,
+        skillName: path.basename(skillDir),
+        skillDir,
+        skillPath: full,
+      });
+    }
+  }
+}
+
+const isMainModule = (() => {
+  try {
+    return process.argv[1] === fileURLToPath(import.meta.url);
+  } catch {
+    return false;
+  }
+})();
+
+if (isMainModule) {
+  main(process.argv.slice(2)).then((code) => process.exit(code)).catch((err) => {
+    process.stderr.write(`[codex-bridge] fatal: ${err.stack ?? err.message}\n`);
+    process.exit(2);
+  });
+}

--- a/plugins/codex-bridge/skills/codex-sync/SKILL.md
+++ b/plugins/codex-bridge/skills/codex-sync/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: codex-sync
+description: Sync OMC plugin skills to Codex `~/.agents/skills/` (OpenAI USER scope) with body-only transform rules and `bridge_source` provenance marker. Use when user says "codex sync", "sync skills to codex", "/codex-sync", or after adding/modifying OMC plugin skills that should also be available in independent Codex CLI sessions. Idempotent — safe to re-run.
+---
+
+# codex-sync
+
+OMC (`plugins/*/skills/**/SKILL.md`) skill 들을 Codex CLI 가 네이티브로 로드하는 `~/.agents/skills/` 로 변환·복사한다.
+
+## 언제 쓰나
+
+- OMC 쪽에서 skill 을 새로 추가했거나 고쳤을 때
+- 독립 Codex CLI 세션 (`codex` 터미널 직접 실행) 에서 OMC skill 을 `$<skill-name>` 으로 호출하고 싶을 때
+- `omx doctor` 전에 skill 상태 정합성 맞출 때
+
+양방향 sync 가 아님. OMC 가 SSOT, `~/.agents/skills/` 는 derived artifact — 매 실행마다 다시 생성된다.
+
+## 핵심 원칙
+
+1. **Safety**: `bridge_source` 마커 없는 `~/.agents/skills/*/SKILL.md` 는 **절대 건드리지 않는다** (사용자 / OMX 파일 보호)
+2. **Body-only transform**: frontmatter 는 불변, body 만 7 개 rule 로 치환
+3. **Orphan prune**: `bridge_source` 마커 있고 원본이 없어진 skill 만 자동 삭제
+4. **Atomic write**: 임시 staging 디렉토리에 렌더링 후 atomic rename 으로 부분 쓰기 방지
+
+## 진입점 (3 가지)
+
+### 1. Claude Code skill (이것)
+
+```
+$codex-sync
+$codex-sync --dry-run
+$codex-sync --plugin github-dev,core-config
+```
+
+Claude Code 가 이 SKILL.md 를 읽은 뒤, 아래 Bash 명령을 실행한다.
+
+### 2. Direct CLI
+
+```bash
+node plugins/codex-bridge/scripts/sync.mjs [options]
+```
+
+### 3. npm (V2 예정)
+
+```bash
+npx @youngjaedev/omc-codex-sync [options]
+```
+
+## CLI Options
+
+| Flag | 동작 |
+|------|-----|
+| `--dry-run` | 파일 변경 없이 계획만 출력 |
+| `--verbose` | 파일별 행위 상세 출력 |
+| `--config <path>` | 커스텀 config 경로 (기본: `codex-bridge.config.json`) |
+| `--plugin <list>` | 쉼표 구분 플러그인 필터 (예: `--plugin github-dev,core-config`) |
+| `--no-prune` | auto-prune 비활성화 |
+| `--report <path>` | JSON 리포트 파일 출력 |
+| `-h`, `--help` | 도움말 |
+
+Exit codes: `0` 성공 · `1` 부분 실패 · `2` 치명적 (config 파싱 실패, 권한 없음, 알 수 없는 인자)
+
+## Transform Rules (body-only)
+
+| From | To | Mode |
+|------|-----|------|
+| `.omc/` | `.omx/` | literal |
+| `CLAUDE.md` | `AGENTS.md` | literal |
+| `/oh-my-claudecode:` | `$` | literal |
+| `oh-my-claudecode` | `oh-my-codex` | literal |
+| `~/.claude/` | `~/.codex/` | literal |
+| `omc` (word-boundary) | `omx` | regex `\bomc\b` |
+| `OMC` (word-boundary) | `OMX` | regex `\bOMC\b` |
+
+**Text-only** 확장자 화이트리스트에 맞는 파일만 치환: `.md`, `.yml`, `.yaml`, `.json`, `.sh`, `.mjs`, `.js`, `.py`, `.ts`. 이 외 (이미지, 바이너리) 는 그대로 복사.
+
+**frontmatter 면제**: `---` 구분자 사이는 불변. `bridge_source` 마커 보호, skill 이름/description 오염 방지.
+
+## 실행 방법
+
+사용자가 `$codex-sync` 로 호출하면 다음 Bash 로 delegate:
+
+```bash
+node plugins/codex-bridge/scripts/sync.mjs "$@"
+```
+
+사용자가 `--dry-run` 을 지정하지 않았고 `~/.agents/skills/` 에 OMC-managed skill 이 없다면, 먼저 `--dry-run --verbose` 로 변경사항을 미리 보여준 뒤 사용자 확인을 받고 실제 실행한다.
+
+## Safety Checks
+
+실행 전 다음을 확인:
+
+1. Node 18+ 설치 여부: `node --version`
+2. `~/.agents/skills/` 쓰기 권한
+3. Target 에 비-OMC skill 이 있는 경우, 충돌 탐지 후 skip + stderr warning
+
+실행 후:
+
+1. 각 synced SKILL.md frontmatter 에 `bridge_source: <plugin>/<skill>` 존재 확인
+2. body 에서 `.omc/` / `CLAUDE.md` / `oh-my-claudecode` 등이 변환되었는지 spot check
+3. `~/.codex/skills/` (OMX 관리) 가 **침범되지 않았음** 확인
+
+## 충돌 처리
+
+- `~/.agents/skills/<name>/SKILL.md` 가 이미 있고 `bridge_source` 마커가 **없음** → skip + stderr warn ("not managed by OMC, inspect with `omx doctor`")
+- 마커 있음 → overwrite (OMC-managed 이므로 안전)
+- 다른 OMC 플러그인에서 동일 이름 → last-wins (경고)
+
+## Out of Scope (V1)
+
+V2 에서 예정:
+- `Task(subagent_type=...)` → Codex native subagent 매핑
+- `AGENTS.md` 섹션 inject (OMX 마커 외부)
+- 파일 변경 hook 으로 auto-sync
+- Project-level `.agents/skills/` 타깃
+- Collision-fallback 프리픽스 자동 부여
+
+## 참조
+
+- Spec: `.claude/spec/2026-04-14-codex-bridge-skill-sync.md`
+- OpenAI Codex Skills: https://developers.openai.com/codex/skills
+- OpenAI Codex Customization: https://developers.openai.com/codex/concepts/customization

--- a/plugins/codex-bridge/tests/config.test.mjs
+++ b/plugins/codex-bridge/tests/config.test.mjs
@@ -1,0 +1,117 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+
+import {
+  loadConfig,
+  parseArgs,
+  isExcluded,
+  DEFAULT_RULES,
+} from '../scripts/sync.mjs';
+
+async function writeJson(p, obj) {
+  await fs.mkdir(path.dirname(p), { recursive: true });
+  await fs.writeFile(p, JSON.stringify(obj), 'utf-8');
+}
+
+test('loadConfig: returns defaults when no config path', async () => {
+  const cfg = await loadConfig(null);
+  assert.equal(cfg.target.scope, 'user');
+  assert.deepEqual(cfg.exclude, []);
+  assert.equal(cfg.transform.bodyOnly, true);
+  assert.equal(cfg.transform.rules.length, DEFAULT_RULES.length);
+});
+
+test('loadConfig: returns defaults when config file missing', async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-bridge-cfg-'));
+  try {
+    const cfg = await loadConfig(path.join(tmp, 'does-not-exist.json'));
+    assert.equal(cfg.target.scope, 'user');
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test('loadConfig: merges user exclude list', async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-bridge-cfg-'));
+  try {
+    const p = path.join(tmp, 'config.json');
+    await writeJson(p, { exclude: ['plugins/midjourney/**'] });
+
+    const cfg = await loadConfig(p);
+    assert.deepEqual(cfg.exclude, ['plugins/midjourney/**']);
+    // Other defaults still present
+    assert.equal(cfg.transform.bodyOnly, true);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test('loadConfig: throws on invalid JSON', async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-bridge-cfg-'));
+  try {
+    const p = path.join(tmp, 'bad.json');
+    await fs.writeFile(p, '{ not: json, ');
+    await assert.rejects(() => loadConfig(p), /parse/i);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test('isExcluded: matches ** glob', () => {
+  assert.equal(isExcluded('plugins/midjourney/skills/x/SKILL.md', ['plugins/midjourney/**']), true);
+  assert.equal(isExcluded('plugins/github-dev/skills/x/SKILL.md', ['plugins/midjourney/**']), false);
+});
+
+test('isExcluded: matches single * glob (no path sep)', () => {
+  assert.equal(isExcluded('plugins/github-dev/skills/commit-push/SKILL.md', ['plugins/*/skills/commit-push/**']), true);
+  assert.equal(isExcluded('plugins/github-dev/skills/other/SKILL.md', ['plugins/*/skills/commit-push/**']), false);
+});
+
+test('isExcluded: empty pattern list excludes nothing', () => {
+  assert.equal(isExcluded('plugins/any/path', []), false);
+});
+
+test('parseArgs: all flags default to off', () => {
+  const a = parseArgs([]);
+  assert.equal(a.dryRun, false);
+  assert.equal(a.verbose, false);
+  assert.equal(a.noPrune, false);
+  assert.equal(a.configPath, null);
+  assert.equal(a.plugins, null);
+  assert.equal(a.reportPath, null);
+  assert.equal(a.help, false);
+});
+
+test('parseArgs: --dry-run, --verbose', () => {
+  const a = parseArgs(['--dry-run', '--verbose']);
+  assert.equal(a.dryRun, true);
+  assert.equal(a.verbose, true);
+});
+
+test('parseArgs: --config <path>', () => {
+  const a = parseArgs(['--config', '/etc/codex-bridge.json']);
+  assert.equal(a.configPath, '/etc/codex-bridge.json');
+});
+
+test('parseArgs: --plugin comma-separated', () => {
+  const a = parseArgs(['--plugin', 'github-dev,core-config']);
+  assert.deepEqual(a.plugins, ['github-dev', 'core-config']);
+});
+
+test('parseArgs: --no-prune, --report', () => {
+  const a = parseArgs(['--no-prune', '--report', '/tmp/out.json']);
+  assert.equal(a.noPrune, true);
+  assert.equal(a.reportPath, '/tmp/out.json');
+});
+
+test('parseArgs: --help / -h', () => {
+  assert.equal(parseArgs(['--help']).help, true);
+  assert.equal(parseArgs(['-h']).help, true);
+});
+
+test('parseArgs: throws on unknown flag', () => {
+  assert.throws(() => parseArgs(['--unknown']), /unknown/i);
+});

--- a/plugins/codex-bridge/tests/discovery.test.mjs
+++ b/plugins/codex-bridge/tests/discovery.test.mjs
@@ -96,3 +96,30 @@ test('discoverSkills: skips plugins with no skills/ dir', async () => {
     await fs.rm(tmpDir, { recursive: true, force: true });
   }
 });
+
+test('discoverSkills: returns deterministically sorted results (pluginName, skillName)', async () => {
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-bridge-disc-'));
+  try {
+    const pluginsDir = path.join(tmpDir, 'plugins');
+    const mk = async (plugin, skill) => {
+      const p = path.join(pluginsDir, plugin, 'skills', skill);
+      await fs.mkdir(p, { recursive: true });
+      await fs.writeFile(path.join(p, 'SKILL.md'), `---\nname: ${skill}\n---\n`);
+    };
+    await mk('zebra', 'zeta');
+    await mk('alpha', 'beta');
+    await mk('alpha', 'alpha-skill');
+    await mk('mango', 'skill-x');
+
+    const skills = await discoverSkills(pluginsDir);
+    const order = skills.map(s => `${s.pluginName}/${s.skillName}`);
+    assert.deepEqual(order, [
+      'alpha/alpha-skill',
+      'alpha/beta',
+      'mango/skill-x',
+      'zebra/zeta',
+    ]);
+  } finally {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  }
+});

--- a/plugins/codex-bridge/tests/discovery.test.mjs
+++ b/plugins/codex-bridge/tests/discovery.test.mjs
@@ -1,0 +1,98 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { fileURLToPath } from 'node:url';
+
+import { discoverSkills, parseFrontmatter } from '../scripts/sync.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const FIXTURES = path.join(__dirname, 'fixtures');
+
+test('parseFrontmatter: normal frontmatter returns {name, description, body}', async () => {
+  const content = await fs.readFile(path.join(FIXTURES, 'normal.md'), 'utf-8');
+  const result = parseFrontmatter(content);
+  assert.ok(result, 'expected non-null result');
+  assert.equal(result.name, 'test-skill');
+  assert.equal(result.description, 'A normal test skill for fixtures');
+  assert.match(result.body, /# Body/);
+  assert.match(result.body, /\.omc\//);
+});
+
+test('parseFrontmatter: no frontmatter returns null', async () => {
+  const content = await fs.readFile(path.join(FIXTURES, 'no-frontmatter.md'), 'utf-8');
+  const result = parseFrontmatter(content);
+  assert.equal(result, null);
+});
+
+test('parseFrontmatter: missing name field returns null name', async () => {
+  const content = await fs.readFile(path.join(FIXTURES, 'missing-name.md'), 'utf-8');
+  const result = parseFrontmatter(content);
+  assert.ok(result, 'expected non-null result');
+  assert.equal(result.name, null);
+  assert.equal(result.description, 'Missing name field, description only');
+});
+
+test('parseFrontmatter: preserves raw frontmatter for re-serialization', async () => {
+  const content = await fs.readFile(path.join(FIXTURES, 'normal.md'), 'utf-8');
+  const result = parseFrontmatter(content);
+  assert.match(result.raw, /^name: test-skill/m);
+  assert.ok(result.fields);
+  assert.equal(result.fields.name, 'test-skill');
+});
+
+test('discoverSkills: finds SKILL.md files one level deep', async () => {
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-bridge-disc-'));
+  try {
+    const p = path.join(tmpDir, 'plugins', 'alpha', 'skills', 'my-skill');
+    await fs.mkdir(p, { recursive: true });
+    await fs.writeFile(path.join(p, 'SKILL.md'), '---\nname: my-skill\ndescription: x\n---\nbody');
+
+    const skills = await discoverSkills(path.join(tmpDir, 'plugins'));
+    assert.equal(skills.length, 1);
+    assert.equal(skills[0].pluginName, 'alpha');
+    assert.equal(skills[0].skillName, 'my-skill');
+    assert.equal(skills[0].skillDir, p);
+    assert.equal(skills[0].skillPath, path.join(p, 'SKILL.md'));
+  } finally {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('discoverSkills: finds SKILL.md in nested subdir', async () => {
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-bridge-disc-'));
+  try {
+    const p = path.join(tmpDir, 'plugins', 'beta', 'skills', 'group', 'nested');
+    await fs.mkdir(p, { recursive: true });
+    await fs.writeFile(path.join(p, 'SKILL.md'), '---\nname: nested\n---\n');
+
+    const skills = await discoverSkills(path.join(tmpDir, 'plugins'));
+    assert.equal(skills.length, 1);
+    assert.equal(skills[0].pluginName, 'beta');
+    assert.equal(skills[0].skillName, 'nested');
+  } finally {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('discoverSkills: returns [] when plugins dir missing', async () => {
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-bridge-disc-'));
+  try {
+    const skills = await discoverSkills(path.join(tmpDir, 'does-not-exist'));
+    assert.deepEqual(skills, []);
+  } finally {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('discoverSkills: skips plugins with no skills/ dir', async () => {
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-bridge-disc-'));
+  try {
+    await fs.mkdir(path.join(tmpDir, 'plugins', 'no-skills-plugin'), { recursive: true });
+    const skills = await discoverSkills(path.join(tmpDir, 'plugins'));
+    assert.deepEqual(skills, []);
+  } finally {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  }
+});

--- a/plugins/codex-bridge/tests/fixtures/missing-name.md
+++ b/plugins/codex-bridge/tests/fixtures/missing-name.md
@@ -1,0 +1,4 @@
+---
+description: Missing name field, description only
+---
+# Body

--- a/plugins/codex-bridge/tests/fixtures/no-frontmatter.md
+++ b/plugins/codex-bridge/tests/fixtures/no-frontmatter.md
@@ -1,0 +1,3 @@
+# Just Body
+
+No frontmatter at all.

--- a/plugins/codex-bridge/tests/fixtures/normal.md
+++ b/plugins/codex-bridge/tests/fixtures/normal.md
@@ -1,0 +1,7 @@
+---
+name: test-skill
+description: A normal test skill for fixtures
+---
+# Body
+
+Some body text using .omc/ and CLAUDE.md references.

--- a/plugins/codex-bridge/tests/prune.test.mjs
+++ b/plugins/codex-bridge/tests/prune.test.mjs
@@ -1,0 +1,108 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+
+import { pruneOrphans } from '../scripts/sync.mjs';
+
+async function freshTmp() {
+  return fs.mkdtemp(path.join(os.tmpdir(), 'codex-bridge-prune-'));
+}
+
+async function mkSkill(root, name, content) {
+  const dir = path.join(root, name);
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(path.join(dir, 'SKILL.md'), content);
+  return dir;
+}
+
+test('pruneOrphans: keeps skill with valid bridge_source', async () => {
+  const tmp = await freshTmp();
+  try {
+    const target = path.join(tmp, 'skills');
+    await mkSkill(target, 'valid-skill',
+      '---\nname: valid-skill\nbridge_source: plugA/valid-skill\n---\nbody');
+
+    const report = await pruneOrphans(target, new Set(['plugA/valid-skill']));
+    assert.deepEqual(report.removed, []);
+    assert.ok(await fileExists(path.join(target, 'valid-skill', 'SKILL.md')));
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test('pruneOrphans: removes skill when bridge_source source is gone', async () => {
+  const tmp = await freshTmp();
+  try {
+    const target = path.join(tmp, 'skills');
+    await mkSkill(target, 'gone',
+      '---\nname: gone\nbridge_source: plugA/gone\n---\nbody');
+
+    const report = await pruneOrphans(target, new Set(['plugA/other']));
+    assert.equal(report.removed.length, 1);
+    assert.equal(report.removed[0].skillName, 'gone');
+    assert.equal(await fileExists(path.join(target, 'gone')), false);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test('pruneOrphans: NEVER touches skill without bridge_source (safety)', async () => {
+  const tmp = await freshTmp();
+  try {
+    const target = path.join(tmp, 'skills');
+    await mkSkill(target, 'user-owned',
+      '---\nname: user-owned\ndescription: a user skill\n---\nbody');
+
+    const report = await pruneOrphans(target, new Set());
+    assert.deepEqual(report.removed, []);
+    assert.ok(await fileExists(path.join(target, 'user-owned', 'SKILL.md')));
+    assert.equal(report.preserved.length, 1);
+    assert.equal(report.preserved[0].reason, 'no-bridge-source');
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test('pruneOrphans: mixed scenario — keeps valid, removes orphan, preserves unmanaged', async () => {
+  const tmp = await freshTmp();
+  try {
+    const target = path.join(tmp, 'skills');
+    await mkSkill(target, 'managed-valid',
+      '---\nname: managed-valid\nbridge_source: plugA/managed-valid\n---\n');
+    await mkSkill(target, 'managed-orphan',
+      '---\nname: managed-orphan\nbridge_source: plugA/old-skill\n---\n');
+    await mkSkill(target, 'omx-owned',
+      '---\nname: omx-owned\ndescription: an OMX skill\n---\n');
+
+    const report = await pruneOrphans(target, new Set(['plugA/managed-valid']));
+
+    assert.equal(report.removed.length, 1);
+    assert.equal(report.removed[0].skillName, 'managed-orphan');
+    assert.ok(await fileExists(path.join(target, 'managed-valid', 'SKILL.md')));
+    assert.ok(await fileExists(path.join(target, 'omx-owned', 'SKILL.md')));
+    assert.equal(await fileExists(path.join(target, 'managed-orphan')), false);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test('pruneOrphans: handles missing target directory gracefully', async () => {
+  const tmp = await freshTmp();
+  try {
+    const report = await pruneOrphans(path.join(tmp, 'never-created'), new Set());
+    assert.deepEqual(report.removed, []);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+async function fileExists(p) {
+  try {
+    await fs.access(p);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/plugins/codex-bridge/tests/sync.test.mjs
+++ b/plugins/codex-bridge/tests/sync.test.mjs
@@ -1,0 +1,185 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+
+import {
+  syncOne,
+  injectBridgeSource,
+  DEFAULT_RULES,
+} from '../scripts/sync.mjs';
+
+async function makeSourceSkill(sourceRoot, pluginName, skillName, skillMdContent, extraFiles = {}) {
+  const dir = path.join(sourceRoot, 'plugins', pluginName, 'skills', skillName);
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(path.join(dir, 'SKILL.md'), skillMdContent);
+  for (const [relPath, content] of Object.entries(extraFiles)) {
+    const full = path.join(dir, relPath);
+    await fs.mkdir(path.dirname(full), { recursive: true });
+    await fs.writeFile(full, content);
+  }
+  return {
+    pluginName,
+    skillName,
+    skillDir: dir,
+    skillPath: path.join(dir, 'SKILL.md'),
+  };
+}
+
+async function freshTmp() {
+  return fs.mkdtemp(path.join(os.tmpdir(), 'codex-bridge-sync-'));
+}
+
+test('injectBridgeSource: appends field when absent', () => {
+  const src = '---\nname: foo\ndescription: bar\n---\n# Body';
+  const out = injectBridgeSource(src, 'pluginA/foo');
+  assert.match(out, /bridge_source: pluginA\/foo/);
+  assert.match(out, /^---\nname: foo\ndescription: bar\nbridge_source: pluginA\/foo\n---\n/);
+});
+
+test('injectBridgeSource: replaces existing bridge_source', () => {
+  const src = '---\nname: foo\nbridge_source: old/path\n---\nbody';
+  const out = injectBridgeSource(src, 'new/path');
+  assert.match(out, /bridge_source: new\/path/);
+  assert.doesNotMatch(out, /bridge_source: old\/path/);
+});
+
+test('injectBridgeSource: wraps content in frontmatter if absent', () => {
+  const src = '# Plain body\nno frontmatter';
+  const out = injectBridgeSource(src, 'p/s');
+  assert.match(out, /^---\nbridge_source: p\/s\n---\n/);
+});
+
+test('syncOne: creates target when not exists, injects bridge_source, transforms body', async () => {
+  const tmp = await freshTmp();
+  try {
+    const source = await makeSourceSkill(
+      tmp,
+      'pluginA',
+      'my-skill',
+      [
+        '---',
+        'name: my-skill',
+        'description: Does things with omc',
+        '---',
+        '# Body',
+        'use CLAUDE.md and .omc/ here',
+      ].join('\n')
+    );
+    const targetRoot = path.join(tmp, 'target', '.agents', 'skills');
+
+    const result = await syncOne(source, targetRoot, DEFAULT_RULES);
+
+    assert.equal(result.status, 'synced');
+    const written = await fs.readFile(path.join(targetRoot, 'my-skill', 'SKILL.md'), 'utf-8');
+    // frontmatter unchanged (description mentions omc intentionally)
+    assert.match(written, /description: Does things with omc/);
+    // bridge_source injected
+    assert.match(written, /bridge_source: pluginA\/my-skill/);
+    // body transformed
+    assert.match(written, /use AGENTS\.md and \.omx\/ here/);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test('syncOne: skips when target has no bridge_source marker (collision guard)', async () => {
+  const tmp = await freshTmp();
+  try {
+    const source = await makeSourceSkill(
+      tmp, 'pluginA', 'shared-name',
+      '---\nname: shared-name\ndescription: OMC version\n---\nomc body'
+    );
+    const targetRoot = path.join(tmp, 'target', '.agents', 'skills');
+    const targetSkillDir = path.join(targetRoot, 'shared-name');
+    await fs.mkdir(targetSkillDir, { recursive: true });
+    await fs.writeFile(
+      path.join(targetSkillDir, 'SKILL.md'),
+      '---\nname: shared-name\ndescription: OMX version (not managed)\n---\npre-existing'
+    );
+
+    const result = await syncOne(source, targetRoot, DEFAULT_RULES);
+
+    assert.equal(result.status, 'skipped');
+    assert.equal(result.reason, 'non-managed-collision');
+    const existing = await fs.readFile(path.join(targetSkillDir, 'SKILL.md'), 'utf-8');
+    // untouched
+    assert.match(existing, /OMX version \(not managed\)/);
+    assert.match(existing, /pre-existing/);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test('syncOne: overwrites when target has bridge_source marker', async () => {
+  const tmp = await freshTmp();
+  try {
+    const source = await makeSourceSkill(
+      tmp, 'pluginA', 'updatable',
+      '---\nname: updatable\ndescription: v2\n---\nnew body'
+    );
+    const targetRoot = path.join(tmp, 'target', '.agents', 'skills');
+    const targetSkillDir = path.join(targetRoot, 'updatable');
+    await fs.mkdir(targetSkillDir, { recursive: true });
+    await fs.writeFile(
+      path.join(targetSkillDir, 'SKILL.md'),
+      '---\nname: updatable\nbridge_source: pluginA/updatable\n---\nold body'
+    );
+
+    const result = await syncOne(source, targetRoot, DEFAULT_RULES);
+
+    assert.equal(result.status, 'synced');
+    const written = await fs.readFile(path.join(targetSkillDir, 'SKILL.md'), 'utf-8');
+    assert.match(written, /new body/);
+    assert.match(written, /bridge_source: pluginA\/updatable/);
+    assert.doesNotMatch(written, /old body/);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test('syncOne: copies additional files in skill dir', async () => {
+  const tmp = await freshTmp();
+  try {
+    const source = await makeSourceSkill(
+      tmp, 'pluginA', 'with-assets',
+      '---\nname: with-assets\ndescription: x\n---\nbody',
+      {
+        'scripts/helper.sh': '#!/bin/bash\necho .omc/',
+        'references/notes.md': '# Reference\nsee CLAUDE.md',
+        'assets/icon.txt': 'binary-ish payload',
+      }
+    );
+    const targetRoot = path.join(tmp, 'target', '.agents', 'skills');
+
+    await syncOne(source, targetRoot, DEFAULT_RULES);
+
+    const out = path.join(targetRoot, 'with-assets');
+    const script = await fs.readFile(path.join(out, 'scripts/helper.sh'), 'utf-8');
+    assert.match(script, /\.omx\//); // transformed (text ext)
+
+    const notes = await fs.readFile(path.join(out, 'references/notes.md'), 'utf-8');
+    assert.match(notes, /AGENTS\.md/); // transformed (.md ext)
+
+    const icon = await fs.readFile(path.join(out, 'assets/icon.txt'), 'utf-8');
+    assert.equal(icon, 'binary-ish payload'); // .txt not in transform whitelist → copied raw
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test('syncOne: skipped when source frontmatter is missing (source defect)', async () => {
+  const tmp = await freshTmp();
+  try {
+    const source = await makeSourceSkill(tmp, 'pluginA', 'broken', '# No frontmatter\nbody');
+    const targetRoot = path.join(tmp, 'target', '.agents', 'skills');
+
+    const result = await syncOne(source, targetRoot, DEFAULT_RULES);
+
+    assert.equal(result.status, 'skipped');
+    assert.equal(result.reason, 'source-missing-frontmatter');
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});

--- a/plugins/codex-bridge/tests/sync.test.mjs
+++ b/plugins/codex-bridge/tests/sync.test.mjs
@@ -6,8 +6,10 @@ import os from 'node:os';
 
 import {
   syncOne,
+  syncAll,
   injectBridgeSource,
   DEFAULT_RULES,
+  DEFAULT_CONFIG,
 } from '../scripts/sync.mjs';
 
 async function makeSourceSkill(sourceRoot, pluginName, skillName, skillMdContent, extraFiles = {}) {
@@ -179,6 +181,91 @@ test('syncOne: skipped when source frontmatter is missing (source defect)', asyn
 
     assert.equal(result.status, 'skipped');
     assert.equal(result.reason, 'source-missing-frontmatter');
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test('syncOne: current behavior — overwrites even if bridge_source points to different plugin (last-wins)', async () => {
+  // This test locks the current spec P1 "last-wins" semantics.
+  // Collision warning is emitted at syncAll level (see syncAll collision test below).
+  const tmp = await freshTmp();
+  try {
+    const source = await makeSourceSkill(
+      tmp, 'pluginA', 'duplicate-name',
+      '---\nname: duplicate-name\ndescription: from A\n---\nA body'
+    );
+    const targetRoot = path.join(tmp, 'target', '.agents', 'skills');
+    const targetSkillDir = path.join(targetRoot, 'duplicate-name');
+    await fs.mkdir(targetSkillDir, { recursive: true });
+    await fs.writeFile(
+      path.join(targetSkillDir, 'SKILL.md'),
+      '---\nname: duplicate-name\nbridge_source: pluginB/duplicate-name\n---\nB body'
+    );
+
+    const result = await syncOne(source, targetRoot, DEFAULT_RULES);
+
+    // Spec P1: last-wins. bridge_source presence authorizes overwrite regardless of plugin owner.
+    assert.equal(result.status, 'synced');
+    const written = await fs.readFile(path.join(targetSkillDir, 'SKILL.md'), 'utf-8');
+    assert.match(written, /A body/);
+    assert.match(written, /bridge_source: pluginA\/duplicate-name/);
+    assert.doesNotMatch(written, /B body/);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test('syncAll: emits collision warning when same skillName appears in multiple plugins', async () => {
+  const tmp = await freshTmp();
+  try {
+    await makeSourceSkill(tmp, 'alpha', 'clash', '---\nname: clash\ndescription: A\n---\nA');
+    await makeSourceSkill(tmp, 'beta', 'clash', '---\nname: clash\ndescription: B\n---\nB');
+
+    const warnings = [];
+    const logger = {
+      warn: (m) => warnings.push(m),
+      info: () => {},
+    };
+
+    const report = await syncAll({
+      pluginsDir: path.join(tmp, 'plugins'),
+      targetDir: path.join(tmp, 'target', '.agents', 'skills'),
+      config: DEFAULT_CONFIG,
+      dryRun: true,
+      prune: false,
+      logger,
+    });
+
+    assert.equal(report.collisions.length, 1);
+    assert.equal(report.collisions[0].skillName, 'clash');
+    assert.deepEqual(report.collisions[0].plugins.sort(), ['alpha', 'beta']);
+    assert.ok(warnings.some(w => /collision.*clash/.test(w)), `expected warning about 'clash', got: ${warnings.join(' | ')}`);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test('syncAll: no collision warning when all skill names unique', async () => {
+  const tmp = await freshTmp();
+  try {
+    await makeSourceSkill(tmp, 'alpha', 'one', '---\nname: one\n---\nbody');
+    await makeSourceSkill(tmp, 'beta', 'two', '---\nname: two\n---\nbody');
+
+    const warnings = [];
+    const logger = { warn: (m) => warnings.push(m), info: () => {} };
+
+    const report = await syncAll({
+      pluginsDir: path.join(tmp, 'plugins'),
+      targetDir: path.join(tmp, 'target', '.agents', 'skills'),
+      config: DEFAULT_CONFIG,
+      dryRun: true,
+      prune: false,
+      logger,
+    });
+
+    assert.equal(report.collisions.length, 0);
+    assert.equal(warnings.filter(w => /collision/.test(w)).length, 0);
   } finally {
     await fs.rm(tmp, { recursive: true, force: true });
   }

--- a/plugins/codex-bridge/tests/transform.test.mjs
+++ b/plugins/codex-bridge/tests/transform.test.mjs
@@ -1,0 +1,93 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { applyTransforms, transformSkillContent, DEFAULT_RULES } from '../scripts/sync.mjs';
+
+test('applyTransforms: .omc/ → .omx/ (literal)', () => {
+  assert.equal(applyTransforms('path .omc/state', DEFAULT_RULES), 'path .omx/state');
+});
+
+test('applyTransforms: CLAUDE.md → AGENTS.md (literal)', () => {
+  assert.equal(applyTransforms('see CLAUDE.md for details', DEFAULT_RULES), 'see AGENTS.md for details');
+});
+
+test('applyTransforms: /oh-my-claudecode: → $ (literal)', () => {
+  assert.equal(applyTransforms('run /oh-my-claudecode:autopilot now', DEFAULT_RULES), 'run $autopilot now');
+});
+
+test('applyTransforms: oh-my-claudecode → oh-my-codex (literal)', () => {
+  assert.equal(applyTransforms('this is oh-my-claudecode docs', DEFAULT_RULES), 'this is oh-my-codex docs');
+});
+
+test('applyTransforms: ~/.claude/ → ~/.codex/ (literal)', () => {
+  assert.equal(applyTransforms('cd ~/.claude/plugins', DEFAULT_RULES), 'cd ~/.codex/plugins');
+});
+
+test('applyTransforms: omc → omx (word-boundary only)', () => {
+  assert.equal(applyTransforms('omc project', DEFAULT_RULES), 'omx project');
+  assert.equal(applyTransforms('use omc, then', DEFAULT_RULES), 'use omx, then');
+  // word-boundary means alphanumeric-adjacent "omc" is NOT replaced
+  assert.equal(applyTransforms('economic', DEFAULT_RULES), 'economic');
+});
+
+test('applyTransforms: OMC → OMX (word-boundary, case-sensitive)', () => {
+  assert.equal(applyTransforms('OMC runtime', DEFAULT_RULES), 'OMX runtime');
+  // case-sensitive: "Omc" not matched (only OMC caps or omc lowercase)
+  assert.equal(applyTransforms('mixed Omc', DEFAULT_RULES), 'mixed Omc');
+});
+
+test('applyTransforms: leaves unrelated text unchanged', () => {
+  const src = 'no special tokens here, just plain text.';
+  assert.equal(applyTransforms(src, DEFAULT_RULES), src);
+});
+
+test('applyTransforms: empty string safe', () => {
+  assert.equal(applyTransforms('', DEFAULT_RULES), '');
+});
+
+test('transformSkillContent: body transformed, frontmatter unchanged (bodyOnly contract)', () => {
+  const src = [
+    '---',
+    'name: foo',
+    'description: mentions omc and CLAUDE.md on purpose',
+    '---',
+    '# Body',
+    'use CLAUDE.md and .omc/ here',
+  ].join('\n');
+
+  const out = transformSkillContent(src, DEFAULT_RULES);
+
+  // frontmatter MUST be unchanged (bodyOnly=true)
+  assert.match(out, /^---\nname: foo\ndescription: mentions omc and CLAUDE\.md on purpose\n---\n/);
+  // body MUST be transformed
+  assert.match(out, /use AGENTS\.md and \.omx\/ here/);
+});
+
+test('transformSkillContent: content without frontmatter transforms whole body', () => {
+  const src = '# Plain\nuse .omc/ here';
+  const out = transformSkillContent(src, DEFAULT_RULES);
+  assert.match(out, /\.omx\//);
+});
+
+test('transformSkillContent: preserves frontmatter with bridge_source marker', () => {
+  const src = [
+    '---',
+    'name: bar',
+    'description: desc',
+    'bridge_source: sample/bar',
+    '---',
+    'body omc text',
+  ].join('\n');
+
+  const out = transformSkillContent(src, DEFAULT_RULES);
+
+  assert.match(out, /bridge_source: sample\/bar/);
+  assert.match(out, /body omx text/);
+});
+
+test('DEFAULT_RULES: has 7 entries as per spec', () => {
+  assert.equal(DEFAULT_RULES.length, 7);
+  const modes = new Set(DEFAULT_RULES.map(r => r.mode));
+  assert.ok(modes.has('literal'));
+  assert.ok(modes.has('word-boundary'));
+});


### PR DESCRIPTION
## Summary

- New plugin `codex-bridge` (22nd in collection) syncs OMC `plugins/*/skills/**/SKILL.md` to `~/.agents/skills/` (OpenAI official USER scope), enabling independent Codex CLI sessions to invoke OMC skills as `$<skill-name>` via native discovery
- Body-only mechanical transform (7 rules) with `bridge_source` frontmatter provenance marker; `~/.codex/skills/` (OMX) and non-managed user skills at target are never touched
- Zero runtime deps — Node 18+ built-in test runner, 48 tests covering discovery, transform, collision guard, orphan prune, config + CLI

## Closes
Closes #9

## Approach
TDD with 5 red-green-refactor cycles (discovery, transform, sync, prune, config). See spec `.claude/spec/2026-04-14-codex-bridge-skill-sync.md` for context and rationale (path decision verified against OpenAI official docs).

## What's in the box
| File | Purpose |
|------|---------|
| `plugins/codex-bridge/scripts/sync.mjs` | Single-file sync engine + CLI (zero deps) |
| `plugins/codex-bridge/codex-bridge.config.json` | Default exclude list + 7 transform rules |
| `plugins/codex-bridge/skills/codex-sync/SKILL.md` | Claude Code `$codex-sync` entry point |
| `plugins/codex-bridge/tests/*.test.mjs` | 48 tests, all green |
| `.claude-plugin/marketplace.json` | Version bump 1.7.8 → 1.7.9, codex-bridge entry added |
| `.claude/settings.json`, `CLAUDE.md`, `README.md` | Registration + docs |

## Key mechanics
- **Body-only transform**: frontmatter unchanged (protects `bridge_source` marker + user-authored name/description), body substituted via `.omc/`→`.omx/`, `CLAUDE.md`→`AGENTS.md`, `/oh-my-claudecode:`→`$`, `~/.claude/`→`~/.codex/`, word-boundary `omc`→`omx`, `OMC`→`OMX`, `oh-my-claudecode`→`oh-my-codex`
- **Collision guard**: target SKILL.md without `bridge_source` marker → skip + stderr warn (never overwrites user/OMX files)
- **Orphan prune**: only files tagged with `bridge_source` are candidates; untagged files excluded from scan
- **Atomic write**: staging dir in target root → `fs.rename`, with `EXDEV` fallback to `fs.cp` + rm

## Real-run verification (Linux)
- Discovered 27 skills → 2 blacklisted (interactive-review, midjourney) → 25 considered
- Synced 23 (2 docs-forge skills skipped due to missing source frontmatter — source defect, not regression)
- `~/.codex/skills/` OMX area: 25 skills before/after (untouched ✓)
- `~/.agents/skills/` pre-existing user skills (architecture-patterns, pyqt6-ui-development-rules, python-design-patterns) preserved ✓
- Idempotent re-run produces identical counts
- Collision guard verified via `bridge_source`-stripped simulation (non-managed file preserved)

## CLI
```
node plugins/codex-bridge/scripts/sync.mjs [options]

Options:
  --dry-run              Plan without writing files
  --verbose              Per-file logs
  --config <path>        Custom config path
  --plugin <list>        Comma-separated plugin filter
  --no-prune             Disable auto-prune of orphans
  --report <path>        Write JSON report to path
  -h, --help             Show this help

Exit codes: 0 success · 1 partial failures · 2 fatal (config parse, argument error)
```

## Out of scope (V2 per spec)
- `agents/openai.yaml` sidecar (provenance marker migration target)
- AGENTS.md inject (OMX marker `<!-- omx:generated:agents-md -->` avoidance)
- Auto-sync hook (Write/Edit on `plugins/*/skills/**`)
- `Task(subagent_type=...)` → Codex native subagent mapping
- Project-level `.agents/skills/` scope
- Collision-fallback prefix mode (V1 skips with warning)
- npm binary distribution

## Test plan
- [x] `node --test plugins/codex-bridge/tests/*.test.mjs` → 48/48 pass
- [x] `node --check` syntax check on all `.mjs` files
- [x] JSON validation: `plugin.json`, `marketplace.json`, `codex-bridge.config.json`, `settings.json`
- [x] Dry-run: `node plugins/codex-bridge/scripts/sync.mjs --dry-run --verbose`
- [x] Real-run against `plugins/*/skills/` → confirm file presence + `bridge_source` marker + body transforms
- [x] OMX non-interference: `ls ~/.codex/skills/ | wc -l` unchanged (25)
- [x] Collision guard simulation (remove `bridge_source`, re-run, expect skip)
- [x] Idempotency (second run produces identical counts)
- [ ] macOS + Windows manual verification (best-effort, not blocking V1)
- [ ] Spawn fresh `codex` CLI session and verify `$create-slide`, `$changelog-guide` etc. callable (manual)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 새로운 통합 플러그인 `codex-bridge` 추가 — OMC 플러그인 스킬을 Codex로 동기화하는 기능(동기화/변환/CLI 지원 포함).

* **Documentation**
  * 플러그인 수를 21→22로 업데이트하고 `codex-bridge` 통합 섹션 및 사용법, 옵션, 동작 규칙 문서 추가.
  * README과 설명서의 배지 및 카탈로그 업데이트.

* **Chores**
  * 패키지 메타데이터 버전(1.7.9) 및 로컬 설정 예제에 새 플러그인 등록.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->