### PR TITLE
docs(github-dev): coderabbit-config quick reference table (live demo PR)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ __pycache__/
 # Windows reserved names (prevent accidental creation)
 nul
 NUL
+.omx/

--- a/docs/architecture/workflows/github-dev.md
+++ b/docs/architecture/workflows/github-dev.md
@@ -1,7 +1,7 @@
 # github-dev Workflow
 
 <!-- workflow-viz: github-dev -->
-<!-- last-updated: 2026-03-18 16:58:01 -->
+<!-- last-updated: 2026-04-28 11:36:46 -->
 
 ## Overview
 

--- a/plugins/github-dev/docs/coderabbit-config.md
+++ b/plugins/github-dev/docs/coderabbit-config.md
@@ -55,6 +55,17 @@ reviews:
 
 CodeRabbit auto-ingests `CLAUDE.md` / `AGENTS.md` / `.cursorrules` as review criteria — no extra config needed. If you maintain `.claude/rules/*.md` modules in this repo, they ARE picked up via the root `CLAUDE.md` `@.claude/rules/...` references.
 
+## Quick reference table
+
+A snapshot of the keys this plugin depends on:
+
+| Key | Default | Plugin dependency |
+|-----|---------|-------------------|
+| `reviews.enable_prompt_for_ai_agents` | true | `code-review` parses the AI Agents block |
+| `reviews.commit_status` | true | `cr-wait` polls this check |
+| `auto_review.enabled` | true | trigger reviews on push |
+| `auto_review.auto_incremental_review`| true | review subsequent  pushes |
+
 ## Verification
 
 After saving, push a commit and verify:

--- a/plugins/github-dev/docs/coderabbit-config.md
+++ b/plugins/github-dev/docs/coderabbit-config.md
@@ -64,7 +64,7 @@ A snapshot of the keys this plugin depends on:
 | `reviews.enable_prompt_for_ai_agents` | true | `code-review` parses the AI Agents block |
 | `reviews.commit_status` | true | `cr-wait` polls this check |
 | `auto_review.enabled` | true | trigger reviews on push |
-| `auto_review.auto_incremental_review`| true | review subsequent  pushes |
+| `auto_review.auto_incremental_review` | true | review subsequent pushes |
 
 ## Verification
 


### PR DESCRIPTION
## Summary
Adds a snapshot table to `plugins/github-dev/docs/coderabbit-config.md` listing the `.coderabbit.yaml` keys the plugin depends on.

## Purpose
Live demonstration of the v1.9.0 `/github-dev:cr-wait` and `/github-dev:code-review` slash commands now invoked via the actual `Skill` mechanism (not manual graphql replay). Verifies criterion 4 (slash invocation) and criterion 6 (slash menu visibility) end-to-end.

## Test plan
- [ ] CodeRabbit auto-review posts on this PR
- [ ] `/github-dev:cr-wait` blocks until commit-status flips, emits JSON
- [ ] `/github-dev:code-review` (no args, post-cr-wait) auto-fetches threads, applies sanitized fixes, single commit, push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **문서화**
  * 코드 리뷰 워크플로우 관련 설정의 빠른 참조 표를 추가하여 주요 설정과 동작 연결을 명확히 했습니다.
* **잡일**
  * 저장소 무시 목록에 .omx/ 디렉터리를 추가했습니다.
  * 아키텍처 문서의 최종 업데이트 타임스탬프를 갱신했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->