### PR TITLE
fix(codex-bridge): 1.3.1 — resolve pluginsDir under versioned cache layout + safe-prune

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "YoungjaeDev"
   },
   "metadata": {
-    "description": "Personal Claude Code plugin collection with 22 specialized plugins",
+    "description": "Personal Claude Code plugin collection with 21 specialized plugins",
     "version": "1.15.1"
   },
   "plugins": [

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Personal Claude Code plugin collection with 22 specialized plugins",
-    "version": "1.15.0"
+    "version": "1.15.1"
   },
   "plugins": [
     {
@@ -152,7 +152,7 @@
       "name": "codex-bridge",
       "source": "./plugins/codex-bridge",
       "description": "Sync my-claude-plugins skills and commands to Codex ~/.agents/skills/ (USER scope) so they become callable as native $skill-name. Body-only transform with bridge_source provenance marker.",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "category": "integration"
     }
   ]

--- a/.claude/rules/codex-bridge-sync.md
+++ b/.claude/rules/codex-bridge-sync.md
@@ -14,7 +14,7 @@ Commands are not a first-class concept in Codex — they're wrapped as synthetic
 
 ## Key Components
 
-- `scripts/sync.mjs` — single-file Node 18+ engine (zero runtime deps). Exports `discoverSkills`, `discoverCommands`, `parseFrontmatter`, `applyTransforms`, `transformSkillContent`, `injectBridgeSource`, `syncOne`, `syncCommand`, `syncAll`, `pruneOrphans`, `loadConfig`, `parseArgs`, `isExcluded`.
+- `scripts/sync.mjs` — single-file Node 18+ engine (zero runtime deps). Exports `discoverSkills`, `discoverCommands`, `resolvePluginsDir`, `resolvePluginContentDir`, `isVersionedCacheChild`, `compareSemver`, `parseFrontmatter`, `applyTransforms`, `transformSkillContent`, `injectBridgeSource`, `syncOne`, `syncCommand`, `syncAll`, `pruneOrphans`, `loadConfig`, `parseArgs`, `isExcluded`.
 - `codex-bridge.config.json` — default `exclude` glob list + 3 transform rules + text extension whitelist.
 - `skills/codex-sync/SKILL.md` — Claude Code entrypoint (`/codex-bridge:codex-sync`).
 - `tests/*.test.mjs` — `node --test` suite, fixtures in `tests/fixtures/`.
@@ -32,6 +32,8 @@ Commands are not a first-class concept in Codex — they're wrapped as synthetic
 - **Emit a collision warning once per duplicate `skillName`** detected across distinct plugins, including all plugin names involved and the winner after sort. Store in `report.collisions[]`.
 - **Guard `const` declarations against top-level TDZ.** Any module-level `if (isMainModule) main(...)` block must appear after every `const` it transitively depends on (e.g. `KNOWN_FLAGS`). Function declarations hoist; lexical bindings do not.
 - **Test Red first.** Fixtures live in `tests/fixtures/`. Write failing test, then the minimal export needed to pass. Re-run the full suite after every cycle.
+- **Resolve `pluginsDir` via `resolvePluginsDir(scriptPath, override)`** which detects monorepo vs Claude Code versioned cache layout (heuristic: every direct child of the monorepo candidate is semver-named ⇒ jump one level up). Honor `--plugins-dir <path>` override. Per-plugin layout is resolved by `resolvePluginContentDir(pluginDir)` which descends into `<plugin>/<latest-semver>/` when `.claude-plugin/` is absent and all children are semver. Together they make discovery work both from `<repo>/plugins/codex-bridge/scripts/sync.mjs` and from `~/.claude/plugins/cache/my-claude-plugins/codex-bridge/<version>/scripts/sync.mjs`.
+- **Skip `pruneOrphans` when `validSources.size === 0`.** A discovery miss (wrong `pluginsDir`, over-restrictive `--plugin` filter, freshly-init repo) must never trigger destructive prune. Emit a stderr warning and push to `report.warnings` so the failure is visible. Pair with the `discoverSkills returned 0 results` warning emitted at the top of `syncAll` for upstream signal.
 
 ## Don'ts
 

--- a/plugins/codex-bridge/.claude-plugin/plugin.json
+++ b/plugins/codex-bridge/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "codex-bridge",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Sync my-claude-plugins skills and commands to Codex ~/.agents/skills/ with body-only transform and bridge_source provenance marker"
 }

--- a/plugins/codex-bridge/CLAUDE.md
+++ b/plugins/codex-bridge/CLAUDE.md
@@ -24,15 +24,29 @@ my-claude-plugins 의 skill 들을 Codex CLI 가 네이티브로 로드하는 `~
 
 ```
 --dry-run              파일 변경 없이 계획만 출력
---verbose              파일별 행위 상세 출력
+--verbose              파일별 행위 + 진단 출력 (resolved pluginsDir, layout, counts)
 --config <path>        커스텀 config 경로
 --plugin <list>        쉼표 구분 플러그인 필터
+--plugins-dir <path>   plugins 디렉토리 명시 지정 (auto-detect 우회)
 --no-prune             auto-prune 비활성화
 --report <path>        JSON 리포트 파일 출력
 --help                 도움말
 ```
 
 Exit codes: `0` 성공 · `1` 부분 실패 · `2` 치명적 (config 파싱 실패, 권한 없음)
+
+## Layout Auto-detection
+
+`pluginsDir` 는 두 레이아웃을 자동 인식한다:
+
+1. **Monorepo / source checkout**: `<repo>/plugins/<plugin>/scripts/sync.mjs` → `<repo>/plugins`
+2. **Claude Code versioned cache**: `~/.claude/plugins/cache/my-claude-plugins/<plugin>/<version>/scripts/sync.mjs` → `~/.claude/plugins/cache/my-claude-plugins`
+
+후자에서는 plugin 별 `<plugin>/<latest-semver>/skills/` · `commands/` 도 자동으로 진입한다 (가장 높은 semver 버전 채택).
+
+휴리스틱: 후보 디렉토리의 모든 자식이 semver 패턴 (`^\d+\.\d+\.\d+`) 이면 versioned cache 로 판정. 잘못 판정될 경우 `--plugins-dir <path>` 로 override.
+
+**Safety**: `pluginsDir` 가 잘못 잡혀 `validSources` 가 비면 auto-prune 은 건너뛴다 (`--dry-run --verbose` 로 진단 권장).
 
 ## Transform Rules (body-only)
 

--- a/plugins/codex-bridge/scripts/sync.mjs
+++ b/plugins/codex-bridge/scripts/sync.mjs
@@ -265,7 +265,7 @@ function globToRegex(pattern) {
 
 const KNOWN_FLAGS = new Set([
   '--dry-run', '--verbose', '--no-prune', '--help', '-h',
-  '--config', '--plugin', '--report',
+  '--config', '--plugin', '--report', '--plugins-dir',
 ]);
 
 export function parseArgs(argv) {
@@ -277,6 +277,7 @@ export function parseArgs(argv) {
     configPath: null,
     plugins: null,
     reportPath: null,
+    pluginsDir: null,
   };
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
@@ -305,6 +306,10 @@ export function parseArgs(argv) {
         out.reportPath = argv[++i];
         if (!out.reportPath) throw new Error('--report requires a path');
         break;
+      case '--plugins-dir':
+        out.pluginsDir = argv[++i];
+        if (!out.pluginsDir) throw new Error('--plugins-dir requires a path');
+        break;
     }
   }
   return out;
@@ -324,6 +329,13 @@ export async function syncAll(options) {
   const allSkills = await discoverSkills(pluginsDir);
   const allCommands = await discoverCommands(pluginsDir);
   const pluginsRoot = path.dirname(pluginsDir);
+
+  const warnings = [];
+  if (allSkills.length === 0) {
+    const msg = `[codex-bridge] discoverSkills returned 0 results from ${pluginsDir} — likely pluginsDir misresolution under Claude Code's versioned cache layout. Inspect with --dry-run --verbose, or pass --plugins-dir <path> to override.`;
+    logger.warn(msg);
+    warnings.push(msg);
+  }
 
   const filtered = allSkills.filter((skill) => {
     if (pluginFilter && !pluginFilter.includes(skill.pluginName)) return false;
@@ -358,6 +370,7 @@ export async function syncAll(options) {
   const report = {
     dryRun,
     targetDir,
+    pluginsDir,
     discovered: allSkills.length,
     discoveredCommands: allCommands.length,
     considered: filtered.length,
@@ -367,6 +380,7 @@ export async function syncAll(options) {
     skipped: [],
     removed: [],
     errors: [],
+    warnings,
   };
 
   const validSources = new Set();
@@ -419,10 +433,16 @@ export async function syncAll(options) {
   }
 
   if (prune && !dryRun) {
-    const pruneResult = await pruneOrphans(targetDir, validSources);
-    report.removed = pruneResult.removed;
-    for (const r of pruneResult.removed) {
-      logger.info(`[codex-bridge] pruned orphan ${r.skillName} (was ${r.bridgeSource})`);
+    if (validSources.size === 0) {
+      const msg = `[codex-bridge] prune skipped: 0 valid sources discovered (likely pluginsDir misresolution or over-restrictive --plugin filter). Inspect with --dry-run --verbose.`;
+      logger.warn(msg);
+      report.warnings.push(msg);
+    } else {
+      const pruneResult = await pruneOrphans(targetDir, validSources);
+      report.removed = pruneResult.removed;
+      for (const r of pruneResult.removed) {
+        logger.info(`[codex-bridge] pruned orphan ${r.skillName} (was ${r.bridgeSource})`);
+      }
     }
   } else if (prune && dryRun) {
     const existingEntries = await fs.readdir(targetDir, { withFileTypes: true }).catch((err) => {
@@ -445,6 +465,21 @@ export async function syncAll(options) {
   return report;
 }
 
+export function isVersionedCacheChild(name) {
+  return /^\d+\.\d+\.\d+(?:[-+].*)?$/.test(name);
+}
+
+export async function resolvePluginsDir(scriptPath, override) {
+  if (override) return path.resolve(override);
+  const candidateA = path.resolve(path.dirname(scriptPath), '..', '..');
+  const entries = await fs.readdir(candidateA, { withFileTypes: true }).catch(() => []);
+  const dirs = entries.filter(e => e.isDirectory()).map(e => e.name);
+  if (dirs.length > 0 && dirs.every(isVersionedCacheChild)) {
+    return path.resolve(candidateA, '..');
+  }
+  return candidateA;
+}
+
 export async function main(argv) {
   let args;
   try {
@@ -460,9 +495,23 @@ export async function main(argv) {
     return 0;
   }
 
-  const pluginRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
-  const pluginsDir = path.resolve(pluginRoot, '..');
+  const scriptPath = fileURLToPath(import.meta.url);
+  const pluginRoot = path.resolve(path.dirname(scriptPath), '..');
+  const pluginsDir = await resolvePluginsDir(scriptPath, args.pluginsDir);
   const configPath = args.configPath ?? path.join(pluginRoot, 'codex-bridge.config.json');
+
+  if (args.verbose) {
+    let layout;
+    if (args.pluginsDir) {
+      layout = 'overridden via --plugins-dir';
+    } else {
+      const monorepoRoot = path.resolve(path.dirname(scriptPath), '..', '..');
+      layout = pluginsDir === monorepoRoot
+        ? 'auto-detected (monorepo)'
+        : 'auto-detected (versioned-cache fallback)';
+    }
+    process.stderr.write(`[codex-bridge] resolved pluginsDir: ${pluginsDir} (${layout})\n`);
+  }
 
   let config;
   try {
@@ -486,6 +535,12 @@ export async function main(argv) {
     prune: !args.noPrune,
     logger,
   });
+
+  if (args.verbose) {
+    const pluginEntries = await fs.readdir(pluginsDir, { withFileTypes: true }).catch(() => []);
+    const pluginCount = pluginEntries.filter(e => e.isDirectory()).length;
+    process.stderr.write(`[codex-bridge] discovered ${pluginCount} plugins, ${report.discovered} skills, ${report.discoveredCommands ?? 0} commands\n`);
+  }
 
   if (args.reportPath) {
     await fs.writeFile(args.reportPath, JSON.stringify(report, null, 2), 'utf-8');
@@ -516,9 +571,11 @@ function printHelp() {
 
 Options:
   --dry-run              Plan without writing files
-  --verbose              Per-file logs
+  --verbose              Per-file logs + diagnostic (resolved pluginsDir, layout, counts)
   --config <path>        Custom config path (default: codex-bridge.config.json)
   --plugin <list>        Comma-separated plugin filter (e.g. --plugin github-dev,core-config)
+  --plugins-dir <path>   Override plugins directory (skips auto-detect; use when running
+                         from an unusual layout, e.g. Claude Code's versioned cache)
   --no-prune             Disable auto-prune of orphans
   --report <path>        Write JSON report to path
   -h, --help             Show this help
@@ -622,6 +679,45 @@ function stripYamlValue(value) {
   return trimmed;
 }
 
+export function compareSemver(a, b) {
+  const parts = (v) => v.split(/[-+]/)[0].split('.').map(n => parseInt(n, 10) || 0);
+  const [aMajor, aMinor, aPatch] = parts(a);
+  const [bMajor, bMinor, bPatch] = parts(b);
+  if (aMajor !== bMajor) return aMajor - bMajor;
+  if (aMinor !== bMinor) return aMinor - bMinor;
+  return aPatch - bPatch;
+}
+
+// Per-plugin layout resolver: returns the directory that holds `skills/` and
+// `commands/` for this plugin. Handles two layouts:
+//
+//   1. Monorepo / source checkout — `<plugin>/.claude-plugin/`, `<plugin>/skills/` …
+//      sit directly under `<plugin>/`. Returns `<plugin>` itself.
+//   2. Claude Code cache — `<plugin>/<semver>/.claude-plugin/`, `<plugin>/<semver>/skills/`
+//      sit under a version subdirectory. Returns `<plugin>/<latest-semver>`.
+//
+// The presence of `.claude-plugin/` directly under `<plugin>` is the canonical
+// monorepo signal. If absent and every direct child is semver-named, treat as
+// cache layout and pick the highest semver. Otherwise return `<plugin>` as-is
+// and let the downstream walker swallow ENOENT.
+export async function resolvePluginContentDir(pluginDir) {
+  let entries;
+  try {
+    entries = await fs.readdir(pluginDir, { withFileTypes: true });
+  } catch (err) {
+    if (err.code === 'ENOENT') return null;
+    throw err;
+  }
+  const dirNames = entries.filter(e => e.isDirectory()).map(e => e.name);
+  if (dirNames.includes('.claude-plugin')) return pluginDir;
+  const semverDirs = dirNames.filter(isVersionedCacheChild);
+  if (semverDirs.length > 0 && semverDirs.length === dirNames.length) {
+    semverDirs.sort(compareSemver);
+    return path.join(pluginDir, semverDirs[semverDirs.length - 1]);
+  }
+  return pluginDir;
+}
+
 export async function discoverSkills(pluginsDir) {
   const results = [];
 
@@ -635,7 +731,9 @@ export async function discoverSkills(pluginsDir) {
 
   for (const entry of pluginEntries) {
     if (!entry.isDirectory()) continue;
-    const skillsRoot = path.join(pluginsDir, entry.name, 'skills');
+    const contentRoot = await resolvePluginContentDir(path.join(pluginsDir, entry.name));
+    if (!contentRoot) continue;
+    const skillsRoot = path.join(contentRoot, 'skills');
     try {
       await walkForSkillMd(skillsRoot, entry.name, results);
     } catch (err) {
@@ -683,7 +781,9 @@ export async function discoverCommands(pluginsDir) {
 
   for (const entry of pluginEntries) {
     if (!entry.isDirectory()) continue;
-    const commandsDir = path.join(pluginsDir, entry.name, 'commands');
+    const contentRoot = await resolvePluginContentDir(path.join(pluginsDir, entry.name));
+    if (!contentRoot) continue;
+    const commandsDir = path.join(contentRoot, 'commands');
     let files;
     try {
       files = await fs.readdir(commandsDir, { withFileTypes: true });

--- a/plugins/codex-bridge/scripts/sync.mjs
+++ b/plugins/codex-bridge/scripts/sync.mjs
@@ -306,10 +306,14 @@ export function parseArgs(argv) {
         out.reportPath = argv[++i];
         if (!out.reportPath) throw new Error('--report requires a path');
         break;
-      case '--plugins-dir':
-        out.pluginsDir = argv[++i];
-        if (!out.pluginsDir) throw new Error('--plugins-dir requires a path');
+      case '--plugins-dir': {
+        const value = argv[++i];
+        if (!value || value.startsWith('-')) {
+          throw new Error('--plugins-dir requires a path');
+        }
+        out.pluginsDir = value;
         break;
+      }
     }
   }
   return out;
@@ -680,12 +684,50 @@ function stripYamlValue(value) {
 }
 
 export function compareSemver(a, b) {
-  const parts = (v) => v.split(/[-+]/)[0].split('.').map(n => parseInt(n, 10) || 0);
-  const [aMajor, aMinor, aPatch] = parts(a);
-  const [bMajor, bMinor, bPatch] = parts(b);
-  if (aMajor !== bMajor) return aMajor - bMajor;
-  if (aMinor !== bMinor) return aMinor - bMinor;
-  return aPatch - bPatch;
+  const split = (v) => {
+    const noBuild = v.split('+', 1)[0];
+    const dashIdx = noBuild.indexOf('-');
+    const main = dashIdx === -1 ? noBuild : noBuild.slice(0, dashIdx);
+    const pre = dashIdx === -1 ? null : noBuild.slice(dashIdx + 1);
+    const nums = main.split('.').map(n => parseInt(n, 10) || 0);
+    return { nums, pre };
+  };
+  const A = split(a);
+  const B = split(b);
+  for (let i = 0; i < 3; i++) {
+    const an = A.nums[i] ?? 0;
+    const bn = B.nums[i] ?? 0;
+    if (an !== bn) return an - bn;
+  }
+  // Numeric core equal — apply semver pre-release rule:
+  // a version WITHOUT pre-release is greater than one WITH pre-release.
+  if (A.pre === null && B.pre === null) return 0;
+  if (A.pre === null) return 1;
+  if (B.pre === null) return -1;
+  // Both have pre-release: compare dot-separated identifiers per semver spec.
+  const aParts = A.pre.split('.');
+  const bParts = B.pre.split('.');
+  const max = Math.max(aParts.length, bParts.length);
+  for (let i = 0; i < max; i++) {
+    const ai = aParts[i];
+    const bi = bParts[i];
+    if (ai === undefined) return -1;
+    if (bi === undefined) return 1;
+    const aNum = /^\d+$/.test(ai);
+    const bNum = /^\d+$/.test(bi);
+    if (aNum && bNum) {
+      const diff = parseInt(ai, 10) - parseInt(bi, 10);
+      if (diff !== 0) return diff;
+    } else if (aNum) {
+      return -1; // numeric identifiers sort before alphanumeric
+    } else if (bNum) {
+      return 1;
+    } else {
+      if (ai < bi) return -1;
+      if (ai > bi) return 1;
+    }
+  }
+  return 0;
 }
 
 // Per-plugin layout resolver: returns the directory that holds `skills/` and

--- a/plugins/codex-bridge/skills/codex-sync/SKILL.md
+++ b/plugins/codex-bridge/skills/codex-sync/SKILL.md
@@ -101,16 +101,16 @@ node plugins/codex-bridge/scripts/sync.mjs "$@"
 
 `--verbose` 출력 첫 줄에 어느 layout 인지 명시된다:
 
-```
+```text
 [codex-bridge] resolved pluginsDir: /path (auto-detected (monorepo))
 [codex-bridge] resolved pluginsDir: /path (auto-detected (versioned-cache fallback))
 [codex-bridge] resolved pluginsDir: /path (overridden via --plugins-dir)
 ```
 
-비표준 layout 이거나 자동 인식이 잘못 동작하면 `--plugins-dir <path>` 로 명시:
+비표준 layout 이거나 자동 인식이 잘못 동작하면 `--plugins-dir <path>` 로 명시 (repo root 에서 실행 가정):
 
 ```bash
-node sync.mjs --dry-run --verbose --plugins-dir /custom/plugins
+node plugins/codex-bridge/scripts/sync.mjs --dry-run --verbose --plugins-dir /custom/plugins
 ```
 
 Windows 경로도 지원 (Node `path.resolve` 가 OS 별 separator 정규화).

--- a/plugins/codex-bridge/skills/codex-sync/SKILL.md
+++ b/plugins/codex-bridge/skills/codex-sync/SKILL.md
@@ -58,9 +58,10 @@ $codex-sync --dry-run
 | Flag | 동작 |
 |------|-----|
 | `--dry-run` | 파일 변경 없이 계획만 출력 |
-| `--verbose` | 파일별 행위 상세 출력 |
+| `--verbose` | 파일별 행위 + 진단 출력 (resolved pluginsDir, layout 종류, plugin/skill/command counts) |
 | `--config <path>` | 커스텀 config 경로 (기본: `codex-bridge.config.json`) |
 | `--plugin <list>` | 쉼표 구분 플러그인 필터 (예: `--plugin github-dev,core-config`) |
+| `--plugins-dir <path>` | plugins 디렉토리 명시 지정 (auto-detect 우회. 비표준 layout 디버깅 / 단위 테스트용) |
 | `--no-prune` | auto-prune 비활성화 |
 | `--report <path>` | JSON 리포트 파일 출력 |
 | `-h`, `--help` | 도움말 |
@@ -91,6 +92,29 @@ node plugins/codex-bridge/scripts/sync.mjs "$@"
 
 사용자가 `--dry-run` 을 지정하지 않았고 `~/.agents/skills/` 에 codex-bridge-managed skill 이 없다면, 먼저 `--dry-run --verbose` 로 변경사항을 미리 보여준 뒤 사용자 확인을 받고 실제 실행한다.
 
+### 실행 위치 (plugin cache vs source checkout)
+
+스크립트는 두 가지 layout 을 자동 인식한다:
+
+- **Source checkout (monorepo)**: `<repo>/plugins/codex-bridge/scripts/sync.mjs` 직접 실행. `pluginsDir` 가 `<repo>/plugins` 로 자동 산출되어 모든 plugin 이 정상 발견됨.
+- **Claude Code plugin cache**: `~/.claude/plugins/cache/my-claude-plugins/codex-bridge/<version>/scripts/sync.mjs` 가 호출되는 케이스. `pluginsDir` 가 `~/.claude/plugins/cache/my-claude-plugins/` 로 산출되며, plugin 별 `<plugin>/<latest-semver>/skills/` · `commands/` 까지 자동으로 descend 한다.
+
+`--verbose` 출력 첫 줄에 어느 layout 인지 명시된다:
+
+```
+[codex-bridge] resolved pluginsDir: /path (auto-detected (monorepo))
+[codex-bridge] resolved pluginsDir: /path (auto-detected (versioned-cache fallback))
+[codex-bridge] resolved pluginsDir: /path (overridden via --plugins-dir)
+```
+
+비표준 layout 이거나 자동 인식이 잘못 동작하면 `--plugins-dir <path>` 로 명시:
+
+```bash
+node sync.mjs --dry-run --verbose --plugins-dir /custom/plugins
+```
+
+Windows 경로도 지원 (Node `path.resolve` 가 OS 별 separator 정규화).
+
 ## Safety Checks
 
 실행 전 다음을 확인:
@@ -99,6 +123,8 @@ node plugins/codex-bridge/scripts/sync.mjs "$@"
 2. `~/.agents/skills/` 쓰기 권한
 3. Target 에 외부 관리 skill 이 있는 경우, 충돌 탐지 후 skip + stderr warning
 4. `--plugin <list>` 사용 시 `--no-prune` 을 함께 사용 (미사용 시 선택되지 않은 플러그인의 bridge-managed skill 이 orphan prune 대상이 될 수 있음)
+5. **Layout auto-detect**: monorepo / Claude Code cache 자동 인식. `--verbose` 출력 첫 줄로 검증 가능 (`auto-detected (monorepo)` / `auto-detected (versioned-cache fallback)` / `overridden via --plugins-dir`)
+6. **Prune safety net** (1.3.1+): discovery 가 0 skill 을 반환하면 (잘못된 `pluginsDir` resolution 가능성) auto-prune 은 자동으로 skip 되고 stderr warning 출력. 이 가드가 있어도 비정상 출력을 보면 즉시 중단 권장
 
 실행 후:
 

--- a/plugins/codex-bridge/tests/discovery.test.mjs
+++ b/plugins/codex-bridge/tests/discovery.test.mjs
@@ -132,10 +132,31 @@ test('compareSemver: orders by major, minor, patch', () => {
   assert.ok(compareSemver('2.0.0', '1.99.99') > 0);
 });
 
-test('compareSemver: ignores prerelease/build metadata for ordering', () => {
-  // Simple numeric-prefix comparison; `-rc.1` is stripped.
-  assert.equal(compareSemver('1.0.0-rc.1', '1.0.0-rc.2'), 0);
+test('compareSemver: pre-release sorts before stable at the same numeric core (semver §11)', () => {
+  assert.ok(compareSemver('1.3.1-rc.1', '1.3.1') < 0, 'pre-release < stable');
+  assert.ok(compareSemver('1.3.1', '1.3.1-rc.1') > 0, 'stable > pre-release');
+});
+
+test('compareSemver: pre-release identifiers compared per semver spec', () => {
+  // numeric identifiers compare numerically
+  assert.ok(compareSemver('1.0.0-rc.1', '1.0.0-rc.2') < 0);
+  assert.ok(compareSemver('1.0.0-rc.10', '1.0.0-rc.9') > 0);
+  // alphanumeric identifiers compare lexically
+  assert.ok(compareSemver('1.0.0-alpha', '1.0.0-beta') < 0);
+  // shorter identifier list sorts before longer when prefixes match
+  assert.ok(compareSemver('1.0.0-rc', '1.0.0-rc.1') < 0);
+  // numeric < alphanumeric per spec
+  assert.ok(compareSemver('1.0.0-1', '1.0.0-a') < 0);
+});
+
+test('compareSemver: numeric core wins over pre-release ordering', () => {
   assert.ok(compareSemver('1.0.0-rc.1', '1.0.1') < 0);
+  assert.ok(compareSemver('1.0.1-rc.1', '1.0.0') > 0);
+});
+
+test('compareSemver: build metadata is ignored for ordering', () => {
+  assert.equal(compareSemver('1.0.0+build1', '1.0.0+build2'), 0);
+  assert.equal(compareSemver('1.0.0', '1.0.0+meta'), 0);
 });
 
 test('resolvePluginContentDir: monorepo plugin (.claude-plugin/ present) returns plugin dir as-is', async () => {

--- a/plugins/codex-bridge/tests/discovery.test.mjs
+++ b/plugins/codex-bridge/tests/discovery.test.mjs
@@ -242,8 +242,12 @@ test('discoverSkills: handles versioned cache layout, picks latest version per p
     const codexSync = skills.find(s => s.pluginName === 'codex-bridge');
     assert.ok(codexSync, 'expected codex-bridge entry');
     assert.equal(codexSync.skillName, 'codex-sync');
-    // Verify the LATEST version was picked (1.3.1, not 1.2.0 / 1.3.0)
-    assert.match(codexSync.skillPath, /\/1\.3\.1\/skills\/codex-sync\/SKILL\.md$/);
+    // Verify the LATEST version was picked (1.3.1, not 1.2.0 / 1.3.0).
+    // Use path.join + path.normalize so the assertion holds on both POSIX and Windows.
+    assert.equal(
+      path.normalize(codexSync.skillPath),
+      path.join(cacheRoot, 'codex-bridge', '1.3.1', 'skills', 'codex-sync', 'SKILL.md')
+    );
     const body = await fs.readFile(codexSync.skillPath, 'utf-8');
     assert.match(body, /latest/);
 
@@ -272,7 +276,10 @@ test('discoverCommands: handles versioned cache layout, picks latest version per
     assert.equal(commands.length, 1);
     assert.equal(commands[0].pluginName, 'github-dev');
     assert.equal(commands[0].commandName, 'commit-and-push');
-    assert.match(commands[0].sourcePath, /\/1\.14\.0\/commands\/commit-and-push\.md$/);
+    assert.equal(
+      path.normalize(commands[0].sourcePath),
+      path.join(cacheRoot, 'github-dev', '1.14.0', 'commands', 'commit-and-push.md')
+    );
   } finally {
     await fs.rm(tmpDir, { recursive: true, force: true });
   }
@@ -296,7 +303,10 @@ test('discoverSkills: monorepo plugin with coincidentally-semver-named subdir is
     assert.equal(skills[0].pluginName, 'mixed-plugin');
     assert.equal(skills[0].skillName, 'real-skill');
     // skill is from monorepo path, NOT the 1.2.3 subdir
-    assert.match(skills[0].skillPath, /\/mixed-plugin\/skills\/real-skill\/SKILL\.md$/);
+    assert.equal(
+      path.normalize(skills[0].skillPath),
+      path.join(pluginDir, 'skills', 'real-skill', 'SKILL.md')
+    );
   } finally {
     await fs.rm(tmpDir, { recursive: true, force: true });
   }

--- a/plugins/codex-bridge/tests/discovery.test.mjs
+++ b/plugins/codex-bridge/tests/discovery.test.mjs
@@ -5,7 +5,7 @@ import path from 'node:path';
 import os from 'node:os';
 import { fileURLToPath } from 'node:url';
 
-import { discoverSkills, parseFrontmatter } from '../scripts/sync.mjs';
+import { discoverSkills, discoverCommands, parseFrontmatter, resolvePluginContentDir, compareSemver } from '../scripts/sync.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const FIXTURES = path.join(__dirname, 'fixtures');
@@ -119,6 +119,163 @@ test('discoverSkills: returns deterministically sorted results (pluginName, skil
       'mango/skill-x',
       'zebra/zeta',
     ]);
+  } finally {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('compareSemver: orders by major, minor, patch', () => {
+  assert.equal(compareSemver('1.0.0', '1.0.0'), 0);
+  assert.ok(compareSemver('1.0.0', '2.0.0') < 0);
+  assert.ok(compareSemver('1.2.0', '1.10.0') < 0);
+  assert.ok(compareSemver('1.0.10', '1.0.2') > 0);
+  assert.ok(compareSemver('2.0.0', '1.99.99') > 0);
+});
+
+test('compareSemver: ignores prerelease/build metadata for ordering', () => {
+  // Simple numeric-prefix comparison; `-rc.1` is stripped.
+  assert.equal(compareSemver('1.0.0-rc.1', '1.0.0-rc.2'), 0);
+  assert.ok(compareSemver('1.0.0-rc.1', '1.0.1') < 0);
+});
+
+test('resolvePluginContentDir: monorepo plugin (.claude-plugin/ present) returns plugin dir as-is', async () => {
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-bridge-disc-'));
+  try {
+    const pluginDir = path.join(tmpDir, 'my-plugin');
+    await fs.mkdir(path.join(pluginDir, '.claude-plugin'), { recursive: true });
+    await fs.mkdir(path.join(pluginDir, 'skills'), { recursive: true });
+
+    const result = await resolvePluginContentDir(pluginDir);
+    assert.equal(result, pluginDir);
+  } finally {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('resolvePluginContentDir: monorepo plugin without .claude-plugin/ but with skills/ falls back to plugin dir', async () => {
+  // Existing tests rely on this fallback (test fixtures don't always create .claude-plugin/).
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-bridge-disc-'));
+  try {
+    const pluginDir = path.join(tmpDir, 'my-plugin');
+    await fs.mkdir(path.join(pluginDir, 'skills'), { recursive: true });
+
+    const result = await resolvePluginContentDir(pluginDir);
+    assert.equal(result, pluginDir);
+  } finally {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('resolvePluginContentDir: cache layout (all children semver) returns latest version subdir', async () => {
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-bridge-disc-'));
+  try {
+    const pluginDir = path.join(tmpDir, 'codex-bridge');
+    for (const v of ['1.2.0', '1.13.0', '1.3.0', '1.3.1']) {
+      await fs.mkdir(path.join(pluginDir, v, '.claude-plugin'), { recursive: true });
+    }
+
+    const result = await resolvePluginContentDir(pluginDir);
+    assert.equal(result, path.join(pluginDir, '1.13.0'));
+  } finally {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('resolvePluginContentDir: ENOENT returns null', async () => {
+  const result = await resolvePluginContentDir('/nonexistent/path/that/should/not/exist');
+  assert.equal(result, null);
+});
+
+test('resolvePluginContentDir: empty plugin dir falls back to plugin dir (downstream walker handles ENOENT)', async () => {
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-bridge-disc-'));
+  try {
+    const pluginDir = path.join(tmpDir, 'empty-plugin');
+    await fs.mkdir(pluginDir, { recursive: true });
+
+    const result = await resolvePluginContentDir(pluginDir);
+    assert.equal(result, pluginDir);
+  } finally {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('discoverSkills: handles versioned cache layout, picks latest version per plugin', async () => {
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-bridge-disc-'));
+  try {
+    // Simulate ~/.claude/plugins/cache/my-claude-plugins/<plugin>/<version>/skills/<skill>/SKILL.md
+    const cacheRoot = path.join(tmpDir, 'my-claude-plugins');
+    const writeSkill = async (plugin, version, skill, body = 'body') => {
+      const p = path.join(cacheRoot, plugin, version, 'skills', skill);
+      await fs.mkdir(path.join(cacheRoot, plugin, version, '.claude-plugin'), { recursive: true });
+      await fs.mkdir(p, { recursive: true });
+      await fs.writeFile(path.join(p, 'SKILL.md'), `---\nname: ${skill}\n---\n${body}`);
+    };
+    await writeSkill('codex-bridge', '1.2.0', 'codex-sync', 'old');
+    await writeSkill('codex-bridge', '1.3.0', 'codex-sync', 'mid');
+    await writeSkill('codex-bridge', '1.3.1', 'codex-sync', 'latest');
+    await writeSkill('other-plugin', '2.0.0', 'foo');
+
+    const skills = await discoverSkills(cacheRoot);
+    assert.equal(skills.length, 2);
+
+    const codexSync = skills.find(s => s.pluginName === 'codex-bridge');
+    assert.ok(codexSync, 'expected codex-bridge entry');
+    assert.equal(codexSync.skillName, 'codex-sync');
+    // Verify the LATEST version was picked (1.3.1, not 1.2.0 / 1.3.0)
+    assert.match(codexSync.skillPath, /\/1\.3\.1\/skills\/codex-sync\/SKILL\.md$/);
+    const body = await fs.readFile(codexSync.skillPath, 'utf-8');
+    assert.match(body, /latest/);
+
+    const foo = skills.find(s => s.pluginName === 'other-plugin');
+    assert.ok(foo, 'expected other-plugin entry');
+    assert.equal(foo.skillName, 'foo');
+  } finally {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('discoverCommands: handles versioned cache layout, picks latest version per plugin', async () => {
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-bridge-disc-'));
+  try {
+    const cacheRoot = path.join(tmpDir, 'my-claude-plugins');
+    const writeCmd = async (plugin, version, name, body = '# cmd') => {
+      const dir = path.join(cacheRoot, plugin, version, 'commands');
+      await fs.mkdir(path.join(cacheRoot, plugin, version, '.claude-plugin'), { recursive: true });
+      await fs.mkdir(dir, { recursive: true });
+      await fs.writeFile(path.join(dir, `${name}.md`), `---\ndescription: x\n---\n${body}`);
+    };
+    await writeCmd('github-dev', '1.13.0', 'commit-and-push', 'old');
+    await writeCmd('github-dev', '1.14.0', 'commit-and-push', 'latest');
+
+    const commands = await discoverCommands(cacheRoot);
+    assert.equal(commands.length, 1);
+    assert.equal(commands[0].pluginName, 'github-dev');
+    assert.equal(commands[0].commandName, 'commit-and-push');
+    assert.match(commands[0].sourcePath, /\/1\.14\.0\/commands\/commit-and-push\.md$/);
+  } finally {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('discoverSkills: monorepo plugin with coincidentally-semver-named subdir is NOT misclassified', async () => {
+  // If a plugin has both .claude-plugin/ AND a child like '1.2.3', the .claude-plugin
+  // marker wins and we treat as monorepo.
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-bridge-disc-'));
+  try {
+    const pluginsDir = path.join(tmpDir, 'plugins');
+    const pluginDir = path.join(pluginsDir, 'mixed-plugin');
+    await fs.mkdir(path.join(pluginDir, '.claude-plugin'), { recursive: true });
+    await fs.mkdir(path.join(pluginDir, '1.2.3'), { recursive: true }); // distractor
+    const skillDir = path.join(pluginDir, 'skills', 'real-skill');
+    await fs.mkdir(skillDir, { recursive: true });
+    await fs.writeFile(path.join(skillDir, 'SKILL.md'), '---\nname: real-skill\n---\nbody');
+
+    const skills = await discoverSkills(pluginsDir);
+    assert.equal(skills.length, 1);
+    assert.equal(skills[0].pluginName, 'mixed-plugin');
+    assert.equal(skills[0].skillName, 'real-skill');
+    // skill is from monorepo path, NOT the 1.2.3 subdir
+    assert.match(skills[0].skillPath, /\/mixed-plugin\/skills\/real-skill\/SKILL\.md$/);
   } finally {
     await fs.rm(tmpDir, { recursive: true, force: true });
   }

--- a/plugins/codex-bridge/tests/resolve-plugins-dir.test.mjs
+++ b/plugins/codex-bridge/tests/resolve-plugins-dir.test.mjs
@@ -1,0 +1,129 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+
+import { resolvePluginsDir, isVersionedCacheChild } from '../scripts/sync.mjs';
+
+async function freshTmp() {
+  return fs.mkdtemp(path.join(os.tmpdir(), 'codex-bridge-resolve-'));
+}
+
+test('isVersionedCacheChild: matches semver MAJOR.MINOR.PATCH', () => {
+  assert.equal(isVersionedCacheChild('1.0.0'), true);
+  assert.equal(isVersionedCacheChild('1.3.1'), true);
+  assert.equal(isVersionedCacheChild('10.20.30'), true);
+});
+
+test('isVersionedCacheChild: matches semver with prerelease/build metadata', () => {
+  assert.equal(isVersionedCacheChild('1.0.0-rc.1'), true);
+  assert.equal(isVersionedCacheChild('1.2.3+build.42'), true);
+  assert.equal(isVersionedCacheChild('1.2.3-alpha+meta'), true);
+});
+
+test('isVersionedCacheChild: rejects plugin-like names', () => {
+  assert.equal(isVersionedCacheChild('codex-bridge'), false);
+  assert.equal(isVersionedCacheChild('github-dev'), false);
+  assert.equal(isVersionedCacheChild('1.0'), false);
+  assert.equal(isVersionedCacheChild('v1.0.0'), false);
+  assert.equal(isVersionedCacheChild(''), false);
+});
+
+test('resolvePluginsDir: monorepo layout returns candidateA (one level above plugin dir)', async () => {
+  const tmp = await freshTmp();
+  try {
+    // tmp/plugins/{alpha,beta}/scripts/sync.mjs
+    const pluginsDir = path.join(tmp, 'plugins');
+    for (const name of ['alpha', 'beta']) {
+      await fs.mkdir(path.join(pluginsDir, name, 'scripts'), { recursive: true });
+    }
+    const scriptPath = path.join(pluginsDir, 'alpha', 'scripts', 'sync.mjs');
+
+    const result = await resolvePluginsDir(scriptPath, null);
+    assert.equal(result, pluginsDir);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test('resolvePluginsDir: versioned cache layout jumps one more level up', async () => {
+  const tmp = await freshTmp();
+  try {
+    // tmp/cache/codex-bridge/{1.2.0,1.3.0}/scripts/sync.mjs
+    const cacheRoot = path.join(tmp, 'cache');
+    const pluginCacheDir = path.join(cacheRoot, 'codex-bridge');
+    for (const ver of ['1.2.0', '1.3.0']) {
+      await fs.mkdir(path.join(pluginCacheDir, ver, 'scripts'), { recursive: true });
+    }
+    const scriptPath = path.join(pluginCacheDir, '1.3.0', 'scripts', 'sync.mjs');
+
+    const result = await resolvePluginsDir(scriptPath, null);
+    assert.equal(result, cacheRoot);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test('resolvePluginsDir: explicit override is returned verbatim (resolved)', async () => {
+  const tmp = await freshTmp();
+  try {
+    const custom = path.join(tmp, 'custom-plugins');
+    await fs.mkdir(custom, { recursive: true });
+    const scriptPath = path.join(tmp, 'irrelevant', 'scripts', 'sync.mjs');
+
+    const result = await resolvePluginsDir(scriptPath, custom);
+    assert.equal(result, path.resolve(custom));
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test('resolvePluginsDir: override resolves relative paths', async () => {
+  const result = await resolvePluginsDir('/somewhere/scripts/sync.mjs', './my/plugins');
+  assert.equal(result, path.resolve('./my/plugins'));
+});
+
+test('resolvePluginsDir: ENOENT (no candidate directory) falls back to candidateA', async () => {
+  const tmp = await freshTmp();
+  try {
+    // scriptPath points to a path whose grandparent does not exist
+    const scriptPath = path.join(tmp, 'never-created', 'subdir', 'scripts', 'sync.mjs');
+    const expectedFallback = path.resolve(path.dirname(scriptPath), '..', '..');
+
+    const result = await resolvePluginsDir(scriptPath, null);
+    assert.equal(result, expectedFallback);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test('resolvePluginsDir: candidateA with mixed children (some semver, some not) treated as monorepo', async () => {
+  const tmp = await freshTmp();
+  try {
+    // plugins-like dir with both 'real-plugin' and a coincidentally-semver-named subdir
+    const pluginsDir = path.join(tmp, 'plugins');
+    await fs.mkdir(path.join(pluginsDir, 'real-plugin'), { recursive: true });
+    await fs.mkdir(path.join(pluginsDir, '1.2.3'), { recursive: true });
+    const scriptPath = path.join(pluginsDir, 'real-plugin', 'scripts', 'sync.mjs');
+
+    const result = await resolvePluginsDir(scriptPath, null);
+    assert.equal(result, pluginsDir, 'mixed children should NOT trigger versioned-cache fallback');
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test('resolvePluginsDir: empty candidateA directory falls back to candidateA (no false positive)', async () => {
+  const tmp = await freshTmp();
+  try {
+    const pluginsDir = path.join(tmp, 'plugins');
+    await fs.mkdir(pluginsDir, { recursive: true });
+    const scriptPath = path.join(pluginsDir, 'phantom-plugin', 'scripts', 'sync.mjs');
+
+    const result = await resolvePluginsDir(scriptPath, null);
+    assert.equal(result, pluginsDir);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});

--- a/plugins/codex-bridge/tests/sync.test.mjs
+++ b/plugins/codex-bridge/tests/sync.test.mjs
@@ -270,3 +270,133 @@ test('syncAll: no collision warning when all skill names unique', async () => {
     await fs.rm(tmp, { recursive: true, force: true });
   }
 });
+
+test('syncAll: prune is SKIPPED when validSources is empty (defends against pluginsDir misresolution)', async () => {
+  // Regression test for the destructive prune bug fixed in 1.3.1.
+  // If discovery returns 0 results (e.g. wrong pluginsDir under Claude Code's
+  // versioned cache layout), pruneOrphans must NOT run — otherwise every
+  // bridge-managed entry in ~/.agents/skills/ would be deleted.
+  const tmp = await freshTmp();
+  try {
+    // Empty plugins dir (no plugins/* under it) — discovery returns []
+    const pluginsDir = path.join(tmp, 'plugins');
+    await fs.mkdir(pluginsDir, { recursive: true });
+
+    // Pre-populate target with a bridge-managed skill that WOULD be pruned
+    // under the old behavior (orphan with no matching source).
+    const targetDir = path.join(tmp, 'target', '.agents', 'skills');
+    const preExisting = path.join(targetDir, 'previously-synced');
+    await fs.mkdir(preExisting, { recursive: true });
+    await fs.writeFile(
+      path.join(preExisting, 'SKILL.md'),
+      '---\nname: previously-synced\nbridge_source: somePlugin/previously-synced\n---\nold body'
+    );
+
+    const warnings = [];
+    const logger = { warn: (m) => warnings.push(m), info: () => {} };
+
+    const report = await syncAll({
+      pluginsDir,
+      targetDir,
+      config: DEFAULT_CONFIG,
+      dryRun: false,
+      prune: true,
+      logger,
+    });
+
+    // Guard fired: nothing pruned, warning emitted, file still present.
+    assert.deepEqual(report.removed, []);
+    assert.ok(
+      warnings.some(w => /prune skipped: 0 valid sources/.test(w)),
+      `expected prune-skip warning, got: ${warnings.join(' | ')}`
+    );
+    assert.ok(
+      report.warnings.some(w => /prune skipped: 0 valid sources/.test(w)),
+      'expected report.warnings to include prune-skip warning'
+    );
+
+    const survivor = await fs.readFile(path.join(preExisting, 'SKILL.md'), 'utf-8');
+    assert.match(survivor, /bridge_source: somePlugin\/previously-synced/);
+    assert.match(survivor, /old body/);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test('syncAll: empty discoverSkills emits warning into report.warnings (early signal)', async () => {
+  const tmp = await freshTmp();
+  try {
+    const pluginsDir = path.join(tmp, 'plugins');
+    await fs.mkdir(pluginsDir, { recursive: true });
+
+    const warnings = [];
+    const logger = { warn: (m) => warnings.push(m), info: () => {} };
+
+    const report = await syncAll({
+      pluginsDir,
+      targetDir: path.join(tmp, 'target', '.agents', 'skills'),
+      config: DEFAULT_CONFIG,
+      dryRun: true,
+      prune: false,
+      logger,
+    });
+
+    assert.ok(
+      warnings.some(w => /discoverSkills returned 0 results/.test(w)),
+      `expected discoverSkills-empty warning, got: ${warnings.join(' | ')}`
+    );
+    assert.ok(
+      report.warnings.some(w => /discoverSkills returned 0 results/.test(w)),
+      'expected report.warnings to include discoverSkills-empty warning'
+    );
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test('syncAll: prune still runs normally when validSources non-empty', async () => {
+  // Sanity check: the safety guard must NOT block legitimate prunes.
+  const tmp = await freshTmp();
+  try {
+    // One source plugin/skill — validSources will include it.
+    await makeSourceSkill(tmp, 'alpha', 'kept', '---\nname: kept\ndescription: x\n---\nbody');
+
+    const targetDir = path.join(tmp, 'target', '.agents', 'skills');
+    // Pre-populate an orphan (bridge-managed but no matching source).
+    const orphan = path.join(targetDir, 'orphan-skill');
+    await fs.mkdir(orphan, { recursive: true });
+    await fs.writeFile(
+      path.join(orphan, 'SKILL.md'),
+      '---\nname: orphan-skill\nbridge_source: deleted/orphan-skill\n---\ngone'
+    );
+
+    const logger = { warn: () => {}, info: () => {} };
+
+    const report = await syncAll({
+      pluginsDir: path.join(tmp, 'plugins'),
+      targetDir,
+      config: DEFAULT_CONFIG,
+      dryRun: false,
+      prune: true,
+      logger,
+    });
+
+    assert.equal(report.removed.length, 1);
+    assert.equal(report.removed[0].skillName, 'orphan-skill');
+    // Orphan dir is gone
+    await assert.rejects(fs.access(orphan));
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test('parseArgs: --plugins-dir captures path', async () => {
+  const { parseArgs } = await import('../scripts/sync.mjs');
+  const args = parseArgs(['--plugins-dir', '/custom/path']);
+  assert.equal(args.pluginsDir, '/custom/path');
+});
+
+test('parseArgs: --plugins-dir without value throws', async () => {
+  const { parseArgs } = await import('../scripts/sync.mjs');
+  assert.throws(() => parseArgs(['--plugins-dir']), /requires a path/);
+});

--- a/plugins/codex-bridge/tests/sync.test.mjs
+++ b/plugins/codex-bridge/tests/sync.test.mjs
@@ -400,3 +400,11 @@ test('parseArgs: --plugins-dir without value throws', async () => {
   const { parseArgs } = await import('../scripts/sync.mjs');
   assert.throws(() => parseArgs(['--plugins-dir']), /requires a path/);
 });
+
+test('parseArgs: --plugins-dir followed by another flag is rejected (does not silently consume the flag)', async () => {
+  const { parseArgs } = await import('../scripts/sync.mjs');
+  // Without the dash-prefix guard, this would parse pluginsDir="--dry-run"
+  // and consume the actual --dry-run flag.
+  assert.throws(() => parseArgs(['--plugins-dir', '--dry-run']), /requires a path/);
+  assert.throws(() => parseArgs(['--plugins-dir', '-h']), /requires a path/);
+});


### PR DESCRIPTION
## Summary

Fixes a destructive regression in `codex-bridge` where invoking `sync.mjs` from Claude Code's plugin cache wiped previously-synced `~/.agents/skills/` entries.

- **Root cause**: `sync.mjs` resolved `pluginsDir` by going *exactly two levels up* from the script. That works for monorepo (`<repo>/plugins/<plugin>/scripts/sync.mjs` → `<repo>/plugins`) but lands one level too low under Claude Code's cache (`<root>/<plugin>/<version>/scripts/sync.mjs` → `<root>/<plugin>` instead of `<root>`). Discovery then enumerated `1.2.0` / `1.3.0` *as if they were plugin names*, the lone `codex-sync` skill won the last-wins sort, and 1.3.0's auto-prune (default-on, new in #15) deleted ~44 sibling entries as orphans.
- **Pre-existing defect**: latent since v1.0; #15 turned it destructive by enabling auto-prune by default.

Closes #16

## Why this isn't just a one-liner

A naive fix that only resolves `pluginsDir` to `<root>/cache/my-claude-plugins/` would still discover **0 skills** under cache layout, because each plugin's content lives at `<plugin>/<version>/skills/`, not `<plugin>/skills/`. So the fix is layered:

1. **Script-level resolution** — `resolvePluginsDir` detects \"every direct child of the monorepo candidate is semver-named\" ⇒ versioned-cache fallback, jump one more level.
2. **Per-plugin layout resolution** — `resolvePluginContentDir` detects \"this plugin lacks a direct `.claude-plugin/` and all children are semver\" ⇒ descend into the highest semver subdir. Mirrors how Claude Code itself selects active versions.
3. **Defense-in-depth prune guard** — `pruneOrphans` is *unconditionally skipped* whenever `validSources.size === 0`. Even if a future bug causes discovery to silently fail, user data in `~/.agents/skills/` will not be deleted.

## Behavior changes

| Scenario | Before (1.3.0) | After (1.3.1) |
|----------|----------------|---------------|
| Run from `<repo>/plugins/codex-bridge/scripts/sync.mjs` | ✅ works | ✅ works (unchanged) |
| Run from `~/.claude/plugins/cache/.../codex-bridge/<v>/scripts/sync.mjs` | ❌ discovers 1 wrong skill, **prunes ~44 entries** | ✅ discovers all 22 plugins / 25+ skills / 21+ commands, syncs correctly |
| `--plugin codex-bridge` from cache | ❌ matches 0 | ✅ matches 1 (correct plugin name, not version string) |
| Discovery returns 0 (any cause) | ❌ prunes everything | ✅ prune skipped, stderr warning, `report.warnings` populated |
| `--verbose` output | minimal | adds `resolved pluginsDir: <path> (<layout>)` + `discovered N plugins, M skills, K commands` |

## New CLI surface

```
--plugins-dir <path>   Override plugins directory (skips auto-detect; use when running
                       from an unusual layout, e.g. Claude Code's versioned cache)
```

`--plugins-dir` is purely additive — no flag rename, no behavior change for existing invocations. PATCH-level bump (1.3.0 → 1.3.1) is appropriate.

## Implementation notes

- **Heuristic for cache detection**: \"every direct child is semver-named\" (`^\d+\.\d+\.\d+(?:[-+].*)?$`). False positives are theoretically possible (a plugin dir whose every child happens to look like semver) but vanishingly rare in practice. The `--plugins-dir` override is the explicit escape hatch.
- **`.claude-plugin/` as monorepo signal**: every plugin manifest sits in `<plugin>/.claude-plugin/plugin.json` per the [Claude Code plugin spec](https://docs.anthropic.com/claude-code/plugins). Its presence directly under `<plugin>` is the canonical \"this is a monorepo content root\" marker. Coincidental sibling subdirs (even semver-named) are ignored.
- **\"Latest semver\" version selection**: when descending into cache layout, picks the highest semver via `compareSemver`. Acknowledged limitation: doesn't read `marketplace.json` to find the *currently-active* version, but in practice latest-installed = active for ~all users.
- **`report.warnings`**: new field. Existing consumers that read `report.errors` / `report.removed` are unaffected; new field is additive.
- **No new runtime dependencies** — Node 18+ built-ins only (per `.claude/rules/codex-bridge-sync.md`).

## Test plan

- [x] `node --test tests/*.test.mjs` — 88 tests pass (63 pre-existing + 25 new across `tests/resolve-plugins-dir.test.mjs`, `tests/discovery.test.mjs`, `tests/sync.test.mjs`).
- [x] **Cache layout simulation**: temp tree mimicking `cache/<plugin>/<semver>/skills|commands/...` discovers all entries and tags them with the correct `pluginName` (not version string).
- [x] **`--plugins-dir` override**: explicit path used verbatim, layout label correctly says `overridden via --plugins-dir`.
- [x] **Prune safety guard**: `--plugins-dir /tmp/empty` + non-dryrun against a custom `agentsHome` confirms `removed: []`, warning emitted, pre-existing bridge-managed file untouched.
- [ ] **Real cache invocation** (post-merge): `node ~/.claude/plugins/cache/my-claude-plugins/codex-bridge/1.3.1/scripts/sync.mjs --dry-run --verbose` — expected `auto-detected (versioned-cache fallback)` + 22 plugins discovered. (Cannot verify before merge since the cache only refreshes after install.)
- [ ] **Windows verification** (post-merge, user environment) — code uses `path.resolve`/`path.join` only, no OS-specific branches; same logic should hold.

## User upgrade workflow

Per `.claude/rules/plugin-versioning.md`:

```bash
rm -rf ~/.claude/plugins/cache/my-claude-plugins/
/plugin marketplace update my-claude-plugins
# Restart Claude Code
```

Then `/codex-bridge:codex-sync --dry-run --verbose` should show `auto-detected (versioned-cache fallback)` and discover the full plugin set. If for any reason `validSources` is still empty (broken install, deeply nested cache, etc.), the prune guard ensures no destructive deletion occurs and the warning will indicate the failure mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 플러그인 디렉토리 자동 감지 개선(모노레포·버전 캐시 레이아웃 인식) 및 상세 진단 출력
  * CLI에 플러그인 디렉토리 수동 지정(--plugins-dir) 및 --dry-run 옵션 추가

* **버그 수정**
  * 플러그인 검색 실패 시 자동 삭제(프루닝) 방지 및 경고 보고 추가
  * 버전 선택 로직 개선으로 최신 버전 식별 정확도 향상

* **문서**
  * CLI 옵션, 실행 위치(레이아웃) 및 안전성 동작 문서 보강

* **테스트**
  * 레이아웃 감지, semver 비교, 프루닝 안전성 등 단위·통합 테스트 추가

* **기타**
  * 마켓플레이스 버전 1.15.1 및 플러그인 버전 1.3.1 반영
<!-- end of auto-generated comment: release notes by coderabbit.ai -->