### PR TITLE
improve(github-dev): cr-fix Codex cache allows inactive -> active mid-run flip

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Personal Claude Code plugin collection with 19 specialized plugins",
-    "version": "1.19.0"
+    "version": "1.20.0"
   },
   "plugins": [
     {
@@ -19,7 +19,7 @@
       "name": "github-dev",
       "source": "./plugins/github-dev",
       "description": "GitHub workflow: commit, PR, issue, worktree, unified CodeRabbit + ChatGPT-Codex cr-fix pipeline (wait + auto-fetch + apply + push loop with branch-protection-gated auto-merge, CR-engagement guard, Codex auto-detect with grace polling, CR Nitpick + Codex P3 silent skip, optional --skip-minor opt-in for Minor + Codex P2 suppression), project tracking, release",
-      "version": "1.16.0",
+      "version": "1.17.0",
       "category": "github"
     },
     {

--- a/plugins/github-dev/.claude-plugin/plugin.json
+++ b/plugins/github-dev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "github-dev",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "description": "GitHub workflow automation commands for Claude Code",
   "commands": [
     "./commands/code-review.md",

--- a/plugins/github-dev/commands/cr-fix.md
+++ b/plugins/github-dev/commands/cr-fix.md
@@ -121,12 +121,20 @@ if [ "$ITER" = "1" ]; then
   if [ "$NO_CODEX" = "true" ]; then
     codex_active="disabled"
   else
-    codex_review_count=$(gh api --paginate "repos/$OWNER/$REPO/pulls/$PR_NUM/reviews" \
-      --jq '.[] | select(.user.login == "chatgpt-codex-connector[bot]") | .id' \
-      | wc -l)
-    if [ "$codex_review_count" -gt 0 ]; then
-      codex_active="active"
+    # Capture gh output separately so a transient API error doesn't masquerade
+    # as "0 Codex reviews". `gh api ... | wc -l` would return 0 on failure
+    # because the pipeline exit status comes from wc, silently locking
+    # codex_active to "inactive" for the whole run.
+    if codex_review_ids=$(gh api --paginate "repos/$OWNER/$REPO/pulls/$PR_NUM/reviews" \
+        --jq '.[] | select(.user.login == "chatgpt-codex-connector[bot]") | .id'); then
+      codex_review_count=$(grep -c . <<< "$codex_review_ids")
+      if [ "$codex_review_count" -gt 0 ]; then
+        codex_active="active"
+      else
+        codex_active="inactive"
+      fi
     else
+      echo "warn: Codex engagement probe failed (gh api error); falling back to inactive — re-run cr-fix to retry" >&2
       codex_active="inactive"
     fi
   fi
@@ -139,11 +147,14 @@ elif [ "$codex_active" = "inactive" ]; then
   # late-arriving Codex review flip the cache to "active". Within a
   # single iteration the resolution is fixed, so the deterministic-per-
   # iteration guarantee still holds.
-  codex_review_count=$(gh api --paginate "repos/$OWNER/$REPO/pulls/$PR_NUM/reviews" \
-    --jq '.[] | select(.user.login == "chatgpt-codex-connector[bot]") | .id' \
-    | wc -l)
-  if [ "$codex_review_count" -gt 0 ]; then
-    codex_active="active"
+  if codex_review_ids=$(gh api --paginate "repos/$OWNER/$REPO/pulls/$PR_NUM/reviews" \
+      --jq '.[] | select(.user.login == "chatgpt-codex-connector[bot]") | .id'); then
+    codex_review_count=$(grep -c . <<< "$codex_review_ids")
+    if [ "$codex_review_count" -gt 0 ]; then
+      codex_active="active"
+    fi
+  else
+    echo "warn: Codex mid-run probe failed; leaving codex_active=inactive for this iteration" >&2
   fi
 fi
 ```

--- a/plugins/github-dev/commands/cr-fix.md
+++ b/plugins/github-dev/commands/cr-fix.md
@@ -121,8 +121,9 @@ if [ "$ITER" = "1" ]; then
   if [ "$NO_CODEX" = "true" ]; then
     codex_active="disabled"
   else
-    codex_review_count=$(gh api "repos/$OWNER/$REPO/pulls/$PR_NUM/reviews" \
-      --jq '[.[] | select(.user.login == "chatgpt-codex-connector[bot]")] | length')
+    codex_review_count=$(gh api --paginate "repos/$OWNER/$REPO/pulls/$PR_NUM/reviews" \
+      --jq '.[] | select(.user.login == "chatgpt-codex-connector[bot]") | .id' \
+      | wc -l)
     if [ "$codex_review_count" -gt 0 ]; then
       codex_active="active"
     else
@@ -138,8 +139,9 @@ elif [ "$codex_active" = "inactive" ]; then
   # late-arriving Codex review flip the cache to "active". Within a
   # single iteration the resolution is fixed, so the deterministic-per-
   # iteration guarantee still holds.
-  codex_review_count=$(gh api "repos/$OWNER/$REPO/pulls/$PR_NUM/reviews" \
-    --jq '[.[] | select(.user.login == "chatgpt-codex-connector[bot]")] | length')
+  codex_review_count=$(gh api --paginate "repos/$OWNER/$REPO/pulls/$PR_NUM/reviews" \
+    --jq '.[] | select(.user.login == "chatgpt-codex-connector[bot]") | .id' \
+    | wc -l)
   if [ "$codex_review_count" -gt 0 ]; then
     codex_active="active"
   fi

--- a/plugins/github-dev/commands/cr-fix.md
+++ b/plugins/github-dev/commands/cr-fix.md
@@ -134,7 +134,7 @@ if [ "$ITER" = "1" ]; then
         codex_active="inactive"
       fi
     else
-      echo "warn: Codex engagement probe failed (gh api error); falling back to inactive — re-run cr-fix to retry" >&2
+      echo "warn: Codex engagement probe failed (gh api error); codex_active=inactive for this iteration — will be re-probed on the next iteration if still inactive" >&2
       codex_active="inactive"
     fi
   fi

--- a/plugins/github-dev/commands/cr-fix.md
+++ b/plugins/github-dev/commands/cr-fix.md
@@ -48,7 +48,7 @@ applied_total=0
 deferred_total=0
 skipped_total=0               # CR Nitpick + Codex P3 silently filtered (telemetry only)
 verification_blocking=false   # global; once true, stays true for the run (disables auto-merge)
-codex_active=unknown          # set in Step 6 first iteration: "active" / "inactive" / "disabled"
+codex_active=unknown          # set in Step 6 first iteration; "inactive" -> "active" mid-run flip allowed at iter 2+ Step 6 entry. Values: "active" / "inactive" / "disabled".
 ```
 
 If `PR_NUM` empty → abort: `No open PR for current branch — push first and open a PR before running cr-fix.`
@@ -112,9 +112,9 @@ for ITER in $(seq 1 $MAX_ITER); do
 
 ## Step 6: Wait phase — CodeRabbit (inlined cr-wait Steps 2-4)
 
-**Codex auto-detect (first iteration only)**:
+**Codex auto-detect (first iteration + mid-run flip)**:
 
-Before the CR probe in iteration 1, resolve `codex_active` for the run:
+Before the CR probe, resolve `codex_active` for the iteration. The first iteration always probes; subsequent iterations only re-probe when the cache is still `inactive`, so an `active` decision is sticky for the rest of the run:
 
 ```bash
 if [ "$ITER" = "1" ]; then
@@ -129,10 +129,24 @@ if [ "$ITER" = "1" ]; then
       codex_active="inactive"
     fi
   fi
+elif [ "$codex_active" = "inactive" ]; then
+  # Mid-run re-probe: a PR opened seconds before the first Codex review
+  # arrives (CodeRabbit responds in seconds, Codex typically 3-5 min)
+  # would otherwise stay locked as "inactive" for the entire run and
+  # skip Step 8b. The probe is idempotent (a pure read on /reviews) so
+  # there is no race condition to prevent — re-running it just lets a
+  # late-arriving Codex review flip the cache to "active". Within a
+  # single iteration the resolution is fixed, so the deterministic-per-
+  # iteration guarantee still holds.
+  codex_review_count=$(gh api "repos/$OWNER/$REPO/pulls/$PR_NUM/reviews" \
+    --jq '[.[] | select(.user.login == "chatgpt-codex-connector[bot]")] | length')
+  if [ "$codex_review_count" -gt 0 ]; then
+    codex_active="active"
+  fi
 fi
 ```
 
-`codex_active` is cached for the rest of the run. A PR that gains its first Codex review mid-run will not auto-flip from `inactive` to `active` — re-run cr-fix to pick it up. This keeps behavior deterministic per run and avoids race conditions on the engagement probe.
+`codex_active` is cached **within** an iteration so Step 6b grace polling and Step 8b inline-fetch both see a fixed value. Across iterations, an `inactive` cache will be re-probed at the next Step 6 entry; `active` and `disabled` never flip back. This catches the common case where a PR opens just before its first Codex review arrives — without the mid-run re-probe the run would skip Codex output entirely even though the review is sitting on the same SHA Step 8 is fetching.
 
 **Probe once (fast path)**:
 

--- a/plugins/github-dev/commands/cr-fix.md
+++ b/plugins/github-dev/commands/cr-fix.md
@@ -127,7 +127,7 @@ if [ "$ITER" = "1" ]; then
     # codex_active to "inactive" for the whole run.
     if codex_review_ids=$(gh api --paginate "repos/$OWNER/$REPO/pulls/$PR_NUM/reviews" \
         --jq '.[] | select(.user.login == "chatgpt-codex-connector[bot]") | .id'); then
-      codex_review_count=$(grep -c . <<< "$codex_review_ids")
+      codex_review_count=$(awk 'NF{c++} END{print c+0}' <<< "$codex_review_ids")
       if [ "$codex_review_count" -gt 0 ]; then
         codex_active="active"
       else
@@ -149,7 +149,7 @@ elif [ "$codex_active" = "inactive" ]; then
   # iteration guarantee still holds.
   if codex_review_ids=$(gh api --paginate "repos/$OWNER/$REPO/pulls/$PR_NUM/reviews" \
       --jq '.[] | select(.user.login == "chatgpt-codex-connector[bot]") | .id'); then
-    codex_review_count=$(grep -c . <<< "$codex_review_ids")
+    codex_review_count=$(awk 'NF{c++} END{print c+0}' <<< "$codex_review_ids")
     if [ "$codex_review_count" -gt 0 ]; then
       codex_active="active"
     fi


### PR DESCRIPTION
## Summary

`cr-fix.md` §6 currently caches `codex_active=inactive` for the entire run when the iter-1 probe finds no Codex reviews. In practice CodeRabbit responds within seconds while Codex takes 3-5 minutes, so the first probe almost always misses Codex on a freshly-opened PR — and the cache lock then makes Step 8b skip Codex inline-fetch for the rest of the run.

The "deterministic per run, no race condition" trade-off isn't actually load-bearing. The probe is `gh api .../reviews | length` — pure read, idempotent. Running it twice on the same data returns the same set, so there's no race condition to prevent. Meanwhile the completeness loss matches a predictable bot timing pattern: Codex consistently 3-5 minutes after PR open is exactly the window the cache locks out.

## Concrete miss case

PR #117 of `YoungjaeDev/jaywalk-vlm-risk` on 2026-05-06:

| Time (UTC) | Event |
|---|---|
| 11:50:07 | PR opened, cr-fix Step 6 first Codex probe → 0 → cache `inactive` |
| 11:53:52 | Codex submits review on the same SHA (3m 45s later) |
| 11:58:21 | CodeRabbit submits review |
| ~11:59 | cr-fix Step 8 fetch — Codex review present but skipped |

The user manually noticed Codex output and asked "is cr-fix parsing it?". It wasn't. Manual override caught **two Codex P1 API drift findings** on `build_exp011_overlays.py` (`extract` vs `extract_at_t` + string list vs `OvsClass` enum on `Sam3OvsPredictor.predict`) that would have made the entire 95-clip overlay batch fail at the first call. Without manual override those bugs would have merged.

## Change

Each subsequent iteration re-probes at Step 6 entry only when `codex_active` is still `inactive`. A non-zero review count flips the cache to `active` for the remainder of the run; `active` and `disabled` never flip back. Cache resolution stays fixed within a single iteration so Step 6b grace polling and Step 8b inline-fetch always see a stable value.

```diff
 if [ "$ITER" = "1" ]; then
   if [ "$NO_CODEX" = "true" ]; then
     codex_active="disabled"
   else
     codex_review_count=$(gh api .../reviews | length)
     if [ "$codex_review_count" -gt 0 ]; then
       codex_active="active"
     else
       codex_active="inactive"
     fi
   fi
+elif [ "$codex_active" = "inactive" ]; then
+  codex_review_count=$(gh api .../reviews | length)
+  if [ "$codex_review_count" -gt 0 ]; then
+    codex_active="active"
+  fi
 fi
```

Spec narrative also updated: `Codex auto-detect (first iteration only)` → `Codex auto-detect (first iteration + mid-run flip)`, plus rewritten paragraph describing the new contract.

## Test plan

- [x] Spec-only change; existing wait / fetch / apply flow unchanged.
- [ ] Field-test on next PR cycle — open a PR, time first Codex probe, confirm iter-2+ re-probe picks up a late-arriving Codex review.

## Reference

- Source incident: PR #117 of `YoungjaeDev/jaywalk-vlm-risk`, cr-fix iter 1 (2026-05-06).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * Codex 활성화 상태를 반복 단위로 관리해 실행 중 새로 도착한 리뷰를 반영하도록 개선되었습니다.
  * 초기 탐지 이후 비활성으로 표시된 경우에만 반복 중 재탐지해 늦게 도착한 리뷰를 더 잘 포착합니다.
  * API 오류가 일시적 실패로 처리되어 “리뷰 없음”으로 오판하지 않습니다.

* **문서**
  * 반복별 캐싱과 재탐지 동작에 대한 설명이 명확히 업데이트되었습니다.

* **기타**
  * 플러그인 및 마켓플레이스 메타데이터 버전이 상향되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->