### PR TITLE
feat(codex-bridge): 1.4.0 — sync subagents to ~/.codex/agents/*.toml

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Personal Claude Code plugin collection with 19 specialized plugins",
-    "version": "1.20.0"
+    "version": "1.21.0"
   },
   "plugins": [
     {
@@ -137,8 +137,8 @@
     {
       "name": "codex-bridge",
       "source": "./plugins/codex-bridge",
-      "description": "Sync my-claude-plugins skills and commands to Codex ~/.agents/skills/ (USER scope) so they become callable as native $skill-name. Body-only transform with bridge_source provenance marker.",
-      "version": "1.3.2",
+      "description": "Sync my-claude-plugins skills, commands, and subagents to Codex (~/.agents/skills/ for skills+commands, ~/.codex/agents/*.toml for subagents — USER scope) so they become callable as native $skill-name / subagent. Body-only transform with bridge_source provenance marker.",
+      "version": "1.4.0",
       "category": "integration"
     }
   ]

--- a/.claude/rules/codex-bridge-sync.md
+++ b/.claude/rules/codex-bridge-sync.md
@@ -8,13 +8,15 @@ Behavioral invariants for the my-claude-plugins → Codex skill sync engine (`pl
 
 ## Role
 
-Sync plugin skills (`plugins/*/skills/**/SKILL.md`) AND commands (`plugins/*/commands/*.md`) to Codex CLI's native skill directory (`~/.agents/skills/`) idempotently. my-claude-plugins is single source of truth (SSOT); the target is a derived artifact rebuilt every run.
+Sync plugin skills (`plugins/*/skills/**/SKILL.md`), commands (`plugins/*/commands/*.md`), AND subagents (`plugins/*/agents/*.md`) to Codex CLI's native directories (`~/.agents/skills/` for skills+commands, `~/.codex/agents/*.toml` for subagents) idempotently. my-claude-plugins is single source of truth (SSOT); the target is a derived artifact rebuilt every run.
 
 Commands are not a first-class concept in Codex — they're wrapped as synthetic skills with `<plugin>-<command>` naming (e.g. `github-dev-resolve-issue`) and `bridge_source: <plugin>/commands/<command>` markers to distinguish from skill-origin entries.
 
+Subagents have their own native target in Codex (`~/.codex/agents/<plugin>-<agent>.toml`). Markdown frontmatter is converted to TOML; body is wrapped in `developer_instructions = """..."""` triple-quoted multi-line string. The provenance marker is a `# bridge_source = "<plugin>/agents/<agent>"` comment on the first line (TOML has no first-class metadata, so the comment carries the role of the YAML `bridge_source:` field).
+
 ## Key Components
 
-- `scripts/sync.mjs` — single-file Node 18+ engine (zero runtime deps). Exports `discoverSkills`, `discoverCommands`, `resolvePluginsDir`, `resolvePluginContentDir`, `isVersionedCacheChild`, `compareSemver`, `parseFrontmatter`, `applyTransforms`, `transformSkillContent`, `injectBridgeSource`, `syncOne`, `syncCommand`, `syncAll`, `pruneOrphans`, `loadConfig`, `parseArgs`, `isExcluded`.
+- `scripts/sync.mjs` — single-file Node 18+ engine (zero runtime deps). Exports `discoverSkills`, `discoverCommands`, `discoverAgents`, `resolvePluginsDir`, `resolvePluginContentDir`, `isVersionedCacheChild`, `compareSemver`, `parseFrontmatter`, `applyTransforms`, `transformSkillContent`, `injectBridgeSource`, `agentToCodexToml`, `syncOne`, `syncCommand`, `syncAgent`, `syncAll`, `pruneOrphans`, `pruneAgentOrphans`, `tomlHasBridgeSource`, `readTomlBridgeSource`, `loadConfig`, `parseArgs`, `isExcluded`.
 - `codex-bridge.config.json` — default `exclude` glob list + 3 transform rules + text extension whitelist.
 - `skills/codex-sync/SKILL.md` — Claude Code entrypoint (`/codex-bridge:codex-sync`).
 - `tests/*.test.mjs` — `node --test` suite, fixtures in `tests/fixtures/`.
@@ -24,8 +26,9 @@ Commands are not a first-class concept in Codex — they're wrapped as synthetic
 - **Preserve frontmatter verbatim.** Never let transform rules touch content between the `---` fences. This protects the `bridge_source` provenance marker AND the user-authored `name`/`description` fields.
 - **Flatten multi-line YAML block-scalar descriptions (`description: |` / `description: >`) to a single line at sync time.** Codex's skill loader expects single-line descriptions per [official spec](https://developers.openai.com/codex/skills). Block scalars have caused source skills to fail to load into `$skill` selector. Normalization happens in `normalizeFrontmatterDescription`, between body transform and `bridge_source` injection — value preserved, form normalized.
 - **Wrap commands as synthetic skills.** `plugins/*/commands/*.md` are converted via `commandToSkillContent` into `<plugin>-<command>/SKILL.md` files. Claude Code-only frontmatter keys (`allowed-tools`, `argument-hint`, `paths`, `version`) are dropped; only `name`, `description` (flattened), and `bridge_source` remain. Body is preserved and goes through standard transform rules.
-- **Inject `bridge_source: <plugin>/<skill>` into every synced SKILL.md frontmatter.** The marker is the single source for orphan pruning and collision guarding — without it the sync engine cannot tell bridge-owned files from user/external files.
-- **Return `status: 'skipped'` with `reason: 'non-managed-collision'` whenever target SKILL.md exists and lacks `bridge_source`.** Emit a stderr warning naming the file.
+- **Convert subagents to Codex TOML.** `plugins/*/agents/*.md` are converted via `agentToCodexToml` into `<plugin>-<agent>.toml` files at `~/.codex/agents/`. Structure: `# bridge_source = "<plugin>/agents/<agent>"` comment on line 1, optional `# original-model`/`# original-skills`/`# original-tools` comments preserving Claude Code-only fields (Codex's model alias namespace differs — drop the value, keep the trail), then real TOML keys `name`, `description`, `developer_instructions = """..."""`. Body transforms run before TOML wrap; backslashes and `"""` sequences are escaped per TOML basic multi-line string rules (`\` → `\\`, `"""` → `\"""`).
+- **Inject `bridge_source: <plugin>/<skill>` into every synced SKILL.md frontmatter.** The marker is the single source for orphan pruning and collision guarding — without it the sync engine cannot tell bridge-owned files from user/external files. For agent .toml files, the same role is played by the `# bridge_source = "..."` comment.
+- **Return `status: 'skipped'` with `reason: 'non-managed-collision'` whenever target SKILL.md (or agent .toml) exists and lacks the `bridge_source` marker.** Emit a stderr warning naming the file.
 - **Sort `discoverSkills` output deterministically** by `(pluginName, skillName)` before returning. Spec P1 `last-wins` semantics require stable ordering so idempotent re-runs produce identical results.
 - **Write via staging dir inside target root, then `fs.rename`** for atomicity. On `EXDEV`, fall back to `fs.cp({ recursive: true, force: true })` followed by `fs.rm` on the staging dir.
 - **Restrict body transforms to the extension whitelist**: `.md`, `.yml`, `.yaml`, `.json`, `.sh`, `.mjs`, `.js`, `.py`, `.ts`. Other extensions must be copied byte-for-byte.
@@ -37,9 +40,9 @@ Commands are not a first-class concept in Codex — they're wrapped as synthetic
 
 ## Don'ts
 
-- **Never touch `~/.codex/skills/`.** That directory is externally managed. The bridge operates exclusively on `~/.agents/skills/`.
-- **Never delete a SKILL.md that lacks `bridge_source`.** Orphan-prune only considers marker-tagged files; untagged files are treated as external ownership.
-- **Never override the OpenAI-official target path.** `~/.agents/skills/` is fixed per OpenAI Codex Skills docs. `CODEX_HOME` env is for state/log/config base only — it does NOT control skill discovery. `config.target.agentsHome` exists for testing only.
+- **Never touch `~/.codex/skills/`.** That directory is externally managed. The bridge operates exclusively on `~/.agents/skills/` (skills+commands) and `~/.codex/agents/` (subagents).
+- **Never delete a SKILL.md or agent .toml that lacks the `bridge_source` marker.** Orphan-prune only considers marker-tagged files (frontmatter `bridge_source:` for skills, `# bridge_source = "..."` comment for agent .toml); untagged files are treated as external/user ownership.
+- **Never override the OpenAI-official target paths.** `~/.agents/skills/` is fixed per OpenAI Codex Skills docs; `~/.codex/agents/*.toml` is fixed per OpenAI Codex Subagents docs. `CODEX_HOME` env is for state/log/config base only — it does NOT control skill or agent discovery. `config.target.agentsHome` and `config.target.agentsTomlHome` exist for testing only.
 - **Never add runtime dependencies.** Node 18+ built-ins only. The spec mandates zero-deps for portability and reproducibility.
 - **Never apply transforms to frontmatter.** `bodyOnly: true` is a contract, not a default. Transforms (`CLAUDE.md`→`AGENTS.md`, `.claude/`→`.codex/`, namespace regex) must only touch body.
 - **Never use non-atomic writes** that leave target in a partial state if the process dies mid-sync.
@@ -53,11 +56,11 @@ Commands are not a first-class concept in Codex — they're wrapped as synthetic
 - Plugin doc: `plugins/codex-bridge/CLAUDE.md`
 - Entry skill: `plugins/codex-bridge/skills/codex-sync/SKILL.md`
 
-## Out of Scope (V2)
+## Out of Scope
 
 - `agents/openai.yaml` sidecar (eventual migration target for `bridge_source`)
 - File-change hook for auto-sync
-- `Task(subagent_type=...)` → Codex native subagent mapping
+- Codex-compatible mapping for agent `model` / `tools` (currently preserved as `# original-*` comments only — user must wire up manually if desired)
 - Project-level `.agents/skills/` scope
 - Collision-fallback prefix mode
 - npm bin distribution

--- a/plugins/codex-bridge/.claude-plugin/plugin.json
+++ b/plugins/codex-bridge/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "codex-bridge",
-  "version": "1.3.2",
-  "description": "Sync my-claude-plugins skills and commands to Codex ~/.agents/skills/ with body-only transform and bridge_source provenance marker"
+  "version": "1.4.0",
+  "description": "Sync my-claude-plugins skills, commands, and subagents to Codex (~/.agents/skills/ for skills+commands, ~/.codex/agents/*.toml for subagents) with body-only transform and bridge_source provenance marker"
 }

--- a/plugins/codex-bridge/CLAUDE.md
+++ b/plugins/codex-bridge/CLAUDE.md
@@ -1,12 +1,12 @@
 # Codex Bridge Plugin
 
-my-claude-plugins 의 skill 들을 Codex CLI 가 네이티브로 로드하는 `~/.agents/skills/` (OpenAI 공식 USER scope) 로 idempotent 하게 변환·복사한다.
+my-claude-plugins 의 skill / command / subagent 를 Codex CLI 가 네이티브로 로드하는 위치 (`~/.agents/skills/` 와 `~/.codex/agents/` — OpenAI 공식 USER scope) 로 idempotent 하게 변환·복사한다.
 
 ## Skill
 
 | Skill | Description |
 |-------|-------------|
-| `codex-sync` | Sync my-claude-plugins skills and commands to `~/.agents/skills/` |
+| `codex-sync` | Sync my-claude-plugins skills, commands, and subagents to `~/.agents/skills/` (skills+commands) and `~/.codex/agents/*.toml` (subagents) |
 
 ## 원칙
 
@@ -60,10 +60,15 @@ namespace regex 는 lookbehind `(?<![:/.\w])` 가드로 `https://x.io/foo:bar` �
 
 ## 경로 정설
 
-- Target: `$HOME/.agents/skills/<name>/SKILL.md` — OpenAI 공식 USER scope
+- Skill / command target: `$HOME/.agents/skills/<name>/SKILL.md` — OpenAI 공식 USER scope skill
+- Subagent target: `$HOME/.codex/agents/<plugin>-<agent>.toml` — OpenAI 공식 USER scope subagent
+- `bridge_source` provenance marker:
+  - skills/commands: `bridge_source: <plugin>/<skill>` 또는 `<plugin>/commands/<command>` (frontmatter key)
+  - agents: `# bridge_source = "<plugin>/agents/<agent>"` (TOML 첫 줄 주석)
+- 마커 없는 파일은 **절대 건드리지 않음** (사용자가 직접 작성한 skill/agent 보호). prune 도 마커 매칭만.
 - `~/.codex/skills/` (외부 관리) 는 **절대 건드리지 않음**
 - `~/.codex/AGENTS.md` 에는 어떤 콘텐츠도 **주입하지 않음**
-- `CODEX_HOME` env 는 state/log base 일 뿐, skill 디렉토리와 무관
+- `CODEX_HOME` env 는 state/log base 일 뿐, skill / agent 디렉토리와 무관
 
 ## Dependencies
 
@@ -74,4 +79,5 @@ namespace regex 는 lookbehind `(?<![:/.\w])` 가드로 `https://x.io/foo:bar` �
 
 - Spec: `.claude/spec/2026-04-14-codex-bridge-skill-sync.md`
 - OpenAI Codex Skills: https://developers.openai.com/codex/skills
+- OpenAI Codex Subagents: https://developers.openai.com/codex/subagents
 - OpenAI Codex Customization: https://developers.openai.com/codex/concepts/customization

--- a/plugins/codex-bridge/codex-bridge.config.json
+++ b/plugins/codex-bridge/codex-bridge.config.json
@@ -1,8 +1,9 @@
 {
-  "_comment": "Default config for codex-bridge. Override via --config <path>. scope=user → $HOME/.agents/skills (OpenAI USER scope). Set target.agentsHome to override (testing).",
+  "_comment": "Default config for codex-bridge. Override via --config <path>. scope=user → $HOME/.agents/skills for skills/commands and $HOME/.codex/agents for subagent .toml files (OpenAI USER scope). Set target.agentsHome / target.agentsTomlHome to override (testing).",
   "target": {
     "scope": "user",
-    "agentsHome": null
+    "agentsHome": null,
+    "agentsTomlHome": null
   },
   "collisionFallbackPrefix": "bridge-",
   "exclude": [

--- a/plugins/codex-bridge/scripts/sync.mjs
+++ b/plugins/codex-bridge/scripts/sync.mjs
@@ -491,7 +491,11 @@ export async function syncAll(options) {
       }
     }
     if (agentsTomlDir) {
-      if (filteredAgents.length === 0 && allAgents.length === 0) {
+      if (pluginFilter) {
+        const msg = `[codex-bridge] agent prune skipped: --plugin filter is active; rerun with --no-prune or full sync separately.`;
+        logger.warn(msg);
+        report.warnings.push(msg);
+      } else if (filteredAgents.length === 0 && allAgents.length === 0) {
         // No agents discovered at all; mirror the same defensive guard as skills/commands.
         const msg = `[codex-bridge] agent prune skipped: 0 agents discovered. Inspect with --dry-run --verbose.`;
         logger.warn(msg);
@@ -1029,7 +1033,7 @@ export function agentToCodexToml(sourceContent, pluginName, agentName, rules) {
   return lines.join('\n');
 }
 
-const BRIDGE_SOURCE_COMMENT_RE = /^#\s*bridge_source\s*=\s*"([^"]*)"\s*$/m;
+const BRIDGE_SOURCE_COMMENT_RE = /^#\s*bridge_source\s*=\s*"([^"\r\n]*)"\s*(?:\r?\n|$)/;
 
 export function tomlHasBridgeSource(content) {
   return BRIDGE_SOURCE_COMMENT_RE.test(content);
@@ -1064,7 +1068,6 @@ export async function syncAgent(agent, agentsTomlDir, rules, options = {}) {
   const stagingPath = path.join(agentsTomlDir, `.staging-${tomlName}-${process.pid}-${Date.now()}.toml`);
   try {
     await fs.writeFile(stagingPath, tomlContent, 'utf-8');
-    await fs.rm(tomlPath, { force: true });
     await moveOrCopy(stagingPath, tomlPath);
   } catch (err) {
     await fs.rm(stagingPath, { force: true }).catch(() => {});

--- a/plugins/codex-bridge/scripts/sync.mjs
+++ b/plugins/codex-bridge/scripts/sync.mjs
@@ -197,6 +197,7 @@ export const DEFAULT_CONFIG = {
   target: {
     scope: 'user',
     agentsHome: null,
+    agentsTomlHome: null,
   },
   collisionFallbackPrefix: 'bridge-',
   exclude: [],
@@ -323,6 +324,7 @@ export async function syncAll(options) {
   const {
     pluginsDir,
     targetDir,
+    agentsTomlDir = null,
     config,
     dryRun = false,
     pluginFilter = null,
@@ -332,6 +334,7 @@ export async function syncAll(options) {
 
   const allSkills = await discoverSkills(pluginsDir);
   const allCommands = await discoverCommands(pluginsDir);
+  const allAgents = await discoverAgents(pluginsDir);
   const pluginsRoot = path.dirname(pluginsDir);
 
   const warnings = [];
@@ -357,6 +360,14 @@ export async function syncAll(options) {
     return true;
   });
 
+  const filteredAgents = allAgents.filter((ag) => {
+    if (pluginFilter && !pluginFilter.includes(ag.pluginName)) return false;
+    const rel = path.relative(pluginsRoot, ag.sourcePath).split(path.sep).join('/');
+    if (isExcluded(rel, config.exclude)) return false;
+    if (isExcluded(`plugins/${ag.pluginName}/**`, config.exclude)) return false;
+    return true;
+  });
+
   const nameToPlugins = new Map();
   for (const skill of filtered) {
     const bucket = nameToPlugins.get(skill.skillName) ?? [];
@@ -374,15 +385,19 @@ export async function syncAll(options) {
   const report = {
     dryRun,
     targetDir,
+    agentsTomlDir,
     pluginsDir,
     discovered: allSkills.length,
     discoveredCommands: allCommands.length,
+    discoveredAgents: allAgents.length,
     considered: filtered.length,
     consideredCommands: filteredCommands.length,
+    consideredAgents: filteredAgents.length,
     collisions,
     synced: [],
     skipped: [],
     removed: [],
+    removedAgents: [],
     errors: [],
     warnings,
   };
@@ -436,6 +451,33 @@ export async function syncAll(options) {
     }
   }
 
+  const validAgentSources = new Set();
+  for (const ag of filteredAgents) {
+    const marker = `${ag.pluginName}/agents/${ag.agentName}`;
+    validAgentSources.add(marker);
+
+    if (!agentsTomlDir) continue;
+
+    if (dryRun) {
+      logger.info(`[dry-run] would sync agent ${marker} → ${ag.targetTomlName}.toml`);
+      report.synced.push({ status: 'dry-run', bridgeSource: marker, tomlName: ag.targetTomlName });
+      continue;
+    }
+
+    try {
+      const result = await syncAgent(ag, agentsTomlDir, config.transform.rules, { logger });
+      if (result.status === 'synced') {
+        logger.info(`[codex-bridge] synced agent ${marker} → ${result.path}`);
+        report.synced.push(result);
+      } else {
+        report.skipped.push({ ...result, tomlName: ag.targetTomlName, bridgeSource: marker });
+      }
+    } catch (err) {
+      logger.warn(`[codex-bridge] error syncing ${marker}: ${err.message}`);
+      report.errors.push({ tomlName: ag.targetTomlName, bridgeSource: marker, error: err.message });
+    }
+  }
+
   if (prune && !dryRun) {
     if (validSources.size === 0) {
       const msg = `[codex-bridge] prune skipped: 0 valid sources discovered (likely pluginsDir misresolution or over-restrictive --plugin filter). Inspect with --dry-run --verbose.`;
@@ -446,6 +488,20 @@ export async function syncAll(options) {
       report.removed = pruneResult.removed;
       for (const r of pruneResult.removed) {
         logger.info(`[codex-bridge] pruned orphan ${r.skillName} (was ${r.bridgeSource})`);
+      }
+    }
+    if (agentsTomlDir) {
+      if (filteredAgents.length === 0 && allAgents.length === 0) {
+        // No agents discovered at all; mirror the same defensive guard as skills/commands.
+        const msg = `[codex-bridge] agent prune skipped: 0 agents discovered. Inspect with --dry-run --verbose.`;
+        logger.warn(msg);
+        report.warnings.push(msg);
+      } else {
+        const agentPruneResult = await pruneAgentOrphans(agentsTomlDir, validAgentSources);
+        report.removedAgents = agentPruneResult.removed;
+        for (const r of agentPruneResult.removed) {
+          logger.info(`[codex-bridge] pruned orphan agent ${r.tomlName} (was ${r.bridgeSource})`);
+        }
       }
     }
   } else if (prune && dryRun) {
@@ -463,6 +519,23 @@ export async function syncAll(options) {
           logger.info(`[dry-run] would prune ${entry.name} (orphan ${parsed.fields.bridge_source})`);
         }
       } catch { /* skip */ }
+    }
+    if (agentsTomlDir) {
+      const tomlEntries = await fs.readdir(agentsTomlDir, { withFileTypes: true }).catch((err) => {
+        if (err.code === 'ENOENT') return [];
+        throw err;
+      });
+      for (const entry of tomlEntries) {
+        if (!entry.isFile() || !entry.name.endsWith('.toml') || entry.name.startsWith('.staging-')) continue;
+        try {
+          const content = await fs.readFile(path.join(agentsTomlDir, entry.name), 'utf-8');
+          const marker = readTomlBridgeSource(content);
+          if (marker && !validAgentSources.has(marker)) {
+            report.removedAgents.push({ tomlName: entry.name, bridgeSource: marker, dryRun: true });
+            logger.info(`[dry-run] would prune agent ${entry.name} (orphan ${marker})`);
+          }
+        } catch { /* skip */ }
+      }
     }
   }
 
@@ -527,12 +600,15 @@ export async function main(argv) {
 
   const targetDir = config.target.agentsHome
     ?? path.join(os.homedir(), '.agents', 'skills');
+  const agentsTomlDir = config.target.agentsTomlHome
+    ?? path.join(os.homedir(), '.codex', 'agents');
 
   const logger = args.verbose ? defaultLogger() : quietLogger();
 
   const report = await syncAll({
     pluginsDir,
     targetDir,
+    agentsTomlDir,
     config,
     dryRun: args.dryRun,
     pluginFilter: args.plugins,
@@ -543,7 +619,7 @@ export async function main(argv) {
   if (args.verbose) {
     const pluginEntries = await fs.readdir(pluginsDir, { withFileTypes: true }).catch(() => []);
     const pluginCount = pluginEntries.filter(e => e.isDirectory()).length;
-    process.stderr.write(`[codex-bridge] discovered ${pluginCount} plugins, ${report.discovered} skills, ${report.discoveredCommands ?? 0} commands\n`);
+    process.stderr.write(`[codex-bridge] discovered ${pluginCount} plugins, ${report.discovered} skills, ${report.discoveredCommands ?? 0} commands, ${report.discoveredAgents ?? 0} agents\n`);
   }
 
   if (args.reportPath) {
@@ -563,10 +639,14 @@ function quietLogger() {
 function printSummary(report) {
   const lines = [
     `[codex-bridge] target: ${report.targetDir}`,
-    `  skills: discovered ${report.discovered}, considered ${report.considered}`,
-    `  commands: discovered ${report.discoveredCommands ?? 0}, considered ${report.consideredCommands ?? 0}`,
-    `  synced: ${report.synced.length}, skipped: ${report.skipped.length}, removed: ${report.removed.length}, errors: ${report.errors.length}`,
   ];
+  if (report.agentsTomlDir) {
+    lines.push(`[codex-bridge] agents toml target: ${report.agentsTomlDir}`);
+  }
+  lines.push(`  skills: discovered ${report.discovered}, considered ${report.considered}`);
+  lines.push(`  commands: discovered ${report.discoveredCommands ?? 0}, considered ${report.consideredCommands ?? 0}`);
+  lines.push(`  agents: discovered ${report.discoveredAgents ?? 0}, considered ${report.consideredAgents ?? 0}`);
+  lines.push(`  synced: ${report.synced.length}, skipped: ${report.skipped.length}, removed: ${report.removed.length}, removedAgents: ${report.removedAgents?.length ?? 0}, errors: ${report.errors.length}`);
   process.stderr.write(`${lines.join('\n')}\n`);
 }
 
@@ -852,6 +932,187 @@ export async function discoverCommands(pluginsDir) {
   });
 
   return results;
+}
+
+export async function discoverAgents(pluginsDir) {
+  const results = [];
+
+  let pluginEntries;
+  try {
+    pluginEntries = await fs.readdir(pluginsDir, { withFileTypes: true });
+  } catch (err) {
+    if (err.code === 'ENOENT') return results;
+    throw err;
+  }
+
+  for (const entry of pluginEntries) {
+    if (!entry.isDirectory()) continue;
+    const contentRoot = await resolvePluginContentDir(path.join(pluginsDir, entry.name));
+    if (!contentRoot) continue;
+    const agentsDir = path.join(contentRoot, 'agents');
+    let files;
+    try {
+      files = await fs.readdir(agentsDir, { withFileTypes: true });
+    } catch (err) {
+      if (err.code === 'ENOENT') continue;
+      throw err;
+    }
+    for (const f of files) {
+      if (!f.isFile() || !f.name.endsWith('.md')) continue;
+      const agentName = f.name.slice(0, -3);
+      results.push({
+        pluginName: entry.name,
+        agentName,
+        sourcePath: path.join(agentsDir, f.name),
+        targetTomlName: `${entry.name}-${agentName}`,
+      });
+    }
+  }
+
+  results.sort((a, b) => {
+    if (a.pluginName !== b.pluginName) return a.pluginName < b.pluginName ? -1 : 1;
+    if (a.agentName !== b.agentName) return a.agentName < b.agentName ? -1 : 1;
+    return 0;
+  });
+
+  return results;
+}
+
+function tomlBasicQuote(text) {
+  return `"${String(text).replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}
+
+function escapeTomlMultilineBody(body) {
+  // TOML basic multi-line strings (""" ... """):
+  // - backslashes must be doubled (\\)
+  // - any literal """ would terminate the string; emit \""" to get a literal triple-quote
+  const withDoubledBackslashes = body.replace(/\\/g, '\\\\');
+  return withDoubledBackslashes.replace(/"""/g, '\\"""');
+}
+
+export function agentToCodexToml(sourceContent, pluginName, agentName, rules) {
+  const fmMatch = FRONTMATTER_RE.exec(sourceContent);
+  let parsed = null;
+  let body = sourceContent;
+
+  if (fmMatch) {
+    parsed = parseFrontmatter(sourceContent);
+    if (parsed) body = parsed.body;
+  }
+
+  const description = parsed && parsed.description
+    ? flattenDescription(parsed.description)
+    : `${agentName} agent from ${pluginName} plugin.`;
+
+  const targetName = `${pluginName}-${agentName}`;
+  const marker = `${pluginName}/agents/${agentName}`;
+
+  const transformedBody = applyTransforms(body, rules);
+  const escaped = escapeTomlMultilineBody(transformedBody);
+  // Strip a single leading newline from body (keeps things tidy; the TOML
+  // multi-line opener swallows the immediate newline after """ anyway).
+  const trimmedBody = escaped.startsWith('\n') ? escaped.slice(1) : escaped;
+
+  const lines = [`# bridge_source = ${tomlBasicQuote(marker)}`];
+  if (parsed && parsed.fields) {
+    if (parsed.fields.model) lines.push(`# original-model = ${tomlBasicQuote(parsed.fields.model)}`);
+    if (parsed.fields.skills) lines.push(`# original-skills = ${tomlBasicQuote(parsed.fields.skills)}`);
+    if (parsed.fields.tools) lines.push(`# original-tools = ${tomlBasicQuote(parsed.fields.tools)}`);
+  }
+  lines.push(`name = ${tomlBasicQuote(targetName)}`);
+  lines.push(`description = ${tomlBasicQuote(description)}`);
+  lines.push('developer_instructions = """');
+  lines.push(trimmedBody.replace(/\n+$/, ''));
+  lines.push('"""');
+  lines.push('');
+
+  return lines.join('\n');
+}
+
+const BRIDGE_SOURCE_COMMENT_RE = /^#\s*bridge_source\s*=\s*"([^"]*)"\s*$/m;
+
+export function tomlHasBridgeSource(content) {
+  return BRIDGE_SOURCE_COMMENT_RE.test(content);
+}
+
+export function readTomlBridgeSource(content) {
+  const m = BRIDGE_SOURCE_COMMENT_RE.exec(content);
+  return m ? m[1] : null;
+}
+
+export async function syncAgent(agent, agentsTomlDir, rules, options = {}) {
+  const logger = options.logger ?? defaultLogger();
+  const sourceContent = await fs.readFile(agent.sourcePath, 'utf-8');
+
+  const tomlName = agent.targetTomlName ?? `${agent.pluginName}-${agent.agentName}`;
+  const tomlPath = path.join(agentsTomlDir, `${tomlName}.toml`);
+  const marker = `${agent.pluginName}/agents/${agent.agentName}`;
+
+  try {
+    const existing = await fs.readFile(tomlPath, 'utf-8');
+    if (!tomlHasBridgeSource(existing)) {
+      logger.warn(`[codex-bridge] skip ${tomlPath}: not managed by codex-bridge (missing # bridge_source marker).`);
+      return { status: 'skipped', reason: 'non-managed-collision' };
+    }
+  } catch (err) {
+    if (err.code !== 'ENOENT') throw err;
+  }
+
+  const tomlContent = agentToCodexToml(sourceContent, agent.pluginName, agent.agentName, rules);
+
+  await fs.mkdir(agentsTomlDir, { recursive: true });
+  const stagingPath = path.join(agentsTomlDir, `.staging-${tomlName}-${process.pid}-${Date.now()}.toml`);
+  try {
+    await fs.writeFile(stagingPath, tomlContent, 'utf-8');
+    await fs.rm(tomlPath, { force: true });
+    await moveOrCopy(stagingPath, tomlPath);
+  } catch (err) {
+    await fs.rm(stagingPath, { force: true }).catch(() => {});
+    throw err;
+  }
+
+  return { status: 'synced', path: tomlPath, bridgeSource: marker };
+}
+
+export async function pruneAgentOrphans(agentsTomlDir, validAgentSources) {
+  const report = { removed: [], preserved: [] };
+
+  let entries;
+  try {
+    entries = await fs.readdir(agentsTomlDir, { withFileTypes: true });
+  } catch (err) {
+    if (err.code === 'ENOENT') return report;
+    throw err;
+  }
+
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith('.toml')) continue;
+    if (entry.name.startsWith('.staging-')) continue;
+
+    const fullPath = path.join(agentsTomlDir, entry.name);
+    let content;
+    try {
+      content = await fs.readFile(fullPath, 'utf-8');
+    } catch (err) {
+      if (err.code === 'ENOENT') continue;
+      throw err;
+    }
+
+    const marker = readTomlBridgeSource(content);
+    if (!marker) {
+      report.preserved.push({ tomlName: entry.name, reason: 'no-bridge-source' });
+      continue;
+    }
+
+    if (validAgentSources.has(marker)) {
+      report.preserved.push({ tomlName: entry.name, reason: 'valid', bridgeSource: marker });
+    } else {
+      await fs.rm(fullPath, { force: true });
+      report.removed.push({ tomlName: entry.name, bridgeSource: marker });
+    }
+  }
+
+  return report;
 }
 
 export function commandToSkillContent(sourceContent, pluginName, commandName) {

--- a/plugins/codex-bridge/skills/codex-sync/SKILL.md
+++ b/plugins/codex-bridge/skills/codex-sync/SKILL.md
@@ -1,14 +1,15 @@
 ---
 name: codex-sync
-description: "Use when syncing my-claude-plugins skills and commands to Codex (~/.agents/skills/) so they become callable as native $skill-name in independent Codex CLI sessions. Triggers: 'codex sync', 'sync skills to codex', '/codex-bridge:codex-sync', or after adding/modifying plugin skills that should also be available in Codex. Body-only transform with bridge_source provenance marker. Idempotent."
+description: "Use when syncing my-claude-plugins skills, commands, and subagents to Codex (~/.agents/skills/ for skills+commands, ~/.codex/agents/*.toml for subagents) so they become callable as native $skill-name / subagent in independent Codex CLI sessions. Triggers: 'codex sync', 'sync skills to codex', '/codex-bridge:codex-sync', or after adding/modifying plugin skills/commands/agents that should also be available in Codex. Body-only transform with bridge_source provenance marker. Idempotent."
 tools: Bash, Read, Glob, Edit, Write
 ---
 
 # codex-sync
 
-my-claude-plugins 의 skill (`plugins/*/skills/**/SKILL.md`) 과 command (`plugins/*/commands/*.md`) 을 Codex 로 이관한다.
+my-claude-plugins 의 skill (`plugins/*/skills/**/SKILL.md`), command (`plugins/*/commands/*.md`), subagent (`plugins/*/agents/*.md`) 을 Codex 로 이관한다.
 
 - Skills + commands → `~/.agents/skills/` (Codex USER scope, 네이티브 `$skill-name` 호출 가능). Commands 는 `<plugin>-<command>` 네임스페이스로 wrap.
+- Subagents → `~/.codex/agents/<plugin>-<agent>.toml` (Codex USER scope subagent). Markdown frontmatter 를 TOML 로 변환, body 는 `developer_instructions` triple-quoted 멀티라인 문자열로 wrap.
 
 ## 언제 쓰나
 
@@ -78,9 +79,51 @@ Exit codes: `0` 성공 · `1` 부분 실패 · `2` 치명적 (config 파싱 실�
 
 **Text-only** 확장자 화이트리스트에 맞는 파일만 치환: `.md`, `.yml`, `.yaml`, `.json`, `.sh`, `.mjs`, `.js`, `.py`, `.ts`. 이 외 (이미지, 바이너리) 는 그대로 복사.
 
-**frontmatter 면제**: `---` 구분자 사이는 불변. `bridge_source` 마커 보호, skill 이름/description 오염 방지.
+**frontmatter 면제** (skills/commands): `---` 구분자 사이는 불변. `bridge_source` 마커 보호, skill 이름/description 오염 방지.
+
+**agent body transform** (TOML 변환): Claude Code agent `.md` body 는 위 3개 rule 적용 후 TOML 의 `developer_instructions = """..."""` 안에 들어간다. backslash 와 `"""` 시퀀스는 TOML basic multi-line string 규칙대로 escape (`\` → `\\`, `"""` → `\"""`).
 
 namespace regex 는 lookbehind `(?<![:/.\w])` 가드로 `https://x.io/foo:bar` 같은 URL 표기 (직전 문자가 단어 문자) 를 false positive 에서 제외한다.
+
+## Subagent sync
+
+Claude Code subagent (`plugins/*/agents/*.md`) 는 OpenAI Codex subagent TOML 포맷으로 변환되어 `~/.codex/agents/<plugin>-<agent>.toml` 로 저장된다.
+
+### 변환 규칙
+
+| Claude Code agent FM | Codex TOML |
+|---------------------|-----------|
+| `name` | `name = "<plugin>-<agent>"` (collision-prefixed) |
+| `description` (multi-line/block scalar 포함) | `description = "<single-line>"` (flatten + TOML escape) |
+| body (`---` 이후) | `developer_instructions = """<transformed body>"""` |
+| `model` | `# original-model = "<value>"` (drop, 주석 보존) |
+| `tools` | `# original-tools = "<value>"` (drop, 주석 보존) |
+| `skills` | `# original-skills = "<value>"` (drop, 주석 보존) |
+| (없음) | `# bridge_source = "<plugin>/agents/<agent>"` (provenance marker) |
+
+### 왜 model 을 drop 하나?
+
+Claude Code 의 `model: haiku|sonnet|opus` alias 는 Codex 의 model identifier (e.g. `gpt-4o`, `o1-mini`) 와 매칭되지 않는다. 무조건 적용하면 Codex 에서 unknown-model 에러가 나거나 의도치 않은 fallback. 보존만 하고 활성화는 사용자 책임 (`# original-model` 주석 보고 필요시 직접 추가).
+
+### TOML 출력 예시
+
+```toml
+# bridge_source = "code-scout/agents/scout"
+# original-model = "haiku"
+# original-skills = "resource-finder"
+name = "code-scout-scout"
+description = "Code and ML resource scout. Finds boilerplates, starter templates, ..."
+developer_instructions = """
+# Scout Agent
+
+A lightweight agent for finding code resources and ML assets quickly.
+...
+"""
+```
+
+### Safety
+
+`~/.codex/agents/*.toml` 중 `# bridge_source = "..."` 주석이 **없는** 파일은 절대 건드리지 않는다 (사용자가 직접 작성한 subagent 보호). 마커 있고 원본 사라진 .toml 만 prune 대상.
 
 ## 실행 방법
 
@@ -129,8 +172,10 @@ Windows 경로도 지원 (Node `path.resolve` 가 OS 별 separator 정규화).
 실행 후:
 
 1. 각 synced SKILL.md frontmatter 에 `bridge_source: <plugin>/<skill>` 존재 확인
-2. body 에서 `CLAUDE.md` / `.claude/` / `/<plugin>:<skill>` 등이 변환되었는지 spot check
-3. `~/.codex/skills/` (외부 관리) 가 **침범되지 않았음** 확인
+2. 각 synced `~/.codex/agents/<name>.toml` 첫 줄에 `# bridge_source = "<plugin>/agents/<name>"` 주석 존재 확인
+3. body 에서 `CLAUDE.md` / `.claude/` / `/<plugin>:<skill>` 등이 변환되었는지 spot check
+4. `~/.codex/skills/` (외부 관리) 가 **침범되지 않았음** 확인
+5. `~/.codex/agents/` 에 사용자가 직접 작성한 `.toml` 이 있다면 (`# bridge_source` 주석 없는 것) 그대로 보존되었는지 확인
 
 ## 충돌 처리
 
@@ -138,16 +183,17 @@ Windows 경로도 지원 (Node `path.resolve` 가 OS 별 separator 정규화).
 - 마커 있음 → overwrite (codex-bridge-managed 이므로 안전)
 - 다른 plugin 에서 동일 이름 → last-wins (경고)
 
-## Out of Scope (V1)
+## Out of Scope
 
-V2 에서 예정:
-- `Task(subagent_type=...)` → Codex native subagent 매핑
+추후 작업:
 - 파일 변경 hook 으로 auto-sync
 - Project-level `.agents/skills/` 타깃
 - Collision-fallback 프리픽스 자동 부여
+- agent `model` / `tools` 의 Codex 호환 매핑 (현재 `# original-*` 주석으로만 보존)
 
 ## 참조
 
 - Spec: `.claude/spec/2026-04-14-codex-bridge-skill-sync.md`
 - OpenAI Codex Skills: https://developers.openai.com/codex/skills
+- OpenAI Codex Subagents: https://developers.openai.com/codex/subagents
 - OpenAI Codex Customization: https://developers.openai.com/codex/concepts/customization

--- a/plugins/codex-bridge/tests/discovery.test.mjs
+++ b/plugins/codex-bridge/tests/discovery.test.mjs
@@ -5,7 +5,7 @@ import path from 'node:path';
 import os from 'node:os';
 import { fileURLToPath } from 'node:url';
 
-import { discoverSkills, discoverCommands, parseFrontmatter, resolvePluginContentDir, compareSemver } from '../scripts/sync.mjs';
+import { discoverSkills, discoverCommands, discoverAgents, parseFrontmatter, resolvePluginContentDir, compareSemver } from '../scripts/sync.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const FIXTURES = path.join(__dirname, 'fixtures');
@@ -282,6 +282,110 @@ test('discoverCommands: handles versioned cache layout, picks latest version per
     );
   } finally {
     await fs.rm(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('discoverAgents: finds agents/*.md files at every plugin', async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-bridge-agents-'));
+  try {
+    const mk = async (plugin, agent) => {
+      const dir = path.join(tmp, 'plugins', plugin, 'agents');
+      await fs.mkdir(dir, { recursive: true });
+      await fs.writeFile(path.join(dir, `${agent}.md`), `---\nname: ${agent}\ndescription: x\n---\nbody`);
+    };
+    await mk('alpha', 'a-agent');
+    await mk('alpha', 'b-agent');
+    await mk('beta', 'c-agent');
+
+    const agents = await discoverAgents(path.join(tmp, 'plugins'));
+    assert.equal(agents.length, 3);
+    const keys = agents.map(a => `${a.pluginName}/${a.agentName}`);
+    assert.deepEqual(keys, ['alpha/a-agent', 'alpha/b-agent', 'beta/c-agent']);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test('discoverAgents: targetTomlName is <plugin>-<agent>', async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-bridge-agents-'));
+  try {
+    const dir = path.join(tmp, 'plugins', 'code-scout', 'agents');
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(path.join(dir, 'scout.md'), '---\nname: scout\ndescription: x\n---\nbody');
+
+    const agents = await discoverAgents(path.join(tmp, 'plugins'));
+    assert.equal(agents.length, 1);
+    assert.equal(agents[0].targetTomlName, 'code-scout-scout');
+    assert.equal(
+      path.normalize(agents[0].sourcePath),
+      path.join(dir, 'scout.md')
+    );
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test('discoverAgents: ignores non-md files in agents/', async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-bridge-agents-'));
+  try {
+    const dir = path.join(tmp, 'plugins', 'p', 'agents');
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(path.join(dir, 'real.md'), '---\nname: real\n---\n');
+    await fs.writeFile(path.join(dir, 'README.txt'), 'not an agent');
+    await fs.writeFile(path.join(dir, 'script.sh'), '#!/bin/sh\n');
+
+    const agents = await discoverAgents(path.join(tmp, 'plugins'));
+    assert.equal(agents.length, 1);
+    assert.equal(agents[0].agentName, 'real');
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test('discoverAgents: returns [] when plugins dir missing', async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-bridge-agents-'));
+  try {
+    const agents = await discoverAgents(path.join(tmp, 'nope'));
+    assert.deepEqual(agents, []);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test('discoverAgents: returns [] when no plugin has agents/', async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-bridge-agents-'));
+  try {
+    await fs.mkdir(path.join(tmp, 'plugins', 'p', 'skills'), { recursive: true });
+    const agents = await discoverAgents(path.join(tmp, 'plugins'));
+    assert.deepEqual(agents, []);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test('discoverAgents: handles versioned cache layout, picks latest version per plugin', async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-bridge-agents-'));
+  try {
+    const cacheRoot = path.join(tmp, 'my-claude-plugins');
+    const writeAgent = async (plugin, version, name, body = '# agent') => {
+      const dir = path.join(cacheRoot, plugin, version, 'agents');
+      await fs.mkdir(path.join(cacheRoot, plugin, version, '.claude-plugin'), { recursive: true });
+      await fs.mkdir(dir, { recursive: true });
+      await fs.writeFile(path.join(dir, `${name}.md`), `---\nname: ${name}\ndescription: x\n---\n${body}`);
+    };
+    await writeAgent('code-scout', '1.0.0', 'scout', 'old');
+    await writeAgent('code-scout', '1.1.0', 'scout', 'latest');
+
+    const agents = await discoverAgents(cacheRoot);
+    assert.equal(agents.length, 1);
+    assert.equal(agents[0].pluginName, 'code-scout');
+    assert.equal(agents[0].agentName, 'scout');
+    assert.equal(
+      path.normalize(agents[0].sourcePath),
+      path.join(cacheRoot, 'code-scout', '1.1.0', 'agents', 'scout.md')
+    );
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
   }
 });
 

--- a/plugins/codex-bridge/tests/prune.test.mjs
+++ b/plugins/codex-bridge/tests/prune.test.mjs
@@ -4,7 +4,7 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import os from 'node:os';
 
-import { pruneOrphans } from '../scripts/sync.mjs';
+import { pruneOrphans, pruneAgentOrphans } from '../scripts/sync.mjs';
 
 async function freshTmp() {
   return fs.mkdtemp(path.join(os.tmpdir(), 'codex-bridge-prune-'));
@@ -106,3 +106,120 @@ async function fileExists(p) {
     return false;
   }
 }
+
+async function mkAgentToml(root, name, content) {
+  await fs.mkdir(root, { recursive: true });
+  await fs.writeFile(path.join(root, `${name}.toml`), content);
+}
+
+test('pruneAgentOrphans: keeps .toml with valid bridge_source comment', async () => {
+  const tmp = await freshTmp();
+  try {
+    const target = path.join(tmp, 'agents');
+    await mkAgentToml(target, 'plg-keep',
+      '# bridge_source = "plg/agents/keep"\nname = "plg-keep"\ndescription = "x"\ndeveloper_instructions = """body"""\n');
+
+    const report = await pruneAgentOrphans(target, new Set(['plg/agents/keep']));
+    assert.deepEqual(report.removed, []);
+    assert.ok(await fileExists(path.join(target, 'plg-keep.toml')));
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test('pruneAgentOrphans: removes .toml when bridge_source source is gone', async () => {
+  const tmp = await freshTmp();
+  try {
+    const target = path.join(tmp, 'agents');
+    await mkAgentToml(target, 'plg-gone',
+      '# bridge_source = "plg/agents/gone"\nname = "plg-gone"\n');
+
+    const report = await pruneAgentOrphans(target, new Set(['plg/agents/other']));
+    assert.equal(report.removed.length, 1);
+    assert.equal(report.removed[0].tomlName, 'plg-gone.toml');
+    assert.equal(await fileExists(path.join(target, 'plg-gone.toml')), false);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test('pruneAgentOrphans: NEVER touches .toml without bridge_source comment (safety)', async () => {
+  const tmp = await freshTmp();
+  try {
+    const target = path.join(tmp, 'agents');
+    await mkAgentToml(target, 'user-owned',
+      'name = "user-owned"\ndescription = "user wrote this"\ndeveloper_instructions = """body"""\n');
+
+    const report = await pruneAgentOrphans(target, new Set());
+    assert.deepEqual(report.removed, []);
+    assert.ok(await fileExists(path.join(target, 'user-owned.toml')));
+    assert.equal(report.preserved.length, 1);
+    assert.equal(report.preserved[0].reason, 'no-bridge-source');
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test('pruneAgentOrphans: mixed scenario — keeps valid, removes orphan, preserves unmanaged', async () => {
+  const tmp = await freshTmp();
+  try {
+    const target = path.join(tmp, 'agents');
+    await mkAgentToml(target, 'managed-valid',
+      '# bridge_source = "plg/agents/valid"\nname = "managed-valid"\n');
+    await mkAgentToml(target, 'managed-orphan',
+      '# bridge_source = "plg/agents/dead"\nname = "managed-orphan"\n');
+    await mkAgentToml(target, 'user-owned',
+      'name = "user-owned"\ndescription = "x"\n');
+
+    const report = await pruneAgentOrphans(target, new Set(['plg/agents/valid']));
+
+    assert.equal(report.removed.length, 1);
+    assert.equal(report.removed[0].tomlName, 'managed-orphan.toml');
+    assert.ok(await fileExists(path.join(target, 'managed-valid.toml')));
+    assert.ok(await fileExists(path.join(target, 'user-owned.toml')));
+    assert.equal(await fileExists(path.join(target, 'managed-orphan.toml')), false);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test('pruneAgentOrphans: handles missing target directory gracefully', async () => {
+  const tmp = await freshTmp();
+  try {
+    const report = await pruneAgentOrphans(path.join(tmp, 'never-created'), new Set());
+    assert.deepEqual(report.removed, []);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test('pruneAgentOrphans: ignores .staging-* files', async () => {
+  const tmp = await freshTmp();
+  try {
+    const target = path.join(tmp, 'agents');
+    await fs.mkdir(target, { recursive: true });
+    await fs.writeFile(path.join(target, '.staging-plg-x-12345.toml'),
+      '# bridge_source = "plg/agents/x"\nname = "plg-x"\n');
+
+    const report = await pruneAgentOrphans(target, new Set());
+    assert.deepEqual(report.removed, []);
+    assert.ok(await fileExists(path.join(target, '.staging-plg-x-12345.toml')));
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test('pruneAgentOrphans: ignores non-.toml files', async () => {
+  const tmp = await freshTmp();
+  try {
+    const target = path.join(tmp, 'agents');
+    await fs.mkdir(target, { recursive: true });
+    await fs.writeFile(path.join(target, 'README.md'), '# notes');
+
+    const report = await pruneAgentOrphans(target, new Set());
+    assert.deepEqual(report.removed, []);
+    assert.ok(await fileExists(path.join(target, 'README.md')));
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});

--- a/plugins/codex-bridge/tests/sync.test.mjs
+++ b/plugins/codex-bridge/tests/sync.test.mjs
@@ -7,6 +7,7 @@ import os from 'node:os';
 import {
   syncOne,
   syncAll,
+  syncAgent,
   injectBridgeSource,
   DEFAULT_RULES,
   DEFAULT_CONFIG,
@@ -385,6 +386,189 @@ test('syncAll: prune still runs normally when validSources non-empty', async () 
     assert.equal(report.removed[0].skillName, 'orphan-skill');
     // Orphan dir is gone
     await assert.rejects(fs.access(orphan));
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+async function makeAgentFile(root, plugin, agent, content) {
+  const dir = path.join(root, 'plugins', plugin, 'agents');
+  await fs.mkdir(dir, { recursive: true });
+  const filePath = path.join(dir, `${agent}.md`);
+  await fs.writeFile(filePath, content);
+  return { pluginName: plugin, agentName: agent, sourcePath: filePath, targetTomlName: `${plugin}-${agent}` };
+}
+
+test('syncAgent: writes <plugin>-<agent>.toml with bridge_source comment marker', async () => {
+  const tmp = await freshTmp();
+  try {
+    const agent = await makeAgentFile(
+      tmp, 'code-scout', 'scout',
+      [
+        '---',
+        'name: scout',
+        'description: |',
+        '  Code and ML resource scout. Finds boilerplates.',
+        'model: haiku',
+        '---',
+        '# Scout Agent',
+        'use CLAUDE.md and .claude/ paths',
+      ].join('\n')
+    );
+    const targetDir = path.join(tmp, 'target', '.codex', 'agents');
+
+    const result = await syncAgent(agent, targetDir, DEFAULT_RULES);
+
+    assert.equal(result.status, 'synced');
+    const tomlPath = path.join(targetDir, 'code-scout-scout.toml');
+    const written = await fs.readFile(tomlPath, 'utf-8');
+    // bridge_source comment as first line
+    assert.match(written, /^# bridge_source = "code-scout\/agents\/scout"/m);
+    // model preserved as comment
+    assert.match(written, /^# original-model = "haiku"$/m);
+    // canonical TOML fields
+    assert.match(written, /^name = "code-scout-scout"$/m);
+    assert.match(written, /^description = "Code and ML resource scout\. Finds boilerplates\."$/m);
+    assert.match(written, /^developer_instructions = """$/m);
+    // body transformed
+    assert.match(written, /AGENTS\.md/);
+    assert.match(written, /\.codex\//);
+    assert.doesNotMatch(written, /CLAUDE\.md/);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test('syncAgent: idempotent — running twice produces identical output', async () => {
+  const tmp = await freshTmp();
+  try {
+    const agent = await makeAgentFile(
+      tmp, 'p', 'a',
+      '---\nname: a\ndescription: x\n---\nbody\n'
+    );
+    const targetDir = path.join(tmp, 'target', '.codex', 'agents');
+
+    await syncAgent(agent, targetDir, DEFAULT_RULES);
+    const after1 = await fs.readFile(path.join(targetDir, 'p-a.toml'), 'utf-8');
+    await syncAgent(agent, targetDir, DEFAULT_RULES);
+    const after2 = await fs.readFile(path.join(targetDir, 'p-a.toml'), 'utf-8');
+    assert.equal(after1, after2);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test('syncAgent: skipped when target .toml exists without bridge_source marker (safety guard)', async () => {
+  const tmp = await freshTmp();
+  try {
+    const agent = await makeAgentFile(
+      tmp, 'p', 'a',
+      '---\nname: a\ndescription: bridge version\n---\nbridge body'
+    );
+    const targetDir = path.join(tmp, 'target', '.codex', 'agents');
+    await fs.mkdir(targetDir, { recursive: true });
+    const tomlPath = path.join(targetDir, 'p-a.toml');
+    await fs.writeFile(
+      tomlPath,
+      'name = "p-a"\ndescription = "external user-managed"\ndeveloper_instructions = "..."\n'
+    );
+
+    const result = await syncAgent(agent, targetDir, DEFAULT_RULES);
+
+    assert.equal(result.status, 'skipped');
+    assert.equal(result.reason, 'non-managed-collision');
+    const still = await fs.readFile(tomlPath, 'utf-8');
+    assert.match(still, /external user-managed/);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test('syncAgent: overwrites when target .toml has bridge_source marker', async () => {
+  const tmp = await freshTmp();
+  try {
+    const agent = await makeAgentFile(
+      tmp, 'p', 'a',
+      '---\nname: a\ndescription: v2\n---\nnew body\n'
+    );
+    const targetDir = path.join(tmp, 'target', '.codex', 'agents');
+    await fs.mkdir(targetDir, { recursive: true });
+    const tomlPath = path.join(targetDir, 'p-a.toml');
+    await fs.writeFile(
+      tomlPath,
+      '# bridge_source = "p/agents/a"\nname = "p-a"\ndescription = "v1"\ndeveloper_instructions = """\nold body\n"""\n'
+    );
+
+    const result = await syncAgent(agent, targetDir, DEFAULT_RULES);
+    assert.equal(result.status, 'synced');
+    const written = await fs.readFile(tomlPath, 'utf-8');
+    assert.match(written, /description = "v2"/);
+    assert.match(written, /new body/);
+    assert.doesNotMatch(written, /old body/);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test('syncAgent: creates target directory when missing', async () => {
+  const tmp = await freshTmp();
+  try {
+    const agent = await makeAgentFile(tmp, 'p', 'a', '---\nname: a\ndescription: x\n---\nbody');
+    const targetDir = path.join(tmp, 'never', 'created', 'agents');
+
+    const result = await syncAgent(agent, targetDir, DEFAULT_RULES);
+    assert.equal(result.status, 'synced');
+    await fs.access(path.join(targetDir, 'p-a.toml'));
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test('syncAgent: leaves no .staging-* file behind on success', async () => {
+  const tmp = await freshTmp();
+  try {
+    const agent = await makeAgentFile(tmp, 'p', 'a', '---\nname: a\ndescription: x\n---\nbody');
+    const targetDir = path.join(tmp, 'target', '.codex', 'agents');
+
+    await syncAgent(agent, targetDir, DEFAULT_RULES);
+    const entries = await fs.readdir(targetDir);
+    const staging = entries.filter(e => e.includes('.staging-'));
+    assert.deepEqual(staging, []);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test('syncAll: discovers and syncs agents alongside skills/commands', async () => {
+  const tmp = await freshTmp();
+  try {
+    // one of each kind
+    await makeSourceSkill(tmp, 'plg', 'sk', '---\nname: sk\ndescription: x\n---\nskill body');
+    const cmdDir = path.join(tmp, 'plugins', 'plg', 'commands');
+    await fs.mkdir(cmdDir, { recursive: true });
+    await fs.writeFile(path.join(cmdDir, 'cmd.md'), '---\ndescription: cmd desc\n---\ncmd body');
+    await makeAgentFile(tmp, 'plg', 'ag', '---\nname: ag\ndescription: agent desc\n---\nagent body');
+
+    const skillsTarget = path.join(tmp, 'target', '.agents', 'skills');
+    const agentsTomlTarget = path.join(tmp, 'target', '.codex', 'agents');
+
+    const report = await syncAll({
+      pluginsDir: path.join(tmp, 'plugins'),
+      targetDir: skillsTarget,
+      agentsTomlDir: agentsTomlTarget,
+      config: DEFAULT_CONFIG,
+      dryRun: false,
+      prune: false,
+      logger: { warn: () => {}, info: () => {} },
+    });
+
+    assert.equal(report.discoveredAgents, 1);
+    assert.equal(report.consideredAgents, 1);
+    // synced array contains all three (skill + command + agent)
+    const sources = report.synced.map(s => s.bridgeSource).sort();
+    assert.deepEqual(sources, ['plg/agents/ag', 'plg/commands/cmd', 'plg/sk']);
+    // toml file actually written
+    await fs.access(path.join(agentsTomlTarget, 'plg-ag.toml'));
   } finally {
     await fs.rm(tmp, { recursive: true, force: true });
   }

--- a/plugins/codex-bridge/tests/sync.test.mjs
+++ b/plugins/codex-bridge/tests/sync.test.mjs
@@ -423,7 +423,10 @@ test('syncAgent: writes <plugin>-<agent>.toml with bridge_source comment marker'
     const tomlPath = path.join(targetDir, 'code-scout-scout.toml');
     const written = await fs.readFile(tomlPath, 'utf-8');
     // bridge_source comment as first line
-    assert.match(written, /^# bridge_source = "code-scout\/agents\/scout"/m);
+    assert.equal(
+      written.split('\n')[0],
+      '# bridge_source = "code-scout/agents/scout"'
+    );
     // model preserved as comment
     assert.match(written, /^# original-model = "haiku"$/m);
     // canonical TOML fields

--- a/plugins/codex-bridge/tests/transform.test.mjs
+++ b/plugins/codex-bridge/tests/transform.test.mjs
@@ -1,7 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { applyTransforms, transformSkillContent, DEFAULT_RULES } from '../scripts/sync.mjs';
+import { applyTransforms, transformSkillContent, agentToCodexToml, DEFAULT_RULES } from '../scripts/sync.mjs';
 
 test('applyTransforms: CLAUDE.md → AGENTS.md (literal)', () => {
   assert.equal(applyTransforms('see CLAUDE.md for details', DEFAULT_RULES), 'see AGENTS.md for details');
@@ -80,4 +80,160 @@ test('DEFAULT_RULES: has 3 entries (literal x2, regex x1)', () => {
   const modes = new Set(DEFAULT_RULES.map(r => r.mode));
   assert.ok(modes.has('literal'));
   assert.ok(modes.has('regex'));
+});
+
+test('agentToCodexToml: basic structure with name, description, developer_instructions', () => {
+  const src = [
+    '---',
+    'name: scout',
+    'description: A short description',
+    '---',
+    '# Body',
+    'content here',
+  ].join('\n');
+
+  const out = agentToCodexToml(src, 'code-scout', 'scout', DEFAULT_RULES);
+
+  assert.match(out, /^# bridge_source = "code-scout\/agents\/scout"/m);
+  assert.match(out, /^name = "code-scout-scout"$/m);
+  assert.match(out, /^description = "A short description"$/m);
+  assert.match(out, /^developer_instructions = """$/m);
+  assert.match(out, /# Body/);
+  assert.match(out, /content here/);
+});
+
+test('agentToCodexToml: flattens multi-line description (block scalar |)', () => {
+  const src = [
+    '---',
+    'name: a',
+    'description: |',
+    '  Code and ML resource scout. Finds boilerplates, starter templates, reference implementations,',
+    '  and ML models/datasets across GitHub and Hugging Face.',
+    '---',
+    'body',
+  ].join('\n');
+
+  const out = agentToCodexToml(src, 'code-scout', 'a', DEFAULT_RULES);
+  const m = /^description = (.+)$/m.exec(out);
+  assert.ok(m, 'expected description field');
+  // single line, no embedded newline literal
+  assert.doesNotMatch(m[1], /\n/);
+  assert.match(m[1], /^"Code and ML resource scout\. Finds boilerplates, starter templates, reference implementations, and ML models\/datasets across GitHub and Hugging Face\."$/);
+});
+
+test('agentToCodexToml: preserves model/skills/tools as # original-* comments', () => {
+  const src = [
+    '---',
+    'name: scout',
+    'description: x',
+    'model: haiku',
+    'skills: resource-finder',
+    'tools: Bash, Read',
+    '---',
+    'body',
+  ].join('\n');
+
+  const out = agentToCodexToml(src, 'p', 'scout', DEFAULT_RULES);
+  assert.match(out, /^# original-model = "haiku"$/m);
+  assert.match(out, /^# original-skills = "resource-finder"$/m);
+  assert.match(out, /^# original-tools = "Bash, Read"$/m);
+  // and these are NOT real TOML keys
+  assert.doesNotMatch(out, /^model = /m);
+  assert.doesNotMatch(out, /^skills = /m);
+  assert.doesNotMatch(out, /^tools = /m);
+});
+
+test('agentToCodexToml: omits # original-* comment when field missing', () => {
+  const src = [
+    '---',
+    'name: a',
+    'description: x',
+    '---',
+    'body',
+  ].join('\n');
+
+  const out = agentToCodexToml(src, 'p', 'a', DEFAULT_RULES);
+  assert.doesNotMatch(out, /original-model/);
+  assert.doesNotMatch(out, /original-skills/);
+  assert.doesNotMatch(out, /original-tools/);
+});
+
+test('agentToCodexToml: body transforms applied (.claude/ -> .codex/)', () => {
+  const src = [
+    '---',
+    'name: a',
+    'description: x',
+    '---',
+    'see CLAUDE.md and .claude/ here',
+  ].join('\n');
+
+  const out = agentToCodexToml(src, 'p', 'a', DEFAULT_RULES);
+  assert.match(out, /AGENTS\.md/);
+  assert.match(out, /\.codex\//);
+  assert.doesNotMatch(out, /CLAUDE\.md/);
+});
+
+test('agentToCodexToml: description fields with quotes escaped', () => {
+  const src = [
+    '---',
+    'name: a',
+    'description: contains "quotes" and \\backslash',
+    '---',
+    'body',
+  ].join('\n');
+
+  const out = agentToCodexToml(src, 'p', 'a', DEFAULT_RULES);
+  const m = /^description = (.+)$/m.exec(out);
+  assert.ok(m);
+  // double-quote and backslash are escaped
+  assert.match(m[1], /\\"quotes\\"/);
+  assert.match(m[1], /\\\\backslash/);
+});
+
+test('agentToCodexToml: body backslashes escaped for TOML basic multiline string', () => {
+  const src = [
+    '---',
+    'name: a',
+    'description: x',
+    '---',
+    'regex: \\b\\w+\\b',
+  ].join('\n');
+
+  const out = agentToCodexToml(src, 'p', 'a', DEFAULT_RULES);
+  // Original backslashes must be doubled (TOML basic string escape)
+  assert.match(out, /regex: \\\\b\\\\w\+\\\\b/);
+});
+
+test('agentToCodexToml: body containing """ is escaped to not terminate the string', () => {
+  const src = [
+    '---',
+    'name: a',
+    'description: x',
+    '---',
+    'example: """python code"""',
+  ].join('\n');
+
+  const out = agentToCodexToml(src, 'p', 'a', DEFAULT_RULES);
+  // First triple-quote must be escaped so it does not terminate the developer_instructions block
+  // Output of literal `"""` is escape sequence `\"""` (backslash + three quotes)
+  assert.match(out, /\\"""python code\\"""/);
+  // structure: developer_instructions = """...""" still ends with a closing """
+  const tail = out.trim().split('\n').slice(-2).join('\n');
+  assert.match(tail, /"""\s*$/);
+});
+
+test('agentToCodexToml: developer_instructions block opens with triple-quote on its own line and closes likewise', () => {
+  const src = '---\nname: a\ndescription: x\n---\nbody line 1\nbody line 2\n';
+  const out = agentToCodexToml(src, 'p', 'a', DEFAULT_RULES);
+  // TOML basic multi-line string trims the immediate newline after opening """,
+  // so "body line 1" should appear immediately after a newline post-open.
+  assert.match(out, /developer_instructions = """\nbody line 1\nbody line 2/);
+  assert.match(out, /\n"""\s*$/);
+});
+
+test('agentToCodexToml: bridge_source comment uses agents/<name> path', () => {
+  const src = '---\nname: scout\ndescription: x\n---\nbody';
+  const out = agentToCodexToml(src, 'code-scout', 'scout', DEFAULT_RULES);
+  // First line is the bridge_source marker (prune relies on this)
+  assert.equal(out.split('\n')[0], '# bridge_source = "code-scout/agents/scout"');
 });


### PR DESCRIPTION
## Summary

Extends `codex-bridge` to V2 by also syncing plugin subagents (`plugins/*/agents/*.md`) to Codex's USER-scope subagent location (`~/.codex/agents/<plugin>-<agent>.toml`). Previously these were explicitly Out of Scope (V1) and silently dropped, so e.g. `code-scout`'s `scout` and `deep-scout` agents could be invoked from Claude Code but not from independent Codex CLI sessions.

Existing skill + command sync semantics are unchanged.

## Changes

### Engine (`plugins/codex-bridge/scripts/sync.mjs`)

- `discoverAgents(pluginsDir)` — mirrors `discoverCommands`, scans `<plugin>/agents/*.md` under both monorepo and versioned-cache layouts.
- `agentToCodexToml(content, pluginName, agentName, rules)` — Claude Code agent `.md` → Codex subagent TOML. Name → `<plugin>-<agent>`, description flattened to single line, body run through standard transform rules, then wrapped in TOML basic multi-line `developer_instructions = """..."""`. Backslashes and `\"\"\"` sequences escaped per spec.
- `syncAgent(agent, agentsTomlDir, rules, options)` — atomic staging + rename, with the same non-managed-collision guard the existing skill/command paths use.
- `pruneAgentOrphans(agentsTomlDir, validAgentSources)` — deletes `.toml` files that have the marker AND whose source has disappeared. Marker-less files (user-authored) are preserved.
- `syncAll` wired through with `report.discoveredAgents` / `consideredAgents` / `removedAgents` counters; `main()` resolves `agentsTomlDir` from `config.target.agentsTomlHome` (defaulting to `~/.codex/agents/`).

### Provenance marker

TOML doesn't have a YAML-style `bridge_source:` key, so the marker is the first-line comment:

```toml
# bridge_source = "code-scout/agents/scout"
```

Prune relies exclusively on this comment — files without it are treated as user-owned and never touched.

### `model` / `tools` / `skills` handling

Codex's model alias namespace (`gpt-4o`, `o1-mini`, …) differs from Claude Code's (`haiku`, `sonnet`, `opus`). Activating an unknown alias would error or fall back unexpectedly, so these fields are dropped from real TOML keys but preserved as `# original-*` comments so the trail survives:

```toml
# bridge_source = "code-scout/agents/scout"
# original-model = "haiku"
# original-skills = "resource-finder"
name = "code-scout-scout"
description = "Code and ML resource scout. Finds boilerplates, ..."
developer_instructions = """
# Scout Agent
...
"""
```

If users want Codex to honor a specific model, they can add a real `model = "..."` line themselves; the comment makes the source intent visible.

### Versioning

- `plugins/codex-bridge/.claude-plugin/plugin.json`: `1.3.2` → `1.4.0` (minor — additive feature)
- `.claude-plugin/marketplace.json`: codex-bridge entry `1.3.2` → `1.4.0`, top-level `metadata.version` `1.20.0` → `1.21.0` per `plugin-versioning.md` rule.

### Config

`codex-bridge.config.json` gains `target.agentsTomlHome: null` (null = use `~/.codex/agents/`).

### Docs

- `skills/codex-sync/SKILL.md`: V1 description updated; new `Subagent sync` section with transform table, model-drop rationale, TOML output example, and safety contract; Out of Scope `Task(subagent_type=...)` line removed.
- `plugins/codex-bridge/CLAUDE.md`: skill table mentions subagents; 경로 정설 section adds the new target + comment-based marker.
- `.claude/rules/codex-bridge-sync.md`: Role + Key Components + Do's + Don'ts + Out of Scope all updated to cover the agent path. New exports listed.

## Verification

### Unit tests

\`\`\`bash
node --test plugins/codex-bridge/tests/*.test.mjs
# 92 → 122 tests, all passing
\`\`\`

Test counts by file (Δ vs. main):
- `discovery.test.mjs`: 22 → 28 (+6)
- `transform.test.mjs`: 10 → 20 (+10)
- `sync.test.mjs`: 17 → 24 (+7)
- `prune.test.mjs`: 5 → 12 (+7)

### End-to-end (against the local cache, code-scout filter)

\`\`\`bash
$ node ~/.claude/plugins/cache/my-claude-plugins/codex-bridge/1.3.2/scripts/sync.mjs \
    --dry-run --verbose --plugin code-scout
[codex-bridge] resolved pluginsDir: ...\my-claude-plugins (auto-detected (versioned-cache fallback))
[dry-run] would sync skill code-scout/resource-finder
[dry-run] would sync agent code-scout/agents/deep-scout → code-scout-deep-scout.toml
[dry-run] would sync agent code-scout/agents/scout → code-scout-scout.toml
[codex-bridge] discovered 21 plugins, 27 skills, 21 commands, 2 agents

$ node .../sync.mjs --plugin code-scout
# writes: ~/.codex/agents/code-scout-scout.toml
#         ~/.codex/agents/code-scout-deep-scout.toml
# both with first line \`# bridge_source = \"code-scout/agents/<name>\"\`

$ node .../sync.mjs --plugin code-scout
# Idempotent: no errors, identical output.
\`\`\`

### Codex CLI end-user check

Validation that the `.toml` files actually load as native Codex subagents requires opening an independent Codex CLI session and exercising the agent. That step is outside Claude Code's reach and is a manual smoke test for the user.

### Safety regressions

- `~/.agents/skills/` (existing skill+command target) — untouched semantics, all existing tests still pass.
- `~/.codex/agents/` non-managed `.toml` files — unit tests cover the marker check; a manually-authored `.toml` without `# bridge_source` will skip on sync and survive prune.

## Local cache patch

To use the new sync without waiting for the cache refresh dance, the same changes (except plugin.json version, which stays at `1.3.2` for cache integrity) have been applied locally to `~/.claude/plugins/cache/my-claude-plugins/codex-bridge/1.3.2/`. Once this PR merges, the standard refresh flow per `plugin-versioning.md` (`rm -rf ~/.claude/plugins/cache/my-claude-plugins/` → `/plugin marketplace update my-claude-plugins` → restart) will replace it cleanly with the official `1.4.0` version.

## References

- OpenAI Codex Subagents: https://developers.openai.com/codex/subagents (`~/.codex/agents/*.toml`, required fields `name` / `description` / `developer_instructions`)
- OpenAI Codex Customization: https://developers.openai.com/codex/concepts/customization

## Test plan

- [x] `node --test plugins/codex-bridge/tests/*.test.mjs` (122/122 green)
- [x] Dry-run + real sync against cache for `--plugin code-scout` produces 2 `.toml` files with the expected marker as first line
- [x] Second consecutive run is idempotent
- [ ] Manual: open independent Codex CLI session, invoke the new subagents
- [ ] Manual: bump cache via `rm -rf ~/.claude/plugins/cache/my-claude-plugins/ && /plugin marketplace update my-claude-plugins` (per `plugin-versioning.md`) once PR merges, then drop the local 1.3.2 patch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * Codex Bridge가 스킬·명령어뿐 아니라 서브에이전트(.toml) 동기화를 지원하도록 확장되었습니다.

* **문서**
  * 동기화 대상, TOML 변환 형식, provenance(bridge_source) 표기와 안전·프루닝 규칙이 명확히 문서화되었습니다.

* **테스트**
  * 서브에이전트 발견, 변환, 동기화 및 프루닝에 대한 포괄적 테스트가 추가되었습니다.

* **Chores**
  * 마켓플레이스 버전 1.21.0, Codex Bridge 플러그인 버전 1.4.0으로 업데이트되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->