### PR TITLE
fix(llm-wiki): grep -P locale failure + drop bc dependency

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Personal Claude Code plugin collection with 21 specialized plugins",
-    "version": "1.30.0"
+    "version": "1.30.1"
   },
   "plugins": [
     {
@@ -145,7 +145,7 @@
       "name": "llm-wiki",
       "source": "./plugins/llm-wiki",
       "description": "Karpathy LLM-Wiki 3-layer (5 skills: query/ingest/lint/bootstrap/post-merge-wiki + 2 soft-hint hooks + bootstrap templates). Universal — works in any repo with .claude/wiki/.",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "category": "memory"
     },
     {

--- a/plugins/llm-wiki/.claude-plugin/plugin.json
+++ b/plugins/llm-wiki/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "llm-wiki",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Karpathy LLM-Wiki 3-layer system: 5 skills (query/ingest/lint/bootstrap/post-merge-wiki) + 2 soft-hint hooks (stale check, post-commit hint). Universal — works in any repo with .claude/wiki/. For spec/issue/PR work-pipeline state see the spec-state plugin.",
   "hooks": {
     "UserPromptSubmit": [

--- a/plugins/llm-wiki/hooks/wiki_post_commit_hint.sh
+++ b/plugins/llm-wiki/hooks/wiki_post_commit_hint.sh
@@ -15,7 +15,7 @@ cmd=""
 if command -v jq >/dev/null 2>&1; then
   cmd=$(printf '%s' "$input_json" | jq -r '.tool_input.command // empty' 2>/dev/null)
 else
-  cmd=$(printf '%s' "$input_json" | grep -oP '"command"\s*:\s*"\K[^"]+' | head -1)
+  cmd=$(printf '%s' "$input_json" | LC_ALL=C.UTF-8 grep -oP '"command"\s*:\s*"\K[^"]+' | head -1)
 fi
 [[ -z "$cmd" ]] && exit 0
 
@@ -39,7 +39,8 @@ touch "$marker"
 # Stat the last commit's diff
 files_changed=$(git diff --name-only HEAD~1 HEAD 2>/dev/null | wc -l || echo 0)
 lines_changed=$(git diff --shortstat HEAD~1 HEAD 2>/dev/null \
-                | grep -oP '\d+(?= insertion| deletion)' | paste -sd+ | bc 2>/dev/null || echo 0)
+                | LC_ALL=C.UTF-8 grep -oP '\d+(?= insertion| deletion)' \
+                | awk '{s+=$1} END{print s+0}' 2>/dev/null || echo 0)
 [[ -z "$lines_changed" ]] && lines_changed=0
 
 # Threshold: 2+ files OR 50+ lines OR a merge commit

--- a/plugins/llm-wiki/hooks/wiki_stale_check.sh
+++ b/plugins/llm-wiki/hooks/wiki_stale_check.sh
@@ -22,7 +22,7 @@ today_ts=$(date +%s)
 stale=()
 
 while IFS= read -r f; do
-  d=$(grep -oP '^last_verified:\s*\K\d{4}-\d{2}-\d{2}' "$f" 2>/dev/null | head -1)
+  d=$(LC_ALL=C.UTF-8 grep -oP '^last_verified:\s*\K\d{4}-\d{2}-\d{2}' "$f" 2>/dev/null | head -1)
   [[ -z "$d" ]] && continue
   d_ts=$(date -d "$d" +%s 2>/dev/null) || continue
   age_days=$(( (today_ts - d_ts) / 86400 ))

--- a/plugins/llm-wiki/skills/lint-wiki/SKILL.md
+++ b/plugins/llm-wiki/skills/lint-wiki/SKILL.md
@@ -41,7 +41,7 @@ LLM-maintained wikis rot in predictable ways (Karpathy gist comments cite 4 fail
    ```bash
    today=$(date +%s)
    while IFS= read -r f; do
-     d=$(grep -oP '^last_verified:\s*\K\d{4}-\d{2}-\d{2}' "$f" || true)
+     d=$(LC_ALL=C.UTF-8 grep -oP '^last_verified:\s*\K\d{4}-\d{2}-\d{2}' "$f" || true)
      [[ -z "$d" ]] && continue
      age_days=$(( (today - $(date -d "$d" +%s)) / 86400 ))
      [[ $age_days -gt 60 ]] && printf '%s (%d days)\n' "$f" "$age_days"
@@ -52,7 +52,7 @@ LLM-maintained wikis rot in predictable ways (Karpathy gist comments cite 4 fail
 5. **Orphan scan** (pages not in index, indexed pages that don't exist):
    ```bash
    diff <(find .claude/wiki -name '*.md' -not -name 'index.md' -not -name 'log.md' | sort) \
-        <(grep -oP '\(\K[^)]+\.md' .claude/wiki/index.md | sed 's|^|.claude/wiki/|' | sort)
+        <(LC_ALL=C.UTF-8 grep -oP '\(\K[^)]+\.md' .claude/wiki/index.md | sed 's|^|.claude/wiki/|' | sort)
    ```
 
 6. **MOC integrity** (cross-refs to non-existent pages):


### PR DESCRIPTION
## Summary

Two portability bugs in the `llm-wiki` plugin, both reproduced on a Windows Git Bash environment with `LANG=` empty.

### 1. `grep -P` dies on empty/non-UTF-8 locale (main impact)

`grep -oP` exits `2` with `grep: -P supports only unibyte and UTF-8 locales` when `LANG` is unset. Because the hooks run under `set -u` + `exec 2>/dev/null`, the failure is invisible and the command just yields an empty string:

- **`hooks/wiki_stale_check.sh:25`** — every page's `last_verified` reads as empty → `continue` → **no page is ever flagged stale.** The entire "soft-hint when wiki goes stale" feature is a silent no-op on affected machines.
- **`hooks/wiki_post_commit_hint.sh:18,42`** — JSON command extraction (no-jq fallback) and the insertion/deletion line count break.
- **`skills/lint-wiki/SKILL.md`** — the staleness (step 4) and orphan (step 5) scans error out when run.

Fix: prefix each `grep -P` with `LC_ALL=C.UTF-8`. Verified that `rg -P` is **not** affected (ripgrep handles UTF-8 internally regardless of locale), so those lines are left as-is.

### 2. `paste -sd+ | bc` requires `bc`

`hooks/wiki_post_commit_hint.sh:42` pipes through `bc`, which isn't installed on many minimal/Windows shells; the line-count metric then always falls back to `0` and the 50-line threshold never trips. Replaced with `awk '{s+=$1} END{print s+0}'` (no extra dependency, returns `0` on empty input).

## Out of scope (noted, not fixed)

`date -d`, `stat -c`, and `md5sum` are GNU-only and would break on macOS/BSD. They work on the target environment, and a correct cross-platform fix needs branching I couldn't test here — leaving for a follow-up rather than shipping half-tested.

## Test plan

- [x] `bash -n` passes on both hooks
- [x] `LC_ALL=C.UTF-8 grep -oP` extracts `last_verified` under `env -u LANG -u LC_ALL`
- [x] `awk` sum path returns `50` for `42 insertions + 8 deletions` and `0` on empty input
- [x] `rg -P` confirmed working under empty locale (left unchanged)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 위키 스캔과 커밋 분석에서 문자 인코딩 처리 안정화로 다양한 환경에서의 파싱 신뢰성 향상
  * 라인 변경량 집계 방식 개선으로 커밋 기반 분석 결과의 정확도 향상

* **기타(버전 업데이트)**
  * 플러그인 및 메타데이터 버전이 소규모 갱신되어 배포 일관성 개선

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/YoungjaeDev/my-claude-plugins/pull/21?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->