### PR TITLE
fix(github-dev): SHA-aware Step 7 sniffer + Step 8c engagement gate (cr-fix 1.21.3)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Personal Claude Code plugin collection with 21 specialized plugins",
-    "version": "1.30.0"
+    "version": "1.30.1"
   },
   "plugins": [
     {
@@ -19,7 +19,7 @@
       "name": "github-dev",
       "source": "./plugins/github-dev",
       "description": "GitHub workflow: commit, PR, issue, worktree, unified CodeRabbit + ChatGPT-Codex cr-fix pipeline (wait + auto-fetch + apply + push loop with branch-protection-gated auto-merge, CR-engagement guard, Codex review-id discovery + dedupe with grace polling, CR Nitpick + Codex P3 silent skip, optional --skip-minor opt-in for Minor + Codex P2 suppression), project tracking, release",
-      "version": "1.21.2",
+      "version": "1.21.3",
       "category": "github"
     },
     {

--- a/plugins/github-dev/.claude-plugin/plugin.json
+++ b/plugins/github-dev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "github-dev",
-  "version": "1.21.2",
+  "version": "1.21.3",
   "description": "GitHub workflow automation commands for Claude Code",
   "commands": [
     "./commands/commit-and-push.md",

--- a/plugins/github-dev/commands/cr-fix.md
+++ b/plugins/github-dev/commands/cr-fix.md
@@ -266,7 +266,7 @@ CodeRabbit sometimes flips `commit_status` to success while still processing. De
 
 ```bash
 PUSH_TIME=$(gh api "repos/$OWNER/$REPO/commits/$CUR_SHA" --jq '.commit.committer.date')
-gh pr view "$PR_NUM" --json comments,reviews --jq --arg t "$PUSH_TIME" '
+gh pr view "$PR_NUM" --json comments,reviews | jq --arg t "$PUSH_TIME" '
   [
     (.comments[]?
       | select(.author.login == "coderabbitai" or .author.login == "coderabbit[bot]" or .author.login == "coderabbitai[bot]")
@@ -282,7 +282,7 @@ gh pr view "$PR_NUM" --json comments,reviews --jq --arg t "$PUSH_TIME" '
 '
 ```
 
-`PUSH_TIME` is the committer date of `$CUR_SHA` (an ISO-8601 string); the jq `>` comparison on ISO-8601 strings is lexicographic but correct because the format is fixed-width and zero-padded. Older "in progress" messages from previous pushes are excluded, so iter=2+ no longer triggers a phantom sleep on a long-dead sniffer hit.
+`PUSH_TIME` is the committer date of `$CUR_SHA` (an ISO-8601 string); the jq `>` comparison on ISO-8601 strings is lexicographic but correct because the format is fixed-width and zero-padded. Older "in progress" messages from previous pushes are excluded, so iter=2+ no longer triggers a phantom sleep on a long-dead sniffer hit. The `gh ... | jq --arg t ...` pipe (instead of `gh ... --jq --arg ...`) is required because `gh`'s built-in `--jq` flag accepts a single filter string and does NOT forward `--arg` / `--argjson` to the underlying jq engine — passing them inline triggers `accepts 1 arg(s), received 4` and the sniffer never runs.
 
 If the count is greater than 0, sleep `$INTERVAL` and repeat Step 6 once before continuing. Counts toward iteration budget only if it triggers a full re-poll (not just the sniff).
 
@@ -383,11 +383,13 @@ If the **combined** count (CR actionable threads + Codex actionable records) is 
 # Has CodeRabbit engaged with THIS push? (review submitted_at / comment created_at > push time)
 PUSH_TIME=$(gh api "repos/$OWNER/$REPO/commits/$CUR_SHA" --jq '.commit.committer.date')
 cr_review_count=$(gh api "repos/$OWNER/$REPO/pulls/$PR_NUM/reviews" \
-  --jq --arg t "$PUSH_TIME" '[.[] | select(.user.login | test("coderabbit"; "i")) | select(.submitted_at > $t)] | length')
+  | jq --arg t "$PUSH_TIME" '[.[] | select(.user.login | test("coderabbit"; "i")) | select(.submitted_at > $t)] | length')
 cr_comment_count=$(gh api "repos/$OWNER/$REPO/issues/$PR_NUM/comments" \
-  --jq --arg t "$PUSH_TIME" '[.[] | select(.user.login | test("coderabbit"; "i")) | select(.created_at > $t)] | length')
+  | jq --arg t "$PUSH_TIME" '[.[] | select(.user.login | test("coderabbit"; "i")) | select(.created_at > $t)] | length')
 cr_engagement=$((cr_review_count + cr_comment_count))
 ```
+
+The `gh ... | jq --arg t ...` pipe is required for the same reason as Step 7: `gh`'s `--jq` flag does not forward `--arg` to the jq engine. The pipe shape mirrors Step 8b's `gh api ... --paginate | jq --argjson rid ...` pattern.
 
 - `cr_engagement > 0`: CR has reviewed THIS push and produced no actionable threads → genuine convergence. Set `final_state="clean"` and jump to Step 13.
 - `cr_engagement == 0` AND `ITER < MAX_ITER`: CR has not started reviewing this push yet (e.g. status went green before the review payload posted, or the PR was just created). Do NOT declare clean. Sleep `$INTERVAL` and re-enter Step 6 (this counts toward the iteration budget, like the in-progress sniffer).

--- a/plugins/github-dev/commands/cr-fix.md
+++ b/plugins/github-dev/commands/cr-fix.md
@@ -382,14 +382,16 @@ If the **combined** count (CR actionable threads + Codex actionable records) is 
 ```bash
 # Has CodeRabbit engaged with THIS push? (review submitted_at / comment created_at > push time)
 PUSH_TIME=$(gh api "repos/$OWNER/$REPO/commits/$CUR_SHA" --jq '.commit.committer.date')
-cr_review_count=$(gh api "repos/$OWNER/$REPO/pulls/$PR_NUM/reviews" \
+cr_review_count=$(gh api --paginate "repos/$OWNER/$REPO/pulls/$PR_NUM/reviews" \
+  | jq -s 'add // []' \
   | jq --arg t "$PUSH_TIME" '[.[] | select(.user.login | test("coderabbit"; "i")) | select(.submitted_at > $t)] | length')
-cr_comment_count=$(gh api "repos/$OWNER/$REPO/issues/$PR_NUM/comments" \
+cr_comment_count=$(gh api --paginate "repos/$OWNER/$REPO/issues/$PR_NUM/comments" \
+  | jq -s 'add // []' \
   | jq --arg t "$PUSH_TIME" '[.[] | select(.user.login | test("coderabbit"; "i")) | select(.created_at > $t)] | length')
 cr_engagement=$((cr_review_count + cr_comment_count))
 ```
 
-The `gh ... | jq --arg t ...` pipe is required for the same reason as Step 7: `gh`'s `--jq` flag does not forward `--arg` to the jq engine. The pipe shape mirrors Step 8b's `gh api ... --paginate | jq --argjson rid ...` pattern.
+`--paginate` is required because both REST endpoints default to `per_page=30` and return chronological ascending order. On long-running PRs (>30 prior reviews/comments) the unpaginated first page contains only old entries, the `> $PUSH_TIME` filter drops all of them, and the iter sleeps until `MAX_ITER` exits with `cr_inactive` even when CR already reviewed this push. `gh api --paginate` emits one JSON document per page (concatenated, not merged), so `jq -s 'add // []'` slurps and flattens them into a single array before the cutoff filter runs. The trailing `gh ... | jq --arg t ...` pipe stays — `gh`'s `--jq` flag does not forward `--arg` to the jq engine. The pipe shape mirrors Step 8b's `gh api ... --paginate | jq --argjson rid ...` pattern.
 
 - `cr_engagement > 0`: CR has reviewed THIS push and produced no actionable threads → genuine convergence. Set `final_state="clean"` and jump to Step 13.
 - `cr_engagement == 0` AND `ITER < MAX_ITER`: CR has not started reviewing this push yet (e.g. status went green before the review payload posted, or the PR was just created). Do NOT declare clean. Sleep `$INTERVAL` and re-enter Step 6 (this counts toward the iteration budget, like the in-progress sniffer).

--- a/plugins/github-dev/commands/cr-fix.md
+++ b/plugins/github-dev/commands/cr-fix.md
@@ -267,14 +267,19 @@ CodeRabbit sometimes flips `commit_status` to success while still processing. De
 ```bash
 # PUSH_TIME = earliest individual status created_at on this SHA. Best proxy for "when GitHub
 # first saw this SHA" — CR / CI typically post a `pending` status within ~seconds of receiving
-# the webhook. NOTE: must use /commits/{sha}/statuses (plural, full history) not /status
-# (singular, latest-per-context combined view) — the singular endpoint hides the early `pending`
-# entries and would yield the review-complete time instead of the push time.
+# the webhook. NOTES:
+#   - Must use /commits/{sha}/statuses (plural, full history) not /status (singular,
+#     latest-per-context combined view) — the singular endpoint hides early `pending`
+#     entries and would yield the review-complete time instead of the push time.
+#   - Must use --paginate; the statuses endpoint returns latest-first with default per_page=30,
+#     so an unpaginated read on a CI-heavy SHA picks "oldest of the newest 30" rather than
+#     the actual earliest status, shifting PUSH_TIME forward past CR's review for this push.
+#     `jq -s 'add // []'` slurps all pages into a single array before sorting.
 # Falls back to commit committer.date only if no statuses exist yet (very rare race) — but
 # committer.date is git metadata, NOT push time, so cherry-picks or stale-commit pushes would
 # otherwise leak prior-push CR activity through the SHA-aware filters below.
-PUSH_TIME=$(gh api "repos/$OWNER/$REPO/commits/$CUR_SHA/statuses" \
-  --jq '[.[].created_at] | sort | .[0] // empty')
+PUSH_TIME=$(gh api --paginate "repos/$OWNER/$REPO/commits/$CUR_SHA/statuses" \
+  | jq -sr 'add // [] | [.[].created_at] | sort | .[0] // empty')
 [ -n "$PUSH_TIME" ] || PUSH_TIME=$(gh api "repos/$OWNER/$REPO/commits/$CUR_SHA" --jq '.commit.committer.date')
 gh pr view "$PR_NUM" --json comments,reviews | jq --arg t "$PUSH_TIME" '
   [
@@ -393,8 +398,8 @@ If the **combined** count (CR actionable threads + Codex actionable records) is 
 # Has CodeRabbit engaged with THIS push? (review submitted_at / comment created_at > push time)
 # PUSH_TIME = earliest individual /statuses created_at; see Step 7 for rationale (committer.date
 # is git metadata, not push time, and would leak prior-push CR activity through this gate).
-PUSH_TIME=$(gh api "repos/$OWNER/$REPO/commits/$CUR_SHA/statuses" \
-  --jq '[.[].created_at] | sort | .[0] // empty')
+PUSH_TIME=$(gh api --paginate "repos/$OWNER/$REPO/commits/$CUR_SHA/statuses" \
+  | jq -sr 'add // [] | [.[].created_at] | sort | .[0] // empty')
 [ -n "$PUSH_TIME" ] || PUSH_TIME=$(gh api "repos/$OWNER/$REPO/commits/$CUR_SHA" --jq '.commit.committer.date')
 cr_review_count=$(gh api --paginate "repos/$OWNER/$REPO/pulls/$PR_NUM/reviews" \
   | jq -s 'add // []' \

--- a/plugins/github-dev/commands/cr-fix.md
+++ b/plugins/github-dev/commands/cr-fix.md
@@ -262,22 +262,27 @@ Token cost during the grace window is ~0 because the polling runs in `Bash(run_i
 
 ## Step 7: In-progress sniffer
 
-CodeRabbit sometimes flips `commit_status` to success while still processing. Detect explicitly:
+CodeRabbit sometimes flips `commit_status` to success while still processing. Detect explicitly — **limited to comments and reviews created after the current push**, otherwise a stale "Come back again in a few minutes" message from a prior push would re-fire the sleep branch on every subsequent iter:
 
 ```bash
-gh pr view "$PR_NUM" --json comments,reviews --jq '
+PUSH_TIME=$(gh api "repos/$OWNER/$REPO/commits/$CUR_SHA" --jq '.commit.committer.date')
+gh pr view "$PR_NUM" --json comments,reviews --jq --arg t "$PUSH_TIME" '
   [
     (.comments[]?
       | select(.author.login == "coderabbitai" or .author.login == "coderabbit[bot]" or .author.login == "coderabbitai[bot]")
+      | select(.createdAt > $t)
       | .body // empty),
     (.reviews[]?
       | select(.author.login == "coderabbitai" or .author.login == "coderabbit[bot]" or .author.login == "coderabbitai[bot]")
+      | select(.submittedAt > $t)
       | .body // empty)
   ]
   | map(select(test("Come back again in a few minutes")))
   | length
 '
 ```
+
+`PUSH_TIME` is the committer date of `$CUR_SHA` (an ISO-8601 string); the jq `>` comparison on ISO-8601 strings is lexicographic but correct because the format is fixed-width and zero-padded. Older "in progress" messages from previous pushes are excluded, so iter=2+ no longer triggers a phantom sleep on a long-dead sniffer hit.
 
 If the count is greater than 0, sleep `$INTERVAL` and repeat Step 6 once before continuing. Counts toward iteration budget only if it triggers a full re-poll (not just the sniff).
 
@@ -369,22 +374,26 @@ If `codex_active == "active"` AND `codex_records` is empty: Codex either approve
 
 ## Step 8c: Combined engagement gate
 
-If the **combined** count (CR actionable threads + Codex actionable records) is zero, run the engagement gate before declaring convergence:
+If the **combined** count (CR actionable threads + Codex actionable records) is zero, run the engagement gate before declaring convergence. The gate is **SHA-aware** — only CR activity created after `$CUR_SHA` was pushed counts. A PR-lifetime engagement query (the prior implementation) over-counts in two race windows:
+
+1. **Stale signal** — every CR review/comment from prior pushes inflates `cr_engagement` indefinitely. A new push with zero CR response yet would falsely declare clean as long as any old CR welcome message exists.
+2. **Step 6 → Step 8 race** — CR's commit-status `success` can land minutes before the actual review threads post (observed lag up to ~15 min). The race is harmless only if engagement is judged on **this** SHA; otherwise prior-SHA CR activity sweeps the gate green before the new threads appear.
 
 ```bash
-# Has CodeRabbit ever engaged with this PR? (any review or any comment)
+# Has CodeRabbit engaged with THIS push? (review submitted_at / comment created_at > push time)
+PUSH_TIME=$(gh api "repos/$OWNER/$REPO/commits/$CUR_SHA" --jq '.commit.committer.date')
 cr_review_count=$(gh api "repos/$OWNER/$REPO/pulls/$PR_NUM/reviews" \
-  --jq '[.[] | select(.user.login | test("coderabbit"; "i"))] | length')
+  --jq --arg t "$PUSH_TIME" '[.[] | select(.user.login | test("coderabbit"; "i")) | select(.submitted_at > $t)] | length')
 cr_comment_count=$(gh api "repos/$OWNER/$REPO/issues/$PR_NUM/comments" \
-  --jq '[.[] | select(.user.login | test("coderabbit"; "i"))] | length')
+  --jq --arg t "$PUSH_TIME" '[.[] | select(.user.login | test("coderabbit"; "i")) | select(.created_at > $t)] | length')
 cr_engagement=$((cr_review_count + cr_comment_count))
 ```
 
-- `cr_engagement > 0`: CR has actually reviewed and produced no actionable threads → genuine convergence. Set `final_state="clean"` and jump to Step 13.
-- `cr_engagement == 0` AND `ITER < MAX_ITER`: CR has not started reviewing yet (e.g. PR was just created). Do NOT declare clean. Sleep `$INTERVAL` and re-enter Step 6 (this counts toward the iteration budget, like the in-progress sniffer).
-- `cr_engagement == 0` AND `ITER == MAX_ITER`: CR is unreachable or inactive. Set `final_state="cr_inactive"` and break the loop. Auto-merge stays disabled (Step 15 already gates on `final_state == "clean"`).
+- `cr_engagement > 0`: CR has reviewed THIS push and produced no actionable threads → genuine convergence. Set `final_state="clean"` and jump to Step 13.
+- `cr_engagement == 0` AND `ITER < MAX_ITER`: CR has not started reviewing this push yet (e.g. status went green before the review payload posted, or the PR was just created). Do NOT declare clean. Sleep `$INTERVAL` and re-enter Step 6 (this counts toward the iteration budget, like the in-progress sniffer).
+- `cr_engagement == 0` AND `ITER == MAX_ITER`: CR is unreachable or inactive on this SHA. Set `final_state="cr_inactive"` and break the loop. Auto-merge stays disabled (Step 15 already gates on `final_state == "clean"`).
 
-This blocks the PR-just-created case where commit-status is naturally green but CR has not yet posted a single comment — the exact pattern that caused the sankun PR #68 immediate-merge incident.
+This blocks the PR-just-created case where commit-status is naturally green but CR has not yet posted a single comment — the exact pattern that caused the sankun PR #68 immediate-merge incident — and also closes the Step 6 → Step 8 race that previously let stale CR activity false-clean a fresh push.
 
 ## Step 9: Display + apply (tiered)
 

--- a/plugins/github-dev/commands/cr-fix.md
+++ b/plugins/github-dev/commands/cr-fix.md
@@ -265,7 +265,17 @@ Token cost during the grace window is ~0 because the polling runs in `Bash(run_i
 CodeRabbit sometimes flips `commit_status` to success while still processing. Detect explicitly — **limited to comments and reviews created after the current push**, otherwise a stale "Come back again in a few minutes" message from a prior push would re-fire the sleep branch on every subsequent iter:
 
 ```bash
-PUSH_TIME=$(gh api "repos/$OWNER/$REPO/commits/$CUR_SHA" --jq '.commit.committer.date')
+# PUSH_TIME = earliest individual status created_at on this SHA. Best proxy for "when GitHub
+# first saw this SHA" — CR / CI typically post a `pending` status within ~seconds of receiving
+# the webhook. NOTE: must use /commits/{sha}/statuses (plural, full history) not /status
+# (singular, latest-per-context combined view) — the singular endpoint hides the early `pending`
+# entries and would yield the review-complete time instead of the push time.
+# Falls back to commit committer.date only if no statuses exist yet (very rare race) — but
+# committer.date is git metadata, NOT push time, so cherry-picks or stale-commit pushes would
+# otherwise leak prior-push CR activity through the SHA-aware filters below.
+PUSH_TIME=$(gh api "repos/$OWNER/$REPO/commits/$CUR_SHA/statuses" \
+  --jq '[.[].created_at] | sort | .[0] // empty')
+[ -n "$PUSH_TIME" ] || PUSH_TIME=$(gh api "repos/$OWNER/$REPO/commits/$CUR_SHA" --jq '.commit.committer.date')
 gh pr view "$PR_NUM" --json comments,reviews | jq --arg t "$PUSH_TIME" '
   [
     (.comments[]?
@@ -381,7 +391,11 @@ If the **combined** count (CR actionable threads + Codex actionable records) is 
 
 ```bash
 # Has CodeRabbit engaged with THIS push? (review submitted_at / comment created_at > push time)
-PUSH_TIME=$(gh api "repos/$OWNER/$REPO/commits/$CUR_SHA" --jq '.commit.committer.date')
+# PUSH_TIME = earliest individual /statuses created_at; see Step 7 for rationale (committer.date
+# is git metadata, not push time, and would leak prior-push CR activity through this gate).
+PUSH_TIME=$(gh api "repos/$OWNER/$REPO/commits/$CUR_SHA/statuses" \
+  --jq '[.[].created_at] | sort | .[0] // empty')
+[ -n "$PUSH_TIME" ] || PUSH_TIME=$(gh api "repos/$OWNER/$REPO/commits/$CUR_SHA" --jq '.commit.committer.date')
 cr_review_count=$(gh api --paginate "repos/$OWNER/$REPO/pulls/$PR_NUM/reviews" \
   | jq -s 'add // []' \
   | jq --arg t "$PUSH_TIME" '[.[] | select(.user.login | test("coderabbit"; "i")) | select(.submitted_at > $t)] | length')


### PR DESCRIPTION
## Summary

cr-fix.md 의 두 가지 P0 stale-signal 버그 수정. 둘 다 PR-lifetime 기준 쿼리가 현재 push 의 CR 활동만 봐야 할 자리에서 이전 push 의 활동까지 카운트해서 false-fire / false-clean 을 유발하던 패턴.

- **Step 7 sniffer (`cr-fix.md:263-282`)**: \`PUSH_TIME=$CUR_SHA committer.date\` 기준으로 \`createdAt\` / \`submittedAt\` 필터 추가. 이전 push 의 \"Come back again in a few minutes\" 가 매 iter sleep 분기를 false-trigger 하던 문제 제거.
- **Step 8c engagement gate (`cr-fix.md:370-388`)**: 동일한 PUSH_TIME 필터로 \`cr_review_count\` / \`cr_comment_count\` 를 SHA-aware 로 변경. PR lifetime 의 CR welcome 메시지가 새 push 의 zero-engagement 상태를 false-clean 하던 race window 차단.

진단 근거: 8개 archived cr-fix state 중 6개 (75%) 가 \`iter=0\` 에서 종료 (codex_processed>0, applied=0, deferred=0 패턴). CR commit-status success ↔ review thread 게시 사이 lag 실측 최대 14분 51초 — Step 6→8 race window 가 실재.

## Version bumps (per .claude/rules/plugin-versioning.md)

- \`plugins/github-dev/.claude-plugin/plugin.json\`: 1.21.2 → 1.21.3
- \`.claude-plugin/marketplace.json\` github-dev entry: 1.21.2 → 1.21.3
- \`.claude-plugin/marketplace.json\` metadata: 1.30.0 → 1.30.1

## Test plan

- [ ] Markdown rendering — cr-fix.md 코드 펜스 / heading 정합성 육안 확인
- [ ] cr-fix 실행 시 Step 7 sniffer 가 이전 push 의 stale CR 메시지로 false-fire 하지 않는지 (실측: 다음 cr-fix run 에서 archived state 의 \`iter\` 값 관찰)
- [ ] Step 8c gate 가 stale CR engagement (PR-lifetime) 로 false-clean 하지 않는지 — race window 시나리오 (CR status success + 0 threads + 이전 push 의 CR engagement 존재) 에서 sleep 분기로 진입하는지
- [ ] PR #21 의 llm-wiki 1.1.1 bump 와 marketplace.json 충돌 시 rebase 로 1.30.2 로 올려 해결

## Out of scope

- Step 6 check-runs fallback (P2, future-proofing)
- \`--codex-grace\` default 통일 (P1, separate)
- Step 6b multi-review batching (P1, separate)
- \`codex_processed_reviews\` size cap (P2, long-running stability)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * CR-fix 파이프라인이 PR 전체가 아닌 현재 푸시(SHA) 기준으로 진행 상태와 수렴 판정을 판단하도록 개선되어, 오래된 피드백으로 인한 잘못된 대기/종료 판단을 방지합니다.

* **Chores**
  * 마켓플레이스 버전 1.30.0 → 1.30.1로 업데이트했습니다.
  * github-dev 플러그인 버전 1.21.2 → 1.21.3으로 업데이트했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/YoungjaeDev/my-claude-plugins/pull/22?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->