### PR TITLE
fix(codex-bridge): match midjourney exclude across cache layout

### DIFF
--- a/plugins/codex-bridge/codex-bridge.config.json
+++ b/plugins/codex-bridge/codex-bridge.config.json
@@ -7,7 +7,7 @@
   },
   "collisionFallbackPrefix": "bridge-",
   "exclude": [
-    "plugins/midjourney/**"
+    "**/midjourney/**"
   ],
   "transform": {
     "bodyOnly": true,


### PR DESCRIPTION
## Problem

The `exclude` glob in `plugins/codex-bridge/codex-bridge.config.json` was `plugins/midjourney/**`, which only matches the monorepo layout. Under Claude Code's versioned plugin cache, the sync script resolves paths relative to the cache root, so the midjourney skill path is:

```
my-claude-plugins/midjourney/<version>/skills/midjourney-imagineapi
```

The pattern `plugins/midjourney/**` never matches this, so `midjourney-imagineapi` was synced to `~/.agents/skills/` despite being intended for exclusion.

## Fix

Change the pattern to `**/midjourney/**`, which matches both layouts:
- monorepo: `plugins/midjourney/...`
- versioned cache: `my-claude-plugins/midjourney/<version>/...`

## Verification

`node scripts/sync.mjs --dry-run --verbose` after the change:
- `skills: discovered 26, considered 25` (midjourney filtered out)
- previously-synced `midjourney-imagineapi` is reported as an orphan to prune
- all other skills/commands/agents unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * Midjourney 관련 파일 제외 규칙을 더 폭넓은 경로 패턴으로 업데이트했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/YoungjaeDev/my-claude-plugins/pull/23?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->