### PR TITLE
feat(project-init): add Day-1 project bootstrap plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,8 +4,8 @@
     "name": "YoungjaeDev"
   },
   "metadata": {
-    "description": "Personal Claude Code plugin collection with 21 specialized plugins",
-    "version": "1.30.1"
+    "description": "Personal Claude Code plugin collection with 22 specialized plugins",
+    "version": "1.31.0"
   },
   "plugins": [
     {
@@ -154,6 +154,13 @@
       "description": "Spec/issue/PR work-pipeline aggregate. state-tracker skill manages .claude/state/spec.json (read/init/start/complete). Called by github-dev:post-merge.",
       "version": "1.0.0",
       "category": "workflow"
+    },
+    {
+      "name": "project-init",
+      "source": "./plugins/project-init",
+      "description": "One-shot first-day project bootstrap: interview, .claude/ scaffold, minimal CLAUDE.md (LLM-Wiki entrypoint), AGENTS.md with Codex GitHub cloud reviewer guidelines (general/ml/web variants), README/CHANGELOG seed, gh repo create + initial push. Single command /project-init:new.",
+      "version": "0.1.0",
+      "category": "planning"
     }
   ]
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,3 +58,47 @@ node plugins/codex-bridge/scripts/sync.mjs --dry-run --verbose
 - 사용자-facing 문서는 한국어 설명을 자연스럽게 유지하고, 명령어와 경로는 코드 포맷으로 표기하세요.
 - README류 문서는 실제 설치/사용 흐름을 우선하고, 플러그인 수, 플러그인 이름, 명령어 예시는 매니페스트와 일치시켜야 합니다.
 - 큰 구조 변경 없이 문서만 보강하는 경우에도 관련 count, badge, 목록이 stale하지 않은지 확인하세요.
+
+## Review guidelines
+
+> 이 섹션은 Codex GitHub cloud reviewer 가 자동으로 읽는 영역이다. 한국어로 리뷰한다. 발견사항은 영향 + 근거 (파일/라인) + 수정 방향 순서로 제시한다. 근거가 부족하면 `unverified` 로 표시한다.
+
+### Do not flag (린터/포매터 영역)
+- 들여쓰기, 따옴표 스타일, trailing whitespace — 포매터 영역.
+- import 순서, 한 줄 helper 추출 — 결함이 아니면 skip.
+- 단순 typo / 영문 문법 — 의미 오류 아니면 skip.
+- Markdown 줄바꿈 / 줄간격 micro-optimization — 가독성 문제 아니면 skip.
+
+### P0 — Correctness / Security
+- Secret / API key / token 노출 (사용자 GitHub PAT, OpenAI/Anthropic key 등).
+- `gh api` / `gh pr merge` / `gh repo create` 류 destructive 명령이 사용자 확인 없이 실행되는 흐름.
+- Plugin SSOT 위반 — `plugins/*/skills/**` 외부에서 sync 결과물 (`~/.agents/skills/`, `~/.codex/agents/`) 을 직접 수정하는 코드.
+- `bridge_source` provenance marker 없이 sync target 파일을 prune / 덮어쓰기.
+- Shell injection — 사용자 입력을 quote 없이 shell 명령에 합치는 경우.
+
+### P1 — Performance / Maintainability
+- **Plugin versioning 위반** — `plugins/<name>/.claude-plugin/plugin.json` 와 `.claude-plugin/marketplace.json` 의 version 불일치, `metadata.version` 누락.
+- **Plugin count drift** — 루트 `CLAUDE.md` / `README.md` 의 플러그인 수 / badge / 트리가 marketplace.json 과 어긋남.
+- **`gh api --paginate` + `--jq` 조합에 `--slurp` 누락** — multi-page 응답에서 jq 가 multiple JSON document 받음 (PR #24 의 실제 finding). 단, `gh` 는 `--slurp` 와 `--jq` 동시 사용을 거부하므로 `gh api --paginate --slurp ENDPOINT | jq ...` 패턴을 쓴다.
+- **Idempotency 회귀** — 같은 디렉토리 재실행 시 사용자 파일 덮어쓰기. `[ -f X ] || cp ...` 가드 누락.
+- Skill / command 의 frontmatter 누락 또는 잘못된 `name:` / `description:` (codex-bridge sync 가 깨짐).
+- `Read` / `Edit` 가능한 영역을 `Bash cat` / `Bash sed` 로 우회 (Claude Code 도구 우선 규칙 위반).
+- 새 dependency, GitHub Actions, CI/CD 권한 변경 — 최소 권한, lockfile, supply-chain.
+
+### Domain-specific (Claude Code plugin marketplace)
+- 새 플러그인 추가 / 제거 PR 은 `CLAUDE.md` 플러그인 수, `README.md` badge + 표 + detail + 트리, `marketplace.json` entry + `metadata.version` 4 곳 동시 업데이트 필수.
+- `plugins/codex-bridge/scripts/sync.mjs` 변경 시 `.claude/rules/codex-bridge-sync.md` 의 invariants (SSOT, body-only transform, `bridge_source` 마커, collision guard) 위반 여부 확인.
+- Skill body 의 transform rule (`CLAUDE.md→AGENTS.md`, `.claude/→.codex/`, namespace regex) 은 frontmatter 보존이 contract. 새 rule 추가 시 `bodyOnly: true` 유지.
+- Plugin 캐시 이슈 (`#17361`, `#19197`) — version bump 만으로는 사용자 캐시 갱신 보장 안 됨. 사용자 안내에 `rm -rf ~/.claude/plugins/cache/my-claude-plugins/` 절차 유지.
+
+## CodeRabbit / Codex 조율
+
+이 저장소는 PR 머지 전 자동 리뷰로 **CodeRabbit + ChatGPT-Codex** 를 사용한다. `/github-dev:cr-fix` 명령이 양쪽을 동시에 처리한다 (`plugins/github-dev/commands/cr-fix.md`).
+
+| Source | Tier 정책 |
+|--------|-----------|
+| CR `🚨 Bug` / `⚠️ Potential issue` / `🔒 Security` / `🔴 Critical-High` / `🟠 Major` | `gated` — per-issue 확인 |
+| CR `🛠️ Refactor` (`🟡 Minor` / `🟢 Trivial` / `🟢 Info`) | `auto` — 자동 적용 |
+| CR `📝 Nitpick` | `skip` |
+| Codex P1 (red), P2 (yellow) | `gated` |
+| Codex P3 (green) | `skip` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 Plugin-based configuration for Claude Code with multi-agent orchestration.
 
-## Plugins (21)
+## Plugins (22)
 
 ### Core
 | Plugin | Description |
@@ -45,6 +45,7 @@ Plugin-based configuration for Claude Code with multi-agent orchestration.
 | Plugin | Description |
 |--------|-------------|
 | `interview` | Structured requirements gathering |
+| `project-init` | First-day project bootstrap (.claude/ + CLAUDE.md + AGENTS.md w/ Codex review guidelines + README/CHANGELOG + gh repo create) |
 
 ### Presentation
 | Plugin | Description |
@@ -104,7 +105,8 @@ Plugin-based configuration for Claude Code with multi-agent orchestration.
 │   ├── tcrei-prompt/       # TCREI prompt structuring
 │   ├── codex-bridge/       # OMC → Codex skill sync
 │   ├── llm-wiki/           # LLM-Wiki 3-layer (wiki lore)
-│   └── spec-state/         # spec/issue/PR work-pipeline aggregate
+│   ├── spec-state/         # spec/issue/PR work-pipeline aggregate
+│   └── project-init/       # Day-1 project bootstrap (interview + .claude/ + AGENTS.md + gh repo)
 ├── CLAUDE.md               # This file
 └── README.md               # Full documentation
 ```

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
 
 # my-claude-plugins
 
-Claude Code를 위한 21개 플러그인 모음 - GitHub 워크플로우부터 AI 이미지 생성까지
+Claude Code를 위한 22개 플러그인 모음 - GitHub 워크플로우부터 AI 이미지 생성까지
 
-[![Plugins](https://img.shields.io/badge/plugins-21-blue.svg)](https://github.com/YoungjaeDev/my-claude-plugins)
+[![Plugins](https://img.shields.io/badge/plugins-22-blue.svg)](https://github.com/YoungjaeDev/my-claude-plugins)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-compatible-purple.svg)](https://docs.anthropic.com/claude-code)
 
@@ -76,6 +76,7 @@ rm -rf ~/.claude/plugins/cache/my-claude-plugins/
 | | `tcrei-prompt` | Google TCREI 구조로 프롬프트 재작성 |
 | **Presentation** | `slidev` | Slidev 마크다운 프레젠테이션 생성 (인터뷰 워크플로우) |
 | **Planning** | `interview` | 구조화된 요구사항 수집 |
+| | `project-init` | Day-1 프로젝트 부트스트랩 (.claude/ + CLAUDE.md + AGENTS.md w/ Codex review guidelines + gh repo create) |
 | **Docs** | `docs-forge` | README/CHANGELOG 생성 (CRO 최적화) |
 | | `rules-forge` | CLAUDE.md + .claude/rules/ 자동 모드 감지 생성 (write-rules 스킬) |
 | **Visualization** | `workflow-viz` | 시스템 워크플로우 Mermaid 다이어그램, ASCII 진행 추적 |
@@ -404,6 +405,32 @@ OMC 플러그인 skill 들 (`plugins/*/skills/**/SKILL.md`)을 Codex CLI 가 네
 
 </details>
 
+<details>
+<summary><strong>project-init</strong> - Day-1 프로젝트 부트스트랩</summary>
+
+새 디렉토리에서 단일 `/project-init:new` 한 번으로 인터뷰 → 로컬 시드 → gh 레포 생성 → 초기 커밋/푸시까지 완료.
+
+**시드 결과:**
+- `.claude/{spec,rules,wiki}/` 빈 구조 (`.gitkeep`)
+- `CLAUDE.md` — minimal stub + LLM Wiki 사용 안내
+- `AGENTS.md` — Codex GitHub cloud reviewer 가 자동으로 읽는 `## Review guidelines` 섹션 포함 (variant: general / ml / web)
+- `README.md`, `CHANGELOG.md` — minimal 시드 (각각 6-section, Keep-a-Changelog Unreleased)
+- gh repo create + 초기 commit + push
+
+**원칙:**
+- Minimal seeding — `bootstrap-wiki` / `write-rules` 는 호출 X, 안내만 (빈 프로젝트에 generic 콘텐츠 만들면 사용자 덮어쓰기 비용 발생)
+- Owner gate — personal vs 조직 결정은 `AskUserQuestion` 으로 명시 선택
+- Idempotent — 같은 디렉토리 재호출 시 기존 파일 보존
+
+**Next actions** (`/project-init:new` 완료 후):
+1. 코드 쌓이면 → `/rules-forge:write-rules`
+2. 첫 도메인 lore → `/llm-wiki:bootstrap-wiki`
+3. 첫 PR merge 후 → `/github-dev:post-merge` (자동 `/llm-wiki:post-merge-wiki` 체이닝)
+
+**Requirements:** `gh` CLI authenticated
+
+</details>
+
 ### Presentation
 
 <details>
@@ -558,7 +585,8 @@ CLAUDE.md 와 `.claude/rules/*.md` 를 Claude Code 2026 공식 패턴
 │   ├── tcrei-prompt/          # TCREI 프롬프트 구조화
 │   ├── codex-bridge/          # OMC → Codex skill 동기화
 │   ├── llm-wiki/              # LLM-Wiki 3-layer (wiki lore)
-│   └── spec-state/            # spec/issue/PR work-pipeline aggregate
+│   ├── spec-state/            # spec/issue/PR work-pipeline aggregate
+│   └── project-init/          # Day-1 프로젝트 부트스트랩 (인터뷰 + .claude/ + AGENTS.md + gh repo)
 ├── CLAUDE.md
 └── README.md
 ```

--- a/plugins/project-init/.claude-plugin/plugin.json
+++ b/plugins/project-init/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "project-init",
+  "version": "0.1.0",
+  "description": "One-shot first-day project bootstrap: .claude/ scaffold, minimal CLAUDE.md (LLM-Wiki entrypoint), AGENTS.md with Codex GitHub cloud reviewer guidelines, README/CHANGELOG seed, gh repo create + push. Single command /project-init:new orchestrates interview -> local seed -> remote repo -> initial commit.",
+  "author": {
+    "name": "YoungjaeDev"
+  }
+}

--- a/plugins/project-init/CLAUDE.md
+++ b/plugins/project-init/CLAUDE.md
@@ -17,7 +17,7 @@
 
 ## 파일 구성
 
-```
+```text
 plugins/project-init/
 ├── .claude-plugin/plugin.json
 ├── commands/new.md                     # 단일 orchestration command

--- a/plugins/project-init/CLAUDE.md
+++ b/plugins/project-init/CLAUDE.md
@@ -1,0 +1,78 @@
+# Project-Init Plugin
+
+새 프로젝트의 Day-1 셋업 (`.claude/`, CLAUDE.md, AGENTS.md, README/CHANGELOG, gh repo create+push) 을 단일 `/project-init:new` 명령으로 orchestrate.
+
+## Command
+
+| Command | Description |
+|---------|-------------|
+| `/project-init:new` | 인터뷰 → 로컬 시드 → gh repo 생성 → 초기 커밋/푸시. 명시적 호출 only (자동 트리거 없음). |
+
+## 원칙
+
+- **Minimal seeding, explicit follow-ups**: Day-1 에 필요한 것만 시드. tech-stack 기반 rules 생성과 wiki 도메인 인터뷰는 **호출 X, 안내만**. 빈 프로젝트에 generic 콘텐츠 만들면 사용자 덮어쓰기 비용 발생.
+- **Owner gate is mandatory**: 사용자가 personal + 다중 org 컨텍스트라 owner 자동 결정 금지. `AskUserQuestion` 으로 명시 선택.
+- **Codex GitHub reviewer surface**: AGENTS.md `## Review guidelines` 섹션이 Codex GitHub cloud reviewer 가 자동으로 읽는 영역. **레포 생성 시점에 시드**해야 첫 PR 부터 효과.
+- **Idempotent re-runs**: 같은 디렉토리에서 두 번째 호출 시 기존 파일 보존 + 단계 skip + 안내 메시지. 절대 덮어쓰지 않음.
+
+## 파일 구성
+
+```
+plugins/project-init/
+├── .claude-plugin/plugin.json
+├── commands/new.md                     # 단일 orchestration command
+├── assets/                             # 출력물에 직접 들어가는 템플릿
+│   ├── AGENTS.review-guidelines.md     # general variant (base)
+│   ├── AGENTS.review-guidelines.ml.md  # ML/data variant
+│   ├── AGENTS.review-guidelines.web.md # 웹/풀스택 variant
+│   ├── README.minimal.md
+│   └── CHANGELOG.initial.md
+├── references/                         # 의사결정 context
+│   ├── codex-review-discovery.md       # AGENTS.md vs /review CLI
+│   └── gh-repo-create-flow.md          # owner 추론 + visibility 결정
+├── scripts/
+│   ├── infer-github-context.sh         # gh api user + orgs
+│   └── idempotent-seed.sh              # 충돌 가드 + .claude/ 시드
+└── CLAUDE.md                           # this file
+```
+
+## Placeholder 규약
+
+assets/ 의 템플릿은 다음 placeholder 만 사용한다 (sed 치환):
+
+| Placeholder | 의미 |
+|-------------|------|
+| `{{PROJECT_NAME}}` | 프로젝트 이름 (Phase 1 응답) |
+| `{{ONE_LINER}}` | 한 줄 description |
+| `{{OWNER}}` | personal account 또는 org 이름 |
+| `{{LICENSE}}` | MIT / Apache-2.0 / GPL-3.0 / None |
+| `{{YEAR}}` | 현재 연도 |
+
+추가 placeholder 도입 시 `commands/new.md` Phase 4/5 의 sed 라인을 함께 업데이트.
+
+## AGENTS.md Variant 정책
+
+3 개 파일은 동일한 골격을 공유한다:
+
+1. `## Project context` — `{{PROJECT_NAME}}` + `{{ONE_LINER}}` (1-2 줄)
+2. `## Build / Test / Lint` — 자리 표시자 TODO
+3. `## Review guidelines` — **Codex 클라우드 리뷰어가 읽는 섹션**
+   - `### Do not flag` (린터 영역 — 도구가 처리)
+   - `### P0 — Correctness / Security`
+   - `### P1 — Performance / Maintainability`
+   - `### Domain-specific` (variant 별로 다름; general 은 TODO 만)
+
+variant 차이는 `### Domain-specific` 섹션 + `### P0` / `### P1` 에 도메인별 1-2 항목 추가. **base 위에 도메인 섹션만 다르게** — 코드 중복 최소화.
+
+## Out of Scope
+
+- CI/CD workflow seed (`.github/workflows/`) — variant 별 다양성 너무 큼
+- Pre-commit hook seed — 같은 이유
+- Boilerplate auto-download (cookiecutter, copier) — `/code-scout:scout` 별도 호출
+- Multi-language 인터뷰 분기 — 한/영 혼용 단일 버전 유지
+
+## 참조
+
+- Plugin versioning rules: `.claude/rules/plugin-versioning.md`
+- Codex GitHub integration: https://developers.openai.com/codex/integrations/github
+- 관련 follow-up: `/rules-forge:write-rules`, `/llm-wiki:bootstrap-wiki`

--- a/plugins/project-init/assets/AGENTS.review-guidelines.md
+++ b/plugins/project-init/assets/AGENTS.review-guidelines.md
@@ -1,0 +1,89 @@
+# AGENTS.md
+
+이 저장소에서 Codex (GitHub cloud reviewer + CLI), Cursor, Windsurf, Gemini CLI 등 비-Claude 에이전트가 따라야 할 루트 지침이다. 상세 규칙의 authoritative source 는 `CLAUDE.md` 이며, 이 파일은 빠른 참조와 리뷰 기준을 정리한다.
+
+## Project context
+
+{{PROJECT_NAME}} — {{ONE_LINER}}
+
+Owner: {{OWNER}}
+
+> 코드 일정 수준 쌓이면 `/rules-forge:write-rules` 로 tech-stack 기반 CLAUDE.md + `.claude/rules/*.md` 를 재생성하고, 이 파일도 그 결과에 맞춰 업데이트한다.
+
+## Build / Test / Lint
+
+<!-- TODO: 코드 추가되면 채운다. 예시: -->
+<!-- ```bash -->
+<!-- # Build -->
+<!-- # uv sync               # Python -->
+<!-- # pnpm install          # Node -->
+<!-- -->
+<!-- # Test -->
+<!-- # uv run pytest -q -->
+<!-- # pnpm test -->
+<!-- -->
+<!-- # Lint / Format -->
+<!-- # uv run ruff check . -->
+<!-- # pnpm lint -->
+<!-- ``` -->
+
+## Review guidelines
+
+> 이 섹션은 Codex GitHub cloud reviewer 가 자동으로 읽는 영역이다 ([공식 문서](https://developers.openai.com/codex/integrations/github)). 한국어로 리뷰한다. 발견사항은 영향 + 근거 (파일/라인) + 수정 방향 순서로 제시한다. 근거가 부족하면 `unverified` 로 표시한다.
+
+### Do not flag (린터/포매터 영역)
+
+- 들여쓰기, 줄바꿈, 따옴표 스타일 — 포매터 (`ruff format`, `prettier`, `gofmt` 등) 가 처리한다.
+- import 순서, alphabetization — `ruff --select I`, `eslint-plugin-import` 가 처리한다.
+- 단순 typo / 영문 문법 — 결함으로 이어지지 않는 한 코멘트하지 않는다.
+- 변수명 취향, 한 줄 짜리 helper 추출 같은 단순 리팩터링 — 동작 변경이 없으면 skip.
+- 주석/문서 문구 개선 — 의미가 틀린 것이 아니면 skip.
+
+### P0 — Correctness / Security (반드시 차단)
+
+- Secret / API key / token 노출, `.env` / credentials 파일 commit.
+- 인증/권한 우회, 사용자 데이터 또는 원본 산출물 (DB, 모델 체크포인트, gt 라벨) 파괴 가능성.
+- `rm -rf`, `git push --force`, `DROP TABLE` 류 destructive command 가 사용자 확인 없이 실행되는 흐름.
+- SQL injection, command injection, path traversal, SSRF, unsafe deserialization (pickle / eval / unserialize).
+- Untrusted PR input 을 직접 shell / DB 쿼리로 흘리는 경로.
+
+### P1 — Performance / Maintainability
+
+- 데이터 저장 / 마이그레이션 / 동기화 변경에서 atomicity, idempotency, rollback, partial-failure 처리가 빠진 경우.
+- Public API, schema, config/env var, serialization format 변경이 하위 호환성 또는 docs/test 없이 들어온 경우.
+- 핵심 로직 변경에 regression test 가 없거나, 실패한 검증을 무시하거나, 검증 불가 사유가 없는 경우.
+- 새 dependency, GitHub Actions, CI/CD 권한 변경 — 최소 권한, lockfile, supply-chain, secret exposure 관점.
+- 명시된 invariant (재현성 기준, 데이터 보존, 아키텍처 계층 경계, 런타임/패키지 관리 규칙) 위반.
+- O(N²) 이상의 알고리즘이 hot path 에 추가됐는데 입력 크기 가정이 없는 경우.
+
+### Domain-specific
+
+<!-- TODO: 프로젝트 도메인 규칙을 여기에 추가한다. 예시는 `.claude/rules/*.md` 가 채워지면 거기로 옮기고 여기서는 `@.claude/rules/<file>.md` 참조만 둔다. -->
+
+## CodeRabbit / Codex 조율
+
+이 저장소는 PR 머지 전 자동 리뷰로 **CodeRabbit + ChatGPT-Codex** 를 사용한다. `/github-dev:cr-fix` 명령이 양쪽을 동시에 처리한다.
+
+| Source | Tier 정책 |
+|--------|-----------|
+| CodeRabbit `🚨 Bug` / `⚠️ Potential issue` / `🔒 Security` / `🔴 Critical-High` / `🟠 Major` | `gated` — 사용자 per-issue 확인 |
+| CodeRabbit `🛠️ Refactor` (`🟡 Minor` / `🟢 Trivial` / `🟢 Info`) | `auto` — 자동 적용 |
+| CodeRabbit `📝 Nitpick` | `skip` — 노출 X |
+| Codex P1 (red), P2 (yellow) | `gated` |
+| Codex P3 (green) | `skip` |
+
+리뷰는 한국어로 작성하되, CR / Codex 의 영어 코멘트는 그대로 받아 들인다.
+
+## 완료 보고
+
+- 변경한 핵심 파일과 동작 변화를 짧게 말한다.
+- 실행한 검증 명령과 결과를 말한다.
+- 실행하지 못한 검증이 있으면 이유를 밝힌다.
+- 발견했지만 범위 밖인 문제는 임의로 고치지 말고 별도 메모로만 언급한다.
+
+## Anti-patterns
+
+- AI / Claude attribution 을 커밋, PR, 이슈, 문서에 추가하지 않는다.
+- 이모지를 코드와 문서에 넣지 않는다.
+- Drive-by refactor — 요청 범위 밖 코드를 임의로 리팩터링하지 않는다.
+- 출력 파일, 임시 파일, 분석 산출물을 프로젝트 루트에 만들지 않는다.

--- a/plugins/project-init/assets/AGENTS.review-guidelines.ml.md
+++ b/plugins/project-init/assets/AGENTS.review-guidelines.ml.md
@@ -1,0 +1,96 @@
+# AGENTS.md
+
+이 저장소에서 Codex (GitHub cloud reviewer + CLI), Cursor, Windsurf, Gemini CLI 등 비-Claude 에이전트가 따라야 할 루트 지침이다. 상세 규칙의 authoritative source 는 `CLAUDE.md` 이며, 이 파일은 빠른 참조와 리뷰 기준을 정리한다.
+
+## Project context
+
+{{PROJECT_NAME}} — {{ONE_LINER}}
+
+Owner: {{OWNER}}
+Domain: ML / data — 모델 학습, 평가, 추론, 데이터 처리 파이프라인 중심.
+
+> 코드 일정 수준 쌓이면 `/rules-forge:write-rules` 로 tech-stack 기반 CLAUDE.md + `.claude/rules/*.md` 를 재생성하고, 이 파일도 그 결과에 맞춰 업데이트한다.
+
+## Build / Test / Lint
+
+<!-- TODO: 코드 추가되면 채운다. ML 프로젝트 기본 패턴: -->
+<!-- ```bash -->
+<!-- # 환경 -->
+<!-- # uv sync                             # Python deps -->
+<!-- # uv pip install --index-strategy unsafe-best-match -r requirements.lock  # PyTorch cu124 등 multi-index 시 -->
+<!-- -->
+<!-- # 학습 / 평가 -->
+<!-- # uv run python scripts/train.py --config configs/base.yaml -->
+<!-- # uv run python scripts/eval.py --checkpoint <path> -->
+<!-- -->
+<!-- # 테스트 / 린트 -->
+<!-- # uv run pytest -q -->
+<!-- # uv run ruff check . -->
+<!-- # uv run python -m py_compile <file.py>  # 빠른 syntax 체크 -->
+<!-- ``` -->
+
+## Review guidelines
+
+> 이 섹션은 Codex GitHub cloud reviewer 가 자동으로 읽는 영역이다 ([공식 문서](https://developers.openai.com/codex/integrations/github)). 한국어로 리뷰한다. 발견사항은 영향 + 근거 (파일/라인) + 수정 방향 순서로 제시한다. 근거가 부족하면 `unverified` 로 표시한다.
+
+### Do not flag (린터/포매터 영역)
+
+- 들여쓰기, 줄바꿈, 따옴표 스타일 — `ruff format`, `black` 등 포매터가 처리.
+- import 순서 — `ruff --select I` 가 처리.
+- 단순 typo / 영문 문법, 변수명 취향 — 결함이 아니면 skip.
+- numpy/torch 차원 표현식 (`x[None, ...]` vs `x.unsqueeze(0)`) 같은 스타일 — 정확성 문제 아니면 skip.
+
+### P0 — Correctness / Security
+
+- Secret / API key (HF_TOKEN, WANDB_API_KEY, OPENAI_API_KEY, CLOUD creds) 노출.
+- 원본 데이터셋 (raw video, gt 라벨, manifest) 파괴 가능성. 사람 검수 결과 (`*_human_reviewed*.json`) 덮어쓰기.
+- 학습 결과 (checkpoint, 평가 JSON) 의 unsafe deserialization (`torch.load` `weights_only=False`, pickle).
+- Destructive command (`rm -rf`, `git push --force`, RunPod pod 삭제) 가 사용자 확인 없이 실행되는 흐름.
+
+### P1 — Performance / Maintainability
+
+- **재현성 회귀** — random seed, 데이터 split, 프롬프트/하이퍼파라미터 변경에 frozen hash 가 깨졌는데 의도적 변경 표시 없음.
+- **데이터 origin 혼선** — 학습/평가/테스트 split 누수, train data 가 eval set 으로 흘러가는 경로.
+- **메모리 / GPU 점유** — `torch.no_grad()` 누락, batch 누적, dataloader `num_workers` 가 hot path 에 거대한 값.
+- **Atomic write 회귀** — JSON / 모델 저장에 `path.write_text(json.dumps(...))` 직접 사용. tempfile + fsync + os.replace 패턴 깨짐.
+- **Tokenizer / preprocessing drift** — 학습 시 사용한 normalization 과 추론 시 normalization 이 silently 다른 경우.
+- 새 dependency (특히 CUDA wheel, PyTorch index), GitHub Actions 권한 변경 — 최소 권한, lockfile 동기화.
+- 명시된 invariant (데이터 보존 정책, 학습 reproducibility hash) 위반.
+
+### Domain-specific (ML)
+
+- **decord / cv2 / PIL 혼용 금지** — 동일 파이프라인 내에서 frame 추출 라이브러리 일관성. 비디오는 `decord.VideoReader` 기본.
+- **dataloader worker 수와 memory_format** — 학습 스크립트 변경 시 OOM 이나 throughput 회귀를 야기할 수 있는 매개변수는 명시적 근거 필요.
+- **LoRA / adapter 학습** — base model freeze 가 실제로 적용됐는지, optimizer 가 trainable 만 보고 있는지 확인.
+- **Mixed precision (fp16 / bf16)** — gradient overflow, NaN 처리 누락 시 학습이 silently 망가짐. `GradScaler` 사용 시 step 순서 확인.
+- **Evaluation metric** — top-1 / top-5, mAP, F1 등 계산식 변경은 기존 baseline 과 비교 가능성 깨뜨림. metric 변경은 별도 PR 로 분리 권장.
+- **vLLM / OpenRouter / 직접 API 백엔드 분기** — 동일 결과를 보장하는 backend 가 아니므로 backend 가 바뀌면 결과도 재측정해야 한다.
+
+<!-- 코드 일정 수준 쌓이면 `.claude/rules/ml.md` 또는 `.claude/rules/training.md` 에 분리하고 여기서는 `@.claude/rules/<file>.md` 로 참조. -->
+
+## CodeRabbit / Codex 조율
+
+이 저장소는 PR 머지 전 자동 리뷰로 **CodeRabbit + ChatGPT-Codex** 를 사용한다. `/github-dev:cr-fix` 명령이 양쪽을 동시에 처리한다.
+
+| Source | Tier 정책 |
+|--------|-----------|
+| CodeRabbit `🚨 Bug` / `⚠️ Potential issue` / `🔒 Security` / `🔴 Critical-High` / `🟠 Major` | `gated` — 사용자 per-issue 확인 |
+| CodeRabbit `🛠️ Refactor` (`🟡 Minor` / `🟢 Trivial` / `🟢 Info`) | `auto` — 자동 적용 |
+| CodeRabbit `📝 Nitpick` | `skip` |
+| Codex P1 (red), P2 (yellow) | `gated` |
+| Codex P3 (green) | `skip` |
+
+## 완료 보고
+
+- 변경한 핵심 파일, 동작 변화, 영향받은 metric / checkpoint 를 짧게 말한다.
+- 실행한 검증 (테스트, py_compile, 1-batch smoke run) 과 결과를 말한다.
+- 실행하지 못한 검증 (예: 전체 학습) 이 있으면 이유 + 추정 비용을 밝힌다.
+- 발견했지만 범위 밖인 문제는 임의로 고치지 말고 별도 메모로만 언급한다.
+
+## Anti-patterns
+
+- AI / Claude attribution 을 커밋, PR, 이슈, 문서에 추가하지 않는다.
+- 이모지를 코드와 문서에 넣지 않는다.
+- Drive-by refactor — 요청 범위 밖 코드를 임의로 리팩터링하지 않는다.
+- 출력 파일, 체크포인트, 분석 노트북을 프로젝트 루트에 만들지 않는다 (`outputs/` 등 dedicated 디렉토리).
+- `python` / `python3` 직접 호출 금지. `uv run python` 사용.

--- a/plugins/project-init/assets/AGENTS.review-guidelines.web.md
+++ b/plugins/project-init/assets/AGENTS.review-guidelines.web.md
@@ -1,0 +1,100 @@
+# AGENTS.md
+
+이 저장소에서 Codex (GitHub cloud reviewer + CLI), Cursor, Windsurf, Gemini CLI 등 비-Claude 에이전트가 따라야 할 루트 지침이다. 상세 규칙의 authoritative source 는 `CLAUDE.md` 이며, 이 파일은 빠른 참조와 리뷰 기준을 정리한다.
+
+## Project context
+
+{{PROJECT_NAME}} — {{ONE_LINER}}
+
+Owner: {{OWNER}}
+Domain: Web / fullstack — frontend + backend API 통합 프로젝트.
+
+> 코드 일정 수준 쌓이면 `/rules-forge:write-rules` 로 tech-stack 기반 CLAUDE.md + `.claude/rules/*.md` 를 재생성하고, 이 파일도 그 결과에 맞춰 업데이트한다.
+
+## Build / Test / Lint
+
+<!-- TODO: 코드 추가되면 채운다. Web 프로젝트 기본 패턴: -->
+<!-- ```bash -->
+<!-- # Install -->
+<!-- # pnpm install   # 또는 npm / yarn / bun -->
+<!-- -->
+<!-- # Dev server -->
+<!-- # pnpm dev -->
+<!-- -->
+<!-- # Test -->
+<!-- # pnpm test          # 단위 테스트 (vitest / jest) -->
+<!-- # pnpm test:e2e      # E2E (playwright / cypress) -->
+<!-- -->
+<!-- # Lint / Type-check -->
+<!-- # pnpm lint -->
+<!-- # pnpm typecheck     # tsc --noEmit -->
+<!-- ``` -->
+
+## Review guidelines
+
+> 이 섹션은 Codex GitHub cloud reviewer 가 자동으로 읽는 영역이다 ([공식 문서](https://developers.openai.com/codex/integrations/github)). 한국어로 리뷰한다. 발견사항은 영향 + 근거 (파일/라인) + 수정 방향 순서로 제시한다. 근거가 부족하면 `unverified` 로 표시한다.
+
+### Do not flag (린터/포매터 영역)
+
+- 들여쓰기, 따옴표, 세미콜론 스타일 — Prettier / Biome 가 처리.
+- import 순서 — ESLint `import/order` 가 처리.
+- 단순 typo / 영문 문법, 변수명 취향 — 결함이 아니면 skip.
+- React component file 안 hook 순서 micro-optimization — 정확성 문제 아니면 skip.
+
+### P0 — Correctness / Security
+
+- Secret / API key 가 client bundle 로 노출 (`NEXT_PUBLIC_*` 에 server-only 키 포함).
+- XSS — `dangerouslySetInnerHTML` 에 unsanitized user input, `v-html` 에 raw HTML.
+- SQL injection / NoSQL injection — ORM 우회한 raw query 에 user input concat.
+- Auth bypass — middleware 누락된 protected route, JWT verification skip.
+- CSRF — state-changing endpoint 에 SameSite / origin check 누락.
+- 사용자 데이터 (DB row, 파일 storage, session token) destructive 변경이 transaction / undo 없이 실행.
+- `npm`/`pnpm` 새 의존성 supply-chain — lockfile 변경 동반되지 않거나 typosquat 의심.
+
+### P1 — Performance / Maintainability
+
+- **N+1 쿼리** — loop 안에서 ORM/fetch 가 호출되는 경로.
+- **Server / Client component 경계 위반** (Next.js App Router) — `"use client"` 누락 또는 server-only 모듈을 client component 에서 import.
+- **데이터 mutation 변경** — atomicity, idempotency, rollback, partial-failure 처리가 빠진 경우.
+- **Public API / schema / config / env var 변경** 이 하위 호환성 또는 docs/test 없이 들어온 경우.
+- **Regression test 부재** — 핵심 로직 변경에 단위/통합 테스트 없음.
+- 새 dependency, GitHub Actions, CI/CD 권한 변경 — 최소 권한, lockfile, supply-chain.
+- 명시된 invariant (아키텍처 계층 경계, 런타임/패키지 관리 규칙) 위반.
+
+### Domain-specific (Web)
+
+- **Hydration mismatch** — SSR 렌더 결과와 client 첫 렌더가 다른 경우 (`Date.now()`, `Math.random()` 사용, `useEffect` 없이 `localStorage` 접근).
+- **Form validation** — 서버사이드 validation 누락 (client validation 만으로 충분하지 않음).
+- **Loading / error / empty state** — 데이터 fetch 컴포넌트가 success path 만 다루는 경우.
+- **Accessibility (a11y)** — `<button>` 대신 `<div onClick>`, `<img alt>` 누락, focus management 깨짐.
+- **CORS / cookie SameSite** — 인증 쿠키 정책이 새 도메인 추가 시 함께 업데이트되는지.
+- **Bundle size 회귀** — heavy library 가 client bundle 에 새로 들어가는데 dynamic import 미사용.
+- **DB migration** — schema 변경에 down migration 또는 backfill 전략 부재.
+
+<!-- 코드 일정 수준 쌓이면 `.claude/rules/frontend.md`, `.claude/rules/backend.md`, `.claude/rules/db.md` 로 분리하고 여기서는 `@.claude/rules/<file>.md` 로 참조. -->
+
+## CodeRabbit / Codex 조율
+
+이 저장소는 PR 머지 전 자동 리뷰로 **CodeRabbit + ChatGPT-Codex** 를 사용한다. `/github-dev:cr-fix` 명령이 양쪽을 동시에 처리한다.
+
+| Source | Tier 정책 |
+|--------|-----------|
+| CodeRabbit `🚨 Bug` / `⚠️ Potential issue` / `🔒 Security` / `🔴 Critical-High` / `🟠 Major` | `gated` — 사용자 per-issue 확인 |
+| CodeRabbit `🛠️ Refactor` (`🟡 Minor` / `🟢 Trivial` / `🟢 Info`) | `auto` — 자동 적용 |
+| CodeRabbit `📝 Nitpick` | `skip` |
+| Codex P1 (red), P2 (yellow) | `gated` |
+| Codex P3 (green) | `skip` |
+
+## 완료 보고
+
+- 변경한 핵심 파일, 동작 변화, 영향받은 page / API endpoint 를 짧게 말한다.
+- 실행한 검증 (테스트, typecheck, lint, dev server 수동 확인) 과 결과를 말한다.
+- 실행하지 못한 검증 (예: E2E 전체) 이 있으면 이유를 밝힌다.
+- 발견했지만 범위 밖인 문제는 임의로 고치지 말고 별도 메모로만 언급한다.
+
+## Anti-patterns
+
+- AI / Claude attribution 을 커밋, PR, 이슈, 문서에 추가하지 않는다.
+- 이모지를 코드와 문서에 넣지 않는다.
+- Drive-by refactor — 요청 범위 밖 코드를 임의로 리팩터링하지 않는다.
+- 출력 파일, 빌드 산출물을 프로젝트 루트에 만들지 않는다 (`dist/`, `.next/` 등 dedicated 디렉토리, gitignore 대상).

--- a/plugins/project-init/assets/CHANGELOG.initial.md
+++ b/plugins/project-init/assets/CHANGELOG.initial.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes to {{PROJECT_NAME}} are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- Initial project skeleton bootstrapped via `/project-init:new`.
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+[Unreleased]: https://github.com/{{OWNER}}/{{PROJECT_NAME}}/commits/main

--- a/plugins/project-init/assets/README.minimal.md
+++ b/plugins/project-init/assets/README.minimal.md
@@ -1,0 +1,47 @@
+# {{PROJECT_NAME}}
+
+{{ONE_LINER}}
+
+<!-- TODO: badge placeholders. CI / coverage / version 추가 후 채운다. -->
+<!-- [![CI](https://github.com/{{OWNER}}/{{PROJECT_NAME}}/actions/workflows/ci.yml/badge.svg)](https://github.com/{{OWNER}}/{{PROJECT_NAME}}/actions) -->
+
+## About
+
+<!-- 1-2 문단으로 무엇을, 누구를 위해, 어떤 문제를 해결하는지. -->
+
+## Getting Started
+
+### Prerequisites
+
+<!-- 의존하는 런타임 / 도구. 예시:
+- Python 3.10+ (또는 Node 18+, Go 1.21+ 등)
+- `uv` (Python 의존성 관리) — `curl -LsSf https://astral.sh/uv/install.sh | sh`
+- `gh` CLI (GitHub 워크플로용)
+-->
+
+### Installation
+
+```bash
+git clone https://github.com/{{OWNER}}/{{PROJECT_NAME}}.git
+cd {{PROJECT_NAME}}
+
+# TODO: install steps
+# uv sync
+# pnpm install
+```
+
+## Usage
+
+<!-- 가장 기본적인 사용 예시 한두 개. -->
+
+```bash
+# TODO: minimal example
+```
+
+## License
+
+{{LICENSE}}
+
+---
+
+> 이 README 는 `/project-init:new` 가 만든 minimal 시드다. 기능이 쌓이면 `/docs-forge:readme` 로 CRO 베스트 프랙티스 적용 + `/humanizer:humanize` 로 AI 패턴 제거를 권장한다.

--- a/plugins/project-init/commands/new.md
+++ b/plugins/project-init/commands/new.md
@@ -233,12 +233,21 @@ case "$vis_lower" in
   *) echo "[abort] Unknown visibility: $VISIBILITY"; exit 1 ;;
 esac
 
-# Repo create + push (dry-run preview first, then real run)
-PREVIEW="gh repo create ${OWNER}/${PROJECT_NAME} --${VIS_FLAG} --description \"${ONE_LINER}\" --source=. --remote=origin --push"
-echo "$PREVIEW"
+# Idempotent re-run 가드: origin remote 가 이미 있으면 `gh repo create
+# --remote=origin` 이 중복 등록을 시도하다 실패한다. 기존 remote 가 가리키는
+# URL 을 노출하고 사용자에게 manual push 명령을 안내한다.
+if git remote get-url origin >/dev/null 2>&1; then
+  EXISTING=$(git remote get-url origin)
+  echo "[skip] origin remote already exists ($EXISTING) — skipping gh repo create."
+  echo "       manual sync: git push -u origin $(git branch --show-current)"
+else
+  # Repo create + push (dry-run preview first, then real run)
+  PREVIEW="gh repo create ${OWNER}/${PROJECT_NAME} --${VIS_FLAG} --description \"${ONE_LINER}\" --source=. --remote=origin --push"
+  echo "$PREVIEW"
 
-# User confirms via AskUserQuestion (Recommended: "Run")
-gh repo create "${OWNER}/${PROJECT_NAME}" --"${VIS_FLAG}" --description "${ONE_LINER}" --source=. --remote=origin --push
+  # User confirms via AskUserQuestion (Recommended: "Run")
+  gh repo create "${OWNER}/${PROJECT_NAME}" --"${VIS_FLAG}" --description "${ONE_LINER}" --source=. --remote=origin --push
+fi
 ```
 
 License 가 None 이 아니면 — gh repo create 후 `gh api` 로 LICENSE 파일 생성하거나 사용자에게 "later" 안내. 단순화를 위해 V1 에서는 안내만.

--- a/plugins/project-init/commands/new.md
+++ b/plugins/project-init/commands/new.md
@@ -127,10 +127,6 @@ placeholder (`<project_name>`, `<one-line description>`) 는 Phase 1 응답으�
 > 응답을 `VARIANT` 변수에 할당 (예: `general` / `ml` / `web`). 사용자가 비워두거나 응답 누락 시 default `VARIANT=general`.
 
 ```bash
-SRC="${CLAUDE_PLUGIN_ROOT}/assets/AGENTS.review-guidelines.${VARIANT}.md"
-# Variant 가 general 이면 base 파일
-[ "$VARIANT" = "general" ] && SRC="${CLAUDE_PLUGIN_ROOT}/assets/AGENTS.review-guidelines.md"
-
 # Portable in-place sed — GNU sed 는 `sed -i 'cmd' file`, BSD/macOS sed 는
 # `sed -i '' 'cmd' file` 시그니처. `sed --version` 으로 분기한다.
 if sed --version >/dev/null 2>&1; then
@@ -138,6 +134,24 @@ if sed --version >/dev/null 2>&1; then
 else
   sed_inplace() { sed -i '' "$@"; }
 fi
+
+# POSIX 소문자화 — ${VAR,,} 는 Bash 4+ 전용이라 macOS 기본 /bin/bash (3.2) 에서
+# bad substitution 으로 깨진다. tr 로 대체 (Phase 6 visibility 정규화에서도 재사용).
+to_lower() { printf '%s' "$1" | tr '[:upper:]' '[:lower:]'; }
+
+# AskUserQuestion 라벨 ("ml (Recommended)" / "web" / "general") 을
+# 파일명 토큰 (general|ml|web) 으로 정규화. 알 수 없는 값은 abort.
+variant_lower=$(to_lower "$VARIANT")
+case "$variant_lower" in
+  *ml*)         VARIANT_FLAG="ml" ;;
+  *web*)        VARIANT_FLAG="web" ;;
+  *general*|"") VARIANT_FLAG="general" ;;
+  *) echo "[abort] Unknown variant: $VARIANT"; exit 1 ;;
+esac
+
+SRC="${CLAUDE_PLUGIN_ROOT}/assets/AGENTS.review-guidelines.${VARIANT_FLAG}.md"
+# Variant 가 general 이면 base 파일
+[ "$VARIANT_FLAG" = "general" ] && SRC="${CLAUDE_PLUGIN_ROOT}/assets/AGENTS.review-guidelines.md"
 
 # sed replacement 컨텍스트에서 위험한 문자 (\, &, |) escape — 사용자 입력에
 # "Frontend & Backend" 같은 `&` 가 있으면 sed 가 매치 전체를 다시 삽입한다.
@@ -203,8 +217,10 @@ git commit -m "chore: bootstrap project skeleton via project-init"
 
 ```bash
 # AskUserQuestion 라벨 ("Private (Recommended)", "Public", "Internal") 을
-# gh CLI 가 받는 단일 토큰 (private|public|internal) 으로 정규화.
-case "${VISIBILITY,,}" in
+# gh CLI 토큰 (private|public|internal) 으로 정규화.
+# Phase 4 의 to_lower 헬퍼 재사용 (POSIX tr — Bash 3.2 호환).
+vis_lower=$(to_lower "$VISIBILITY")
+case "$vis_lower" in
   *private*)  VIS_FLAG="private" ;;
   *public*)   VIS_FLAG="public" ;;
   *internal*) VIS_FLAG="internal" ;;

--- a/plugins/project-init/commands/new.md
+++ b/plugins/project-init/commands/new.md
@@ -206,11 +206,17 @@ done
 # Git init if needed
 [ -d .git ] || git init -b main
 
-# Stage all seeded files
+# Stage all seeded files (이미 존재한 파일은 git add 가 no-op)
 git add .claude/ CLAUDE.md AGENTS.md README.md CHANGELOG.md
 
-# Initial commit
-git commit -m "chore: bootstrap project skeleton via project-init"
+# Idempotent re-run 경로: Phase 4/5 가 모두 skip 했고 staged diff 가 없으면
+# `git commit` 이 `nothing to commit` 으로 실패해 이후 gh repo create 까지
+# abort 된다. staged 변경 존재 여부로 분기한다.
+if ! git diff --cached --quiet; then
+  git commit -m "chore: bootstrap project skeleton via project-init"
+else
+  echo "[skip] no new changes to commit — idempotent re-run path"
+fi
 ```
 
 `AskUserQuestion`: dry-run 미리보기 후 confirm.

--- a/plugins/project-init/commands/new.md
+++ b/plugins/project-init/commands/new.md
@@ -1,0 +1,221 @@
+---
+description: First-day project bootstrap — interview, .claude/ scaffold, CLAUDE.md + AGENTS.md (Codex reviewer guidelines) + README + CHANGELOG seed, gh repo create + initial push
+---
+
+# /project-init:new
+
+새 디렉토리에서 한 번 호출해 "Day 1 ready" 프로젝트를 만든다 — 인터뷰 → 로컬 시드 → gh 레포 생성 → 초기 커밋/푸시.
+
+> **Trigger surface**: 명시적 user invocation 만. 자동 트리거 없음 (잘못된 디렉토리에서 실행되면 위험).
+
+## 핵심 원칙
+
+- **Minimal seeding, explicit follow-ups**: Day 1 에 진짜 필요한 것 (`.claude/` 빈 구조, CLAUDE.md stub, AGENTS.md review guidelines, README/CHANGELOG, gh 레포) 만 시드. tech-stack 기반 rules 생성 (`/rules-forge:write-rules`) 와 wiki domain 인터뷰 (`/llm-wiki:bootstrap-wiki`) 는 **호출하지 않고 Phase 7 안내만**. 빈 프로젝트에 generic 콘텐츠 생성하면 사용자가 덮어쓰는 비용 발생.
+- **Owner gate is mandatory**: 사용자가 부업 컨텍스트 (개인 + 조직 레포) 를 가져 owner 결정은 자동화 금지 — Phase 1 인터뷰에서 반드시 묻는다.
+- **Codex GitHub reviewer surface**: `AGENTS.md` 의 `## Review guidelines` 섹션이 Codex GitHub cloud reviewer 가 자동으로 읽는 영역. 레포 생성 시점에 시드해야 첫 PR 부터 효과.
+
+## 사전 조건
+
+- `gh` CLI 설치 + `gh auth status` OK
+- `git` 설치
+- 현재 디렉토리가 작업 대상 — `pwd` 출력을 사용자에게 보여주고 진행 확인
+
+## Phase 0 — Preflight (자동, no prompt)
+
+```bash
+# 인증 확인
+gh auth status || { echo "[abort] gh CLI not authenticated. Run: gh auth login"; exit 1; }
+
+# Git identity 추출
+GIT_USER_NAME=$(git config --global user.name || echo "")
+GIT_USER_EMAIL=$(git config --global user.email || echo "")
+
+# 현재 디렉토리 상태 진단
+CWD=$(pwd)
+DIR_NAME=$(basename "$CWD")
+HAS_GIT=$([ -d .git ] && echo "yes" || echo "no")
+HAS_CLAUDE=$([ -d .claude ] && echo "yes" || echo "no")
+HAS_CODE=$(find . -maxdepth 2 -type f \( -name "*.py" -o -name "*.ts" -o -name "*.js" -o -name "*.go" -o -name "*.rs" -o -name "*.java" \) 2>/dev/null | head -1 | wc -l)
+
+# GitHub owner 후보 수집
+bash ${CLAUDE_PLUGIN_ROOT}/scripts/infer-github-context.sh
+# 출력: JSON { "personal": "<login>", "orgs": ["<org1>", "<org2>", ...] }
+```
+
+만약 `HAS_CLAUDE=yes` 또는 `.git/` 안에 commit 가 이미 있는 경우 — **idempotency guard** 발동:
+- `AskUserQuestion` 으로 "이미 셋업된 디렉토리. 계속 시도하면 기존 파일은 보존되지만 일부 단계가 skip 됨. 계속?" 확인.
+
+## Phase 1 — Project Identity Interview
+
+**Single batched `AskUserQuestion` — 4 questions** (description 은 자유 텍스트라 Other 로 받음).
+
+Question 1: **Project name**
+- header: "Name"
+- options: `<DIR_NAME>` (default) / "Custom (Other)"
+
+Question 2: **Owner**
+- header: "Owner"
+- options: 동적 생성 — Phase 0 의 personal account + 모든 orgs. 각 옵션 description 에 "Personal" / "Organization" 표시.
+
+Question 3: **Visibility**
+- header: "Visibility"
+- options: "Private (Recommended)" / "Public"
+- (org owner 면 "Internal" 추가)
+
+Question 4: **License**
+- header: "License"
+- options: "MIT (Recommended)" / "Apache-2.0" / "GPL-3.0" / "None"
+
+> Description (one-liner) 은 별도 평문 질문 X — Phase 1 응답 받은 직후 평문으로 한 줄 짧게 묻거나, AskUserQuestion 의 Other 입력으로 받는다. 평문 description 입력이 더 자연스러우므로 별도 짧은 질문 1 회 허용.
+
+## Phase 2 — `.claude/` Scaffold (structure only)
+
+```bash
+bash ${CLAUDE_PLUGIN_ROOT}/scripts/idempotent-seed.sh ensure-claude-dirs
+# 생성: .claude/{spec,rules,wiki}/.gitkeep
+```
+
+`bootstrap-wiki` / `write-rules` 는 호출하지 않는다 — 빈 프로젝트에는 적을 lore 도, tech-stack signal 도 없다.
+
+## Phase 3 — CLAUDE.md Minimal Stub
+
+기존 `CLAUDE.md` 가 있으면 skip with notice. 없으면 다음 형태로 작성:
+
+```markdown
+# <project_name>
+
+<one-line description>
+
+## LLM Wiki (`.claude/wiki/`)
+
+이 프로젝트는 Karpathy LLM-Wiki 3-layer 시스템 위에 동작한다. 도메인 lore (provider quirks, design rationale, debugging stories) 는 wiki 가 보관한다.
+
+- **진입점**: `.claude/wiki/index.md` (Map of Content). 페이지 직접 grep 금지.
+- **사용 순서**:
+  1. lore 가 필요할 때 → `/llm-wiki:query-wiki` 먼저
+  2. 새 발견 → `/llm-wiki:ingest-finding`
+  3. PR merge 후 → `/github-dev:post-merge` 가 자동으로 `/llm-wiki:post-merge-wiki` 체이닝
+- **현재 상태**: wiki 비어있음. 적극 채워라. 첫 도메인 lore 가 쌓이기 시작하면 `/llm-wiki:bootstrap-wiki` 호출로 도메인 구조 인터뷰를 받는다.
+
+## Setup Status
+
+이 파일은 `/project-init:new` 가 만든 minimal stub 이다. 코드가 어느 정도 쌓이면 다음을 호출해라:
+
+- `/rules-forge:write-rules` — tech-stack 기반 CLAUDE.md + `.claude/rules/*.md` 재생성
+- `/llm-wiki:bootstrap-wiki` — 첫 wiki 도메인 인터뷰 + 템플릿 시드
+
+> 사용자의 global `~/.claude/CLAUDE.md` 가 항상 우선한다. 이 파일은 프로젝트 한정 규칙만 보관한다.
+```
+
+placeholder (`<project_name>`, `<one-line description>`) 는 Phase 1 응답으로 치환.
+
+## Phase 4 — AGENTS.md Seed (★ 이 플러그인의 차별점)
+
+**Variant 선택**: Phase 1 description 키워드로 추천하되 사용자 확인.
+
+| Keyword in description | Recommended variant |
+|------------------------|---------------------|
+| "deep learning", "ML", "model", "training", "dataset", "vision", "NLP" | `ml` |
+| "web", "fullstack", "frontend", "backend", "API", "REST", "GraphQL" | `web` |
+| 그 외 / 명확하지 않음 | `general` (base) |
+
+`AskUserQuestion`:
+- header: "Variant"
+- options: "<recommended> (Recommended)" / 나머지 2 개
+
+```bash
+SRC="${CLAUDE_PLUGIN_ROOT}/assets/AGENTS.review-guidelines.${VARIANT}.md"
+# Variant 가 general 이면 base 파일
+[ "$VARIANT" = "general" ] && SRC="${CLAUDE_PLUGIN_ROOT}/assets/AGENTS.review-guidelines.md"
+
+cp "$SRC" AGENTS.md
+# placeholder 치환
+sed -i "s|{{PROJECT_NAME}}|${PROJECT_NAME}|g" AGENTS.md
+sed -i "s|{{ONE_LINER}}|${ONE_LINER}|g" AGENTS.md
+sed -i "s|{{OWNER}}|${OWNER}|g" AGENTS.md
+```
+
+AGENTS.md 의 `## Review guidelines` 섹션은 Codex GitHub cloud reviewer 가 자동으로 읽는다 ([OpenAI Codex GitHub integration](https://developers.openai.com/codex/integrations/github)) — 사용자에게 한 줄 안내.
+
+## Phase 5 — README + CHANGELOG
+
+```bash
+[ -f README.md ] || cp ${CLAUDE_PLUGIN_ROOT}/assets/README.minimal.md README.md
+[ -f CHANGELOG.md ] || cp ${CLAUDE_PLUGIN_ROOT}/assets/CHANGELOG.initial.md CHANGELOG.md
+
+sed -i "s|{{PROJECT_NAME}}|${PROJECT_NAME}|g" README.md CHANGELOG.md
+sed -i "s|{{ONE_LINER}}|${ONE_LINER}|g" README.md
+sed -i "s|{{OWNER}}|${OWNER}|g" README.md
+sed -i "s|{{LICENSE}}|${LICENSE}|g" README.md
+```
+
+게이트: README.md 첫 30줄 미리보기 후 수정 기회. 한 번 더 호출하지 않고 inline `Edit` 로 즉시 수정.
+
+## Phase 6 — GitHub Repo Creation
+
+```bash
+# Git init if needed
+[ -d .git ] || git init -b main
+
+# Stage all seeded files
+git add .claude/ CLAUDE.md AGENTS.md README.md CHANGELOG.md
+
+# Initial commit
+git commit -m "chore: bootstrap project skeleton via project-init"
+```
+
+`AskUserQuestion`: dry-run 미리보기 후 confirm.
+
+```bash
+# Repo create + push (dry-run preview first, then real run)
+PREVIEW="gh repo create ${OWNER}/${PROJECT_NAME} --${VISIBILITY,,} --description \"${ONE_LINER}\" --source=. --remote=origin --push"
+echo "$PREVIEW"
+
+# User confirms via AskUserQuestion (Recommended: "Run")
+gh repo create "${OWNER}/${PROJECT_NAME}" --"${VISIBILITY,,}" --description "${ONE_LINER}" --source=. --remote=origin --push
+```
+
+License 가 None 이 아니면 — gh repo create 후 `gh api` 로 LICENSE 파일 생성하거나 사용자에게 "later" 안내. 단순화를 위해 V1 에서는 안내만.
+
+## Phase 7 — Summary + Next Actions
+
+```
+✓ Project '<name>' bootstrapped at <cwd>
+
+Files seeded:
+  .claude/spec/.gitkeep
+  .claude/rules/.gitkeep
+  .claude/wiki/.gitkeep
+  CLAUDE.md       (minimal stub — LLM Wiki entrypoint)
+  AGENTS.md       (variant: <variant> — includes Codex Review guidelines)
+  README.md       (6-section minimal)
+  CHANGELOG.md    ([Unreleased] only)
+
+GitHub repo: https://github.com/<owner>/<name>
+
+Next actions (call when ready):
+  1. 코드가 쌓이면        → /rules-forge:write-rules
+     (tech-stack 기반 CLAUDE.md + .claude/rules/*.md 재생성)
+
+  2. 첫 도메인 lore 쌓이면 → /llm-wiki:bootstrap-wiki
+     (도메인 인터뷰 + .claude/wiki/<domain>/ 구조 시드)
+
+  3. 첫 PR merge 후        → /github-dev:post-merge
+     (자동으로 /llm-wiki:post-merge-wiki 체이닝)
+```
+
+## 실패 처리
+
+| 단계 | 실패 시 동작 |
+|------|--------------|
+| Phase 0 — gh auth | abort + 안내 (`gh auth login`) |
+| Phase 0 — idempotency guard 사용자 abort | 즉시 stop, partial seed 보존 |
+| Phase 6 — `gh repo create` | local 변경/커밋은 그대로, push 만 실패. 사용자에게 manual retry 명령 안내 |
+| Phase 6 — repo 이름 충돌 | gh CLI error 메시지 그대로 노출 + Phase 1 재시도 권유 |
+
+## Out of Scope
+
+- CI/CD workflow seed (`.github/workflows/`)
+- pre-commit hook seed
+- 외부 boilerplate auto-download (cookiecutter 등 — 필요하면 `/code-scout:scout` 별도 호출)
+- 다국어 인터뷰 분기 — 한/영 혼용 단일 버전 유지

--- a/plugins/project-init/commands/new.md
+++ b/plugins/project-init/commands/new.md
@@ -123,16 +123,22 @@ placeholder (`<project_name>`, `<one-line description>`) 는 Phase 1 응답으�
 - header: "Variant"
 - options: "<recommended> (Recommended)" / 나머지 2 개
 
+> 응답을 `VARIANT` 변수에 할당 (예: `general` / `ml` / `web`). 사용자가 비워두거나 응답 누락 시 default `VARIANT=general`.
+
 ```bash
 SRC="${CLAUDE_PLUGIN_ROOT}/assets/AGENTS.review-guidelines.${VARIANT}.md"
 # Variant 가 general 이면 base 파일
 [ "$VARIANT" = "general" ] && SRC="${CLAUDE_PLUGIN_ROOT}/assets/AGENTS.review-guidelines.md"
 
-cp "$SRC" AGENTS.md
-# placeholder 치환
-sed -i "s|{{PROJECT_NAME}}|${PROJECT_NAME}|g" AGENTS.md
-sed -i "s|{{ONE_LINER}}|${ONE_LINER}|g" AGENTS.md
-sed -i "s|{{OWNER}}|${OWNER}|g" AGENTS.md
+if [ ! -f AGENTS.md ]; then
+  cp "$SRC" AGENTS.md
+  # placeholder 치환
+  sed -i "s|{{PROJECT_NAME}}|${PROJECT_NAME}|g" AGENTS.md
+  sed -i "s|{{ONE_LINER}}|${ONE_LINER}|g" AGENTS.md
+  sed -i "s|{{OWNER}}|${OWNER}|g" AGENTS.md
+else
+  echo "[skip] AGENTS.md already exists — preserving existing content"
+fi
 ```
 
 AGENTS.md 의 `## Review guidelines` 섹션은 Codex GitHub cloud reviewer 가 자동으로 읽는다 ([OpenAI Codex GitHub integration](https://developers.openai.com/codex/integrations/github)) — 사용자에게 한 줄 안내.
@@ -145,7 +151,7 @@ AGENTS.md 의 `## Review guidelines` 섹션은 Codex GitHub cloud reviewer 가 �
 
 sed -i "s|{{PROJECT_NAME}}|${PROJECT_NAME}|g" README.md CHANGELOG.md
 sed -i "s|{{ONE_LINER}}|${ONE_LINER}|g" README.md
-sed -i "s|{{OWNER}}|${OWNER}|g" README.md
+sed -i "s|{{OWNER}}|${OWNER}|g" README.md CHANGELOG.md
 sed -i "s|{{LICENSE}}|${LICENSE}|g" README.md
 ```
 
@@ -179,7 +185,7 @@ License 가 None 이 아니면 — gh repo create 후 `gh api` 로 LICENSE 파�
 
 ## Phase 7 — Summary + Next Actions
 
-```
+```text
 ✓ Project '<name>' bootstrapped at <cwd>
 
 Files seeded:

--- a/plugins/project-init/commands/new.md
+++ b/plugins/project-init/commands/new.md
@@ -18,6 +18,7 @@ description: First-day project bootstrap — interview, .claude/ scaffold, CLAUD
 
 - `gh` CLI 설치 + `gh auth status` OK
 - `git` 설치
+- `jq` 설치 (Phase 0 의 `infer-github-context.sh` 와 일부 placeholder 치환 헬퍼가 의존)
 - 현재 디렉토리가 작업 대상 — `pwd` 출력을 사용자에게 보여주고 진행 확인
 
 ## Phase 0 — Preflight (자동, no prompt)
@@ -130,6 +131,14 @@ SRC="${CLAUDE_PLUGIN_ROOT}/assets/AGENTS.review-guidelines.${VARIANT}.md"
 # Variant 가 general 이면 base 파일
 [ "$VARIANT" = "general" ] && SRC="${CLAUDE_PLUGIN_ROOT}/assets/AGENTS.review-guidelines.md"
 
+# Portable in-place sed — GNU sed 는 `sed -i 'cmd' file`, BSD/macOS sed 는
+# `sed -i '' 'cmd' file` 시그니처. `sed --version` 으로 분기한다.
+if sed --version >/dev/null 2>&1; then
+  sed_inplace() { sed -i "$@"; }
+else
+  sed_inplace() { sed -i '' "$@"; }
+fi
+
 # sed replacement 컨텍스트에서 위험한 문자 (\, &, |) escape — 사용자 입력에
 # "Frontend & Backend" 같은 `&` 가 있으면 sed 가 매치 전체를 다시 삽입한다.
 esc_sed() { printf '%s' "$1" | sed 's/[\\&|]/\\&/g'; }
@@ -141,9 +150,9 @@ LICENSE_ESC=$(esc_sed "$LICENSE")
 if [ ! -f AGENTS.md ]; then
   cp "$SRC" AGENTS.md
   # placeholder 치환 (escape 된 값 사용)
-  sed -i "s|{{PROJECT_NAME}}|${PROJECT_NAME_ESC}|g" AGENTS.md
-  sed -i "s|{{ONE_LINER}}|${ONE_LINER_ESC}|g" AGENTS.md
-  sed -i "s|{{OWNER}}|${OWNER_ESC}|g" AGENTS.md
+  sed_inplace "s|{{PROJECT_NAME}}|${PROJECT_NAME_ESC}|g" AGENTS.md
+  sed_inplace "s|{{ONE_LINER}}|${ONE_LINER_ESC}|g" AGENTS.md
+  sed_inplace "s|{{OWNER}}|${OWNER_ESC}|g" AGENTS.md
 else
   echo "[skip] AGENTS.md already exists — preserving existing content"
 fi
@@ -154,14 +163,25 @@ AGENTS.md 의 `## Review guidelines` 섹션은 Codex GitHub cloud reviewer 가 �
 ## Phase 5 — README + CHANGELOG
 
 ```bash
-[ -f README.md ] || cp ${CLAUDE_PLUGIN_ROOT}/assets/README.minimal.md README.md
-[ -f CHANGELOG.md ] || cp ${CLAUDE_PLUGIN_ROOT}/assets/CHANGELOG.initial.md CHANGELOG.md
+# 새로 시드한 파일만 추적 — 기존 파일에 의도적으로 둔 {{PROJECT_NAME}} 류
+# placeholder 가 변조되지 않도록 cp 한 파일에만 치환을 적용한다.
+SEEDED_FILES=()
+if [ ! -f README.md ]; then
+  cp "${CLAUDE_PLUGIN_ROOT}/assets/README.minimal.md" README.md
+  SEEDED_FILES+=("README.md")
+fi
+if [ ! -f CHANGELOG.md ]; then
+  cp "${CLAUDE_PLUGIN_ROOT}/assets/CHANGELOG.initial.md" CHANGELOG.md
+  SEEDED_FILES+=("CHANGELOG.md")
+fi
 
-# Phase 4 에서 정의한 *_ESC 값 재사용 — escape 된 값으로 안전 치환
-sed -i "s|{{PROJECT_NAME}}|${PROJECT_NAME_ESC}|g" README.md CHANGELOG.md
-sed -i "s|{{ONE_LINER}}|${ONE_LINER_ESC}|g" README.md
-sed -i "s|{{OWNER}}|${OWNER_ESC}|g" README.md CHANGELOG.md
-sed -i "s|{{LICENSE}}|${LICENSE_ESC}|g" README.md
+# Phase 4 에서 정의한 sed_inplace / *_ESC 재사용 — escape + 플랫폼 portable
+for f in "${SEEDED_FILES[@]}"; do
+  sed_inplace "s|{{PROJECT_NAME}}|${PROJECT_NAME_ESC}|g" "$f"
+  sed_inplace "s|{{ONE_LINER}}|${ONE_LINER_ESC}|g" "$f"
+  sed_inplace "s|{{OWNER}}|${OWNER_ESC}|g" "$f"
+  sed_inplace "s|{{LICENSE}}|${LICENSE_ESC}|g" "$f"
+done
 ```
 
 게이트: README.md 첫 30줄 미리보기 후 수정 기회. 한 번 더 호출하지 않고 inline `Edit` 로 즉시 수정.

--- a/plugins/project-init/commands/new.md
+++ b/plugins/project-init/commands/new.md
@@ -130,12 +130,20 @@ SRC="${CLAUDE_PLUGIN_ROOT}/assets/AGENTS.review-guidelines.${VARIANT}.md"
 # Variant 가 general 이면 base 파일
 [ "$VARIANT" = "general" ] && SRC="${CLAUDE_PLUGIN_ROOT}/assets/AGENTS.review-guidelines.md"
 
+# sed replacement 컨텍스트에서 위험한 문자 (\, &, |) escape — 사용자 입력에
+# "Frontend & Backend" 같은 `&` 가 있으면 sed 가 매치 전체를 다시 삽입한다.
+esc_sed() { printf '%s' "$1" | sed 's/[\\&|]/\\&/g'; }
+PROJECT_NAME_ESC=$(esc_sed "$PROJECT_NAME")
+ONE_LINER_ESC=$(esc_sed "$ONE_LINER")
+OWNER_ESC=$(esc_sed "$OWNER")
+LICENSE_ESC=$(esc_sed "$LICENSE")
+
 if [ ! -f AGENTS.md ]; then
   cp "$SRC" AGENTS.md
-  # placeholder 치환
-  sed -i "s|{{PROJECT_NAME}}|${PROJECT_NAME}|g" AGENTS.md
-  sed -i "s|{{ONE_LINER}}|${ONE_LINER}|g" AGENTS.md
-  sed -i "s|{{OWNER}}|${OWNER}|g" AGENTS.md
+  # placeholder 치환 (escape 된 값 사용)
+  sed -i "s|{{PROJECT_NAME}}|${PROJECT_NAME_ESC}|g" AGENTS.md
+  sed -i "s|{{ONE_LINER}}|${ONE_LINER_ESC}|g" AGENTS.md
+  sed -i "s|{{OWNER}}|${OWNER_ESC}|g" AGENTS.md
 else
   echo "[skip] AGENTS.md already exists — preserving existing content"
 fi
@@ -149,10 +157,11 @@ AGENTS.md 의 `## Review guidelines` 섹션은 Codex GitHub cloud reviewer 가 �
 [ -f README.md ] || cp ${CLAUDE_PLUGIN_ROOT}/assets/README.minimal.md README.md
 [ -f CHANGELOG.md ] || cp ${CLAUDE_PLUGIN_ROOT}/assets/CHANGELOG.initial.md CHANGELOG.md
 
-sed -i "s|{{PROJECT_NAME}}|${PROJECT_NAME}|g" README.md CHANGELOG.md
-sed -i "s|{{ONE_LINER}}|${ONE_LINER}|g" README.md
-sed -i "s|{{OWNER}}|${OWNER}|g" README.md CHANGELOG.md
-sed -i "s|{{LICENSE}}|${LICENSE}|g" README.md
+# Phase 4 에서 정의한 *_ESC 값 재사용 — escape 된 값으로 안전 치환
+sed -i "s|{{PROJECT_NAME}}|${PROJECT_NAME_ESC}|g" README.md CHANGELOG.md
+sed -i "s|{{ONE_LINER}}|${ONE_LINER_ESC}|g" README.md
+sed -i "s|{{OWNER}}|${OWNER_ESC}|g" README.md CHANGELOG.md
+sed -i "s|{{LICENSE}}|${LICENSE_ESC}|g" README.md
 ```
 
 게이트: README.md 첫 30줄 미리보기 후 수정 기회. 한 번 더 호출하지 않고 inline `Edit` 로 즉시 수정.
@@ -173,12 +182,21 @@ git commit -m "chore: bootstrap project skeleton via project-init"
 `AskUserQuestion`: dry-run 미리보기 후 confirm.
 
 ```bash
+# AskUserQuestion 라벨 ("Private (Recommended)", "Public", "Internal") 을
+# gh CLI 가 받는 단일 토큰 (private|public|internal) 으로 정규화.
+case "${VISIBILITY,,}" in
+  *private*)  VIS_FLAG="private" ;;
+  *public*)   VIS_FLAG="public" ;;
+  *internal*) VIS_FLAG="internal" ;;
+  *) echo "[abort] Unknown visibility: $VISIBILITY"; exit 1 ;;
+esac
+
 # Repo create + push (dry-run preview first, then real run)
-PREVIEW="gh repo create ${OWNER}/${PROJECT_NAME} --${VISIBILITY,,} --description \"${ONE_LINER}\" --source=. --remote=origin --push"
+PREVIEW="gh repo create ${OWNER}/${PROJECT_NAME} --${VIS_FLAG} --description \"${ONE_LINER}\" --source=. --remote=origin --push"
 echo "$PREVIEW"
 
 # User confirms via AskUserQuestion (Recommended: "Run")
-gh repo create "${OWNER}/${PROJECT_NAME}" --"${VISIBILITY,,}" --description "${ONE_LINER}" --source=. --remote=origin --push
+gh repo create "${OWNER}/${PROJECT_NAME}" --"${VIS_FLAG}" --description "${ONE_LINER}" --source=. --remote=origin --push
 ```
 
 License 가 None 이 아니면 — gh repo create 후 `gh api` 로 LICENSE 파일 생성하거나 사용자에게 "later" 안내. 단순화를 위해 V1 에서는 안내만.

--- a/plugins/project-init/references/codex-review-discovery.md
+++ b/plugins/project-init/references/codex-review-discovery.md
@@ -1,0 +1,50 @@
+# Codex Review Discovery — AGENTS.md vs `/review` CLI
+
+이 문서는 `/project-init:new` 의 Phase 4 (AGENTS.md seed) 가 왜 레포 생성 시점에 시드해야 효과적인지 정리한다.
+
+## 두 가지 Codex review 경로
+
+| 경로 | 트리거 | AGENTS.md 영향 |
+|------|--------|----------------|
+| **Codex GitHub cloud reviewer** | PR open / `@codex review` 댓글 | **자동**으로 레포 루트 `AGENTS.md` 의 `## Review guidelines` 섹션을 로드해 시스템 프롬프트에 포함 |
+| **Codex CLI (`mcp__codex-cli__review` 또는 `chatgpt-codex review`)** | 로컬에서 명시적 호출 | AGENTS.md 는 같은 위치/형식이면 동일하게 읽힘 (CLI 가 cwd 의 `AGENTS.md` discover) |
+
+핵심 사실: Codex cloud reviewer 는 `AGENTS.md` 의 `## Review guidelines` 헤더 아래 콘텐츠를 우선적으로 참고한다. 다른 섹션 (`## Project context`, `## Build / Test / Lint`) 도 시스템 프롬프트에 들어가지만 review 의 critical path 는 review guidelines 섹션이다.
+
+> 출처: [OpenAI Codex GitHub integration](https://developers.openai.com/codex/integrations/github) — "Codex reads `AGENTS.md` to learn the codebase conventions before reviewing".
+
+## 왜 "레포 생성 시점에" 시드해야 하나
+
+1. **첫 PR 부터 효과**: AGENTS.md 가 main 브랜치에 없으면 첫 PR 리뷰 시 Codex 가 generic 기준 (lint stuff, style nits) 으로 리뷰한다.
+2. **Default branch protection**: AGENTS.md 를 첫 commit 에 포함하면 protected branch policy 와 무관하게 모든 PR 이 이미 base 에 깔린 가이드라인을 본다.
+3. **사용자 학습 효과**: 빈 프로젝트에 AGENTS.md 가 있으면 첫 PR 작성자가 "여기는 이런 기준" 을 미리 인지.
+
+## Review guidelines 섹션 핵심 구조
+
+Codex review 가 잘 작동하는 패턴 — 4 개 섹션:
+
+1. **`### Do not flag`** (린터/포매터 영역) — **선두에 배치**. Codex 가 generic lint nit 을 코멘트하는 비용을 차단.
+2. **`### P0 — Correctness / Security`** — must-block 항목.
+3. **`### P1 — Performance / Maintainability`** — should-block 항목.
+4. **`### Domain-specific`** — 프로젝트 고유 invariant. variant 별로 다름.
+
+### "Do not flag" 가 선두인 이유
+
+부정형 (negative) 스코핑이 긍정형 (positive) 보다 review noise 를 더 효과적으로 줄인다. Codex 는 새 PR 을 보면 lint-level diff 부터 코멘트하려는 경향이 있는데, "do not flag" 가 먼저 보이면 그 욕구가 시스템 프롬프트 단계에서 억제된다.
+
+## CodeRabbit 와의 조율
+
+CodeRabbit 은 `AGENTS.md` 를 읽지 않는다 — 자체 `.coderabbit.yaml` 또는 review-instruction 시스템을 사용한다. 따라서:
+
+- AGENTS.md 의 review guidelines 는 Codex 만을 1차 타겟.
+- CodeRabbit instruction (필요 시) 은 별도 `.coderabbit.yaml` 또는 `.github/CODEOWNERS` 와 함께 관리.
+- `/github-dev:cr-fix` 명령이 두 봇의 결과를 동시에 처리하며 tier 정책으로 noise 를 정리.
+
+> 참고: `.claude/spec/2026-05-06-codex-review-integration.md` — `cr-fix` 의 CR + Codex 통합 세부 내용.
+
+## AGENTS.md 가 이미 존재하는 경우
+
+`/project-init:new` 의 Phase 4 는 idempotent 가드를 가진다:
+
+- AGENTS.md 가 이미 있으면 덮어쓰지 않음 + 사용자에게 "기존 AGENTS.md 에 `## Review guidelines` 섹션이 없으면 manual 추가 권장" 안내.
+- 기존 AGENTS.md 에 review guidelines 섹션이 없는지 grep 으로 확인 후 사용자 결정 게이트.

--- a/plugins/project-init/references/gh-repo-create-flow.md
+++ b/plugins/project-init/references/gh-repo-create-flow.md
@@ -1,0 +1,112 @@
+# gh repo create — Owner 추론 + Visibility 결정 트리
+
+`/project-init:new` Phase 1 인터뷰와 Phase 6 레포 생성의 의사결정 컨텍스트.
+
+## Owner 추론 (자동 X, 인터뷰 필수)
+
+사용자가 personal account + 부업/소속 org 들을 동시에 가지는 경우가 일반적이라 **owner 자동 결정 금지**. `gh api` 로 후보만 수집하고 `AskUserQuestion` 으로 선택받는다.
+
+### 후보 수집 명령
+
+```bash
+# Personal account
+PERSONAL=$(gh api user --jq '.login')
+
+# Orgs 사용자가 멤버인 것 전체
+ORGS=$(gh api /user/orgs --jq '.[].login')
+# 또는 페이지네이션 안전:
+ORGS=$(gh api --paginate /user/orgs --jq '.[].login')
+```
+
+> `--paginate` 안전 사용: orgs 가 30 개 넘는 경우 첫 페이지 30 개만 잡힘.
+
+### 결정 트리
+
+```
+Q: "Where to create the repo?"
+├─ {personal_login}                     [Personal]
+├─ {org1}                                [Organization]
+├─ {org2}                                [Organization]
+└─ ...
+```
+
+옵션 description 에 "Personal" / "Organization" 명시 — 사용자가 두 org 가 비슷한 이름일 때 헷갈리지 않게.
+
+## Visibility 결정
+
+```
+Q: "Visibility?"
+├─ Private (Recommended)
+├─ Public
+└─ Internal     ← org owner 일 때만 노출 (personal 은 internal 불가)
+```
+
+Recommended default 가 Private 인 이유:
+- 신규 프로젝트는 아직 정리되지 않은 secret / debug commit / WIP 코드를 포함할 가능성. 나중에 public 으로 전환은 한 줄이지만 (`gh repo edit --visibility public`), public → private 전환 후 fork 회수는 불가능.
+- 의도가 public OSS 라도 첫 1 주는 private 으로 두고 정리 후 전환하는 패턴이 안전.
+
+> Public 으로 전환 명령: `gh repo edit {{OWNER}}/{{PROJECT_NAME}} --visibility public --accept-visibility-change-consequences`
+
+## License 결정
+
+License 는 visibility 와 독립이다 (private 레포에도 license 둘 수 있음).
+
+| Option | 언제 |
+|--------|------|
+| **MIT** (Recommended) | 단순 permissive, 가장 호환성 높음 |
+| **Apache-2.0** | 특허 grant 명시 필요할 때 |
+| **GPL-3.0** | copyleft 의도 (derivative 도 GPL 유지 강제) |
+| **None** | 명시적으로 license 안 둘 때 (private 레포라면 "사실상 all rights reserved") |
+
+`gh repo create` 의 `--license <name>` 플래그로 자동 LICENSE 파일 생성 가능 (template 사용). 단 license 가 None 이면 생략.
+
+```bash
+# License 자동 시드
+gh repo create "${OWNER}/${PROJECT_NAME}" \
+  --${VISIBILITY,,} \
+  --description "${ONE_LINER}" \
+  --license "${LICENSE}" \
+  --source=. --remote=origin --push
+```
+
+> 한계: `gh repo create --license` 는 빈 레포 (코드 없음) 일 때만 license 파일을 자동 생성한다. `--source=.` 와 함께 쓰면 이미 commit 가 있어서 license 자동 생성이 안 될 수 있음 — 그 경우 별도로 `gh api -X POST /repos/.../contents/LICENSE` 로 시드하거나 사용자에게 manual 안내. V1 에서는 명령에 `--license` 만 넣고 실패해도 무시 (사용자 안내).
+
+## Push 흐름
+
+```bash
+# 0. git init (이미 .git 있으면 skip)
+[ -d .git ] || git init -b main
+
+# 1. 모든 시드 파일 stage
+git add .claude/ CLAUDE.md AGENTS.md README.md CHANGELOG.md
+
+# 2. Initial commit
+git commit -m "chore: bootstrap project skeleton via project-init"
+
+# 3. gh repo create + 자동 push
+gh repo create "${OWNER}/${PROJECT_NAME}" \
+  --${VISIBILITY,,} \
+  --description "${ONE_LINER}" \
+  --source=. --remote=origin --push
+```
+
+`--source=.` 는 현재 디렉토리를 git source 로 지정. `--remote=origin` 은 자동으로 `origin` remote 등록. `--push` 는 현재 branch 를 push.
+
+## 실패 시 복구
+
+| 실패 | 복구 |
+|------|------|
+| `gh repo create` — repo 이름 충돌 | Phase 1 재시도 (다른 이름 선택). local commit 은 그대로 보존. |
+| `gh repo create` — 권한 부족 (org 멤버 X) | Phase 1 owner 재선택 권유. |
+| Push 실패 — 네트워크 / auth | `git remote add origin ...` + `git push -u origin main` 수동 명령 안내. |
+| Initial commit 실패 — gitignore 빠짐 | 임시 `.env`, `node_modules/` 등이 stage 됐는지 확인. `.gitignore` 시드는 V1 scope 밖이라 사용자가 명시적으로 처리. |
+
+## Idempotency
+
+같은 디렉토리에서 `/project-init:new` 두 번째 호출 시:
+1. `.git` 이 이미 존재하면 `git init` skip.
+2. AGENTS.md / CLAUDE.md / README.md / CHANGELOG.md 중 어느 하나라도 이미 존재하면 Phase 4 / 5 에서 해당 파일은 skip + 안내.
+3. `.claude/` 가 이미 있으면 Phase 2 의 `.gitkeep` 만 추가 (디렉토리 구조 자체는 보존).
+4. `gh repo` 가 이미 존재하면 — `gh repo view ${OWNER}/${PROJECT_NAME}` 으로 확인 후 사용자에게 "remote 만 wire 할까요?" 결정.
+
+이 가드는 `scripts/idempotent-seed.sh` 가 담당한다.

--- a/plugins/project-init/references/gh-repo-create-flow.md
+++ b/plugins/project-init/references/gh-repo-create-flow.md
@@ -12,13 +12,16 @@
 # Personal account
 PERSONAL=$(gh api user --jq '.login')
 
-# Orgs 사용자가 멤버인 것 전체
-ORGS=$(gh api /user/orgs --jq '.[].login')
-# 또는 페이지네이션 안전:
-ORGS=$(gh api --paginate /user/orgs --jq '.[].login')
+# Orgs (paginated)
+# gh CLI 는 --slurp 와 --jq 동시 사용을 거부하므로 --slurp 출력을 local jq 로
+# 파이프한다. --paginate 단독 + --jq 는 multi-page 시 jq 가 separate JSON
+# document 를 받아 페이지 경계에서 첫 페이지만 남게 됨 (PR #24 의 실제 finding).
+ORGS=$(gh api --paginate --slurp /user/orgs | jq -c '[.[][].login]')
 ```
 
-> `--paginate` 안전 사용: orgs 가 30 개 넘는 경우 첫 페이지 30 개만 잡힘.
+> `--paginate` 만 단독으로 쓰면 30 개 초과 결과가 multi-document 로 흘러서
+> `--jq` 가 첫 페이지만 잡는다. `--slurp` 으로 array-of-arrays 로 묶고
+> `jq '[.[][].login]'` 로 flatten 하는 패턴이 portable + correct.
 
 ### 결정 트리
 

--- a/plugins/project-init/scripts/idempotent-seed.sh
+++ b/plugins/project-init/scripts/idempotent-seed.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# idempotent-seed.sh
+#
+# /project-init:new 의 파일 시드 단계용 idempotent 헬퍼. 같은 디렉토리에서
+# 두 번째 호출 시 기존 파일을 절대 덮어쓰지 않는다.
+#
+# Usage:
+#   bash idempotent-seed.sh ensure-claude-dirs
+#   bash idempotent-seed.sh seed-if-missing <src-template> <dst-path>
+#   bash idempotent-seed.sh check-collision <dst-path>   # exit 0 = absent, 1 = collision
+#   bash idempotent-seed.sh diagnose                     # 현재 디렉토리 상태 JSON 출력
+#
+# 출력은 사람이 읽기 위한 평문 (notice / abort), diagnose 만 JSON.
+
+set -euo pipefail
+
+CMD="${1:-}"
+shift || true
+
+cmd_ensure_claude_dirs() {
+  local subdirs=("spec" "rules" "wiki")
+  for sub in "${subdirs[@]}"; do
+    mkdir -p ".claude/${sub}"
+    if [ ! -f ".claude/${sub}/.gitkeep" ]; then
+      : > ".claude/${sub}/.gitkeep"
+      echo "[seed] created .claude/${sub}/.gitkeep"
+    else
+      echo "[skip] .claude/${sub}/.gitkeep already exists"
+    fi
+  done
+}
+
+cmd_seed_if_missing() {
+  local src="${1:-}"
+  local dst="${2:-}"
+  if [ -z "$src" ] || [ -z "$dst" ]; then
+    echo "[idempotent-seed] usage: seed-if-missing <src> <dst>" >&2
+    exit 2
+  fi
+  if [ ! -f "$src" ]; then
+    echo "[idempotent-seed] source missing: $src" >&2
+    exit 2
+  fi
+  if [ -e "$dst" ]; then
+    echo "[skip] $dst already exists — not overwriting"
+    return 0
+  fi
+  cp "$src" "$dst"
+  echo "[seed] copied $(basename "$src") -> $dst"
+}
+
+cmd_check_collision() {
+  local dst="${1:-}"
+  if [ -z "$dst" ]; then
+    echo "[idempotent-seed] usage: check-collision <path>" >&2
+    exit 2
+  fi
+  if [ -e "$dst" ]; then
+    echo "[collision] $dst exists"
+    exit 1
+  fi
+  echo "[absent] $dst"
+  exit 0
+}
+
+cmd_diagnose() {
+  local cwd
+  cwd=$(pwd)
+  local has_git="false"
+  [ -d .git ] && has_git="true"
+  local has_claude="false"
+  [ -d .claude ] && has_claude="true"
+  local has_claude_md="false"
+  [ -f CLAUDE.md ] && has_claude_md="true"
+  local has_agents_md="false"
+  [ -f AGENTS.md ] && has_agents_md="true"
+  local has_readme="false"
+  [ -f README.md ] && has_readme="true"
+  local has_changelog="false"
+  [ -f CHANGELOG.md ] && has_changelog="true"
+  local commit_count="0"
+  if [ "$has_git" = "true" ]; then
+    commit_count=$(git rev-list --count HEAD 2>/dev/null || echo "0")
+  fi
+  local has_remote="false"
+  if [ "$has_git" = "true" ] && git remote get-url origin >/dev/null 2>&1; then
+    has_remote="true"
+  fi
+  # Quick code signal — first detected ext, else "none"
+  local code_signal="none"
+  for ext in py ts tsx js jsx go rs java rb php; do
+    if find . -maxdepth 3 -type f -name "*.${ext}" 2>/dev/null | head -1 | grep -q .; then
+      code_signal="${ext}"
+      break
+    fi
+  done
+
+  jq -nc \
+    --arg cwd "$cwd" \
+    --arg dir_name "$(basename "$cwd")" \
+    --argjson has_git "$has_git" \
+    --argjson has_claude "$has_claude" \
+    --argjson has_claude_md "$has_claude_md" \
+    --argjson has_agents_md "$has_agents_md" \
+    --argjson has_readme "$has_readme" \
+    --argjson has_changelog "$has_changelog" \
+    --argjson commit_count "$commit_count" \
+    --argjson has_remote "$has_remote" \
+    --arg code_signal "$code_signal" \
+    '{
+      cwd: $cwd,
+      dir_name: $dir_name,
+      git: { initialized: $has_git, commits: $commit_count, remote_origin: $has_remote },
+      seeded: {
+        claude_dir: $has_claude,
+        claude_md: $has_claude_md,
+        agents_md: $has_agents_md,
+        readme: $has_readme,
+        changelog: $has_changelog
+      },
+      code_signal: $code_signal
+    }'
+}
+
+case "$CMD" in
+  ensure-claude-dirs) cmd_ensure_claude_dirs "$@" ;;
+  seed-if-missing)    cmd_seed_if_missing "$@" ;;
+  check-collision)    cmd_check_collision "$@" ;;
+  diagnose)           cmd_diagnose "$@" ;;
+  ""|help|-h|--help)
+    cat <<EOF
+idempotent-seed.sh — /project-init:new helper
+
+Commands:
+  ensure-claude-dirs                  Create .claude/{spec,rules,wiki}/.gitkeep
+  seed-if-missing <src> <dst>         Copy template only if dst absent
+  check-collision <path>              Exit 1 if path exists, 0 if absent
+  diagnose                            Output JSON snapshot of cwd state
+
+All commands are idempotent — re-running is safe.
+EOF
+    ;;
+  *)
+    echo "[idempotent-seed] unknown command: $CMD" >&2
+    exit 2
+    ;;
+esac

--- a/plugins/project-init/scripts/infer-github-context.sh
+++ b/plugins/project-init/scripts/infer-github-context.sh
@@ -42,9 +42,15 @@ fi
 # Orgs (paginated)
 # Note: gh CLI rejects --slurp + --jq together, so we pipe to local jq.
 # --slurp wraps multi-page responses as array-of-arrays; [.[][].login] flattens.
-ORGS_JSON=$(gh api --paginate --slurp /user/orgs 2>/dev/null | jq -c '[.[][].login]' 2>/dev/null || echo "[]")
-if [ -z "$ORGS_JSON" ]; then
-  ORGS_JSON="[]"
+# gh / jq 실패를 빈 목록으로 삼키지 않는다 — exit 2 로 분리해야 사용자가
+# "조직 없음" 과 "API 실패" 를 구분해 owner 선택을 잘못 내리지 않는다.
+if ! ORGS_RAW=$(gh api --paginate --slurp /user/orgs 2>/dev/null); then
+  echo "[infer-github-context] gh api /user/orgs failed (network/rate-limit/permission)" >&2
+  exit 2
+fi
+if ! ORGS_JSON=$(printf '%s' "$ORGS_RAW" | jq -c '[.[][].login]' 2>/dev/null); then
+  echo "[infer-github-context] jq parse failed on /user/orgs response" >&2
+  exit 2
 fi
 
 # 최종 JSON 조립 — jq 가 -c 로 compact 출력

--- a/plugins/project-init/scripts/infer-github-context.sh
+++ b/plugins/project-init/scripts/infer-github-context.sh
@@ -19,6 +19,13 @@ if ! command -v gh >/dev/null 2>&1; then
   exit 1
 fi
 
+# jq 존재 확인 — paginated org 응답 flatten + 최종 envelope 조립에 필수
+# (gh CLI 는 --slurp 와 --jq 동시 사용 거부 → local jq 가 hard dependency)
+if ! command -v jq >/dev/null 2>&1; then
+  echo "[infer-github-context] jq not installed. Install: https://jqlang.github.io/jq/download/" >&2
+  exit 1
+fi
+
 # Auth 확인
 if ! gh auth status >/dev/null 2>&1; then
   echo "[infer-github-context] gh CLI not authenticated. Run: gh auth login" >&2

--- a/plugins/project-init/scripts/infer-github-context.sh
+++ b/plugins/project-init/scripts/infer-github-context.sh
@@ -33,7 +33,9 @@ if [ -z "$PERSONAL" ]; then
 fi
 
 # Orgs (paginated)
-ORGS_JSON=$(gh api --paginate /user/orgs --jq '[.[].login]' 2>/dev/null || echo "[]")
+# Note: gh CLI rejects --slurp + --jq together, so we pipe to local jq.
+# --slurp wraps multi-page responses as array-of-arrays; [.[][].login] flattens.
+ORGS_JSON=$(gh api --paginate --slurp /user/orgs 2>/dev/null | jq -c '[.[][].login]' 2>/dev/null || echo "[]")
 if [ -z "$ORGS_JSON" ]; then
   ORGS_JSON="[]"
 fi

--- a/plugins/project-init/scripts/infer-github-context.sh
+++ b/plugins/project-init/scripts/infer-github-context.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# infer-github-context.sh
+#
+# gh CLI 로 personal account + 사용자가 멤버인 모든 org 를 수집해
+# JSON 으로 stdout 출력. /project-init:new Phase 0 에서 owner 후보 시드용.
+#
+# 출력 예시:
+#   {"personal":"youngjaedev","orgs":["hansungts","my-org-2"]}
+#
+# 실패 조건:
+#   - gh CLI 미설치 또는 미인증 → exit 1, stderr 에 안내
+#   - gh api 호출 실패 → exit 2
+
+set -euo pipefail
+
+# gh CLI 존재 확인
+if ! command -v gh >/dev/null 2>&1; then
+  echo "[infer-github-context] gh CLI not installed. Install: https://cli.github.com/" >&2
+  exit 1
+fi
+
+# Auth 확인
+if ! gh auth status >/dev/null 2>&1; then
+  echo "[infer-github-context] gh CLI not authenticated. Run: gh auth login" >&2
+  exit 1
+fi
+
+# Personal account
+PERSONAL=$(gh api user --jq '.login' 2>/dev/null || true)
+if [ -z "$PERSONAL" ]; then
+  echo "[infer-github-context] failed to fetch personal account" >&2
+  exit 2
+fi
+
+# Orgs (paginated)
+ORGS_JSON=$(gh api --paginate /user/orgs --jq '[.[].login]' 2>/dev/null || echo "[]")
+if [ -z "$ORGS_JSON" ]; then
+  ORGS_JSON="[]"
+fi
+
+# 최종 JSON 조립 — jq 가 -c 로 compact 출력
+jq -nc --arg personal "$PERSONAL" --argjson orgs "$ORGS_JSON" \
+  '{personal: $personal, orgs: $orgs}'


### PR DESCRIPTION
## Summary

새 플러그인 `project-init` 추가 — 새 디렉토리에서 단일 `/project-init:new` 한 번이면 인터뷰 → 로컬 시드 → gh 레포 생성 → 초기 커밋/푸시까지 끝나는 Day-1 부트스트랩 오케스트레이터.

핵심 차별점은 **AGENTS.md `## Review guidelines` 섹션을 레포 생성 시점에 시드**한다는 것. Codex GitHub cloud reviewer 가 이 섹션을 자동으로 읽기 때문에 (`https://developers.openai.com/codex/integrations/github`), main 에 미리 들어가 있어야 첫 PR 부터 효과가 있다. variant 3 종 (general / ml / web) 으로 도메인별 P0/P1 + Do-not-flag 항목을 distill 했다.

## What it does

- **Phase 0 — Preflight**: `gh auth status` 확인, personal account + orgs 후보 수집 (`scripts/infer-github-context.sh`), cwd 상태 진단 (`scripts/idempotent-seed.sh diagnose`).
- **Phase 1 — Identity interview**: `AskUserQuestion` 4 batch (name, owner, visibility, license). owner 는 자동 결정 X — 부업/조직 컨텍스트 때문에 반드시 명시 선택.
- **Phase 2 — `.claude/` scaffold**: `{spec,rules,wiki}/.gitkeep` 만 시드. `bootstrap-wiki` / `write-rules` 호출 X (빈 프로젝트에 generic 콘텐츠 만들면 덮어쓰기 비용 발생).
- **Phase 3 — CLAUDE.md minimal stub**: LLM Wiki 사용법 + Setup Status 안내. 5-15 줄 짜리.
- **Phase 4 — AGENTS.md seed**: description 키워드로 variant 추천 → `AskUserQuestion` 확인 → placeholder 치환 후 시드.
- **Phase 5 — README + CHANGELOG**: 6-section README, Keep-a-Changelog `[Unreleased]` only.
- **Phase 6 — `gh repo create + --source=. --push`**: dry-run 미리보기 후 확인.
- **Phase 7 — Summary + Next actions**: `/rules-forge:write-rules`, `/llm-wiki:bootstrap-wiki`, `/github-dev:post-merge` 명시적 안내.

## Why this shape

- **Minimal seeding, explicit follow-ups**: tech-stack 기반 rules 생성과 wiki 도메인 인터뷰는 호출하지 않고 **Phase 7 안내만**. 빈 프로젝트에 generic 콘텐츠 만들면 사용자 덮어쓰기 비용 발생.
- **Owner gate is mandatory**: personal + 다중 org 컨텍스트에서 자동 결정 금지.
- **Codex reviewer surface 첫 PR 부터 효과**: AGENTS.md 가 main 에 없으면 첫 PR 부터 generic lint nit 으로 리뷰됨.
- **Idempotent**: 같은 디렉토리 재호출 시 `[skip]` 메시지, 절대 덮어쓰지 않음.

## Files

```
plugins/project-init/
├── .claude-plugin/plugin.json
├── commands/new.md                      # 단일 orchestration command
├── assets/
│   ├── AGENTS.review-guidelines.md      # general variant
│   ├── AGENTS.review-guidelines.ml.md   # ML/data variant
│   ├── AGENTS.review-guidelines.web.md  # web variant
│   ├── README.minimal.md
│   └── CHANGELOG.initial.md
├── references/
│   ├── codex-review-discovery.md        # AGENTS.md vs Codex CLI 설명
│   └── gh-repo-create-flow.md           # owner/visibility 결정 트리
├── scripts/
│   ├── infer-github-context.sh
│   └── idempotent-seed.sh               # 4 subcommands (ensure-claude-dirs / seed-if-missing / check-collision / diagnose)
└── CLAUDE.md
```

## Marketplace sync (per `.claude/rules/plugin-versioning.md`)

- `plugins/project-init/.claude-plugin/plugin.json`: `0.1.0`
- `.claude-plugin/marketplace.json`: 새 entry + `metadata.version` `1.30.1` → `1.31.0`, description `21` → `22` plugins.
- 루트 `CLAUDE.md`: Planning 카테고리에 entry 추가, 카운트 + 트리 업데이트.
- 루트 `README.md`: badge `21` → `22`, 플러그인 표 + detail `<details>` + 트리 업데이트.

## Verification done

- `bash -n` syntax check on both scripts → OK
- `idempotent-seed.sh diagnose` → valid JSON
- `idempotent-seed.sh ensure-claude-dirs` smoke test → idempotent ([seed] then [skip])
- `infer-github-context.sh` → `{"personal":"YoungjaeDev","orgs":["aicads"]}`
- `jq .` validates `marketplace.json` + `plugin.json` — version match `0.1.0`

End-to-end (실제 `gh repo create` 호출) 는 remote state 만들기 때문에 사용자가 인터랙티브하게 확인할 단계로 남겨둠.

## Out of Scope (V1)

- `.github/workflows/` CI 시드 — variant 별 다양성 너무 큼, 별도 plugin 후보
- pre-commit hook 시드 — 같은 이유
- cookiecutter / copier 자동 다운로드 — `/code-scout:scout` 별도 호출
- 다국어 인터뷰 분기 — 한/영 혼용 단일 버전 유지

## Test plan

- [ ] 빈 디렉토리에서 `/project-init:new` 실행 → 모든 시드 파일 + gh repo + 초기 커밋 확인 (manual, 사용자 검증)
- [ ] 같은 디렉토리 재실행 → idempotency guard 발동, 기존 파일 보존
- [ ] description 에 "deep learning" 포함 → ML variant 가 Recommended 로 제시
- [ ] `gh api /user/orgs` 가 2+ org 반환 시 AskUserQuestion 옵션이 동적으로 personal + 모든 orgs 제시
- [ ] AGENTS.md `## Review guidelines` 구조가 OpenAI 공식 패턴 (`Do not flag` 선두 / P0 / P1 / Domain-specific) 일치

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 새로운 프로젝트 초기화 플러그인 추가 - 프로젝트 부트스트랩을 자동으로 수행하며, 기본 디렉토리 구조, 설정 파일, Git 저장소 생성을 한 번에 처리할 수 있습니다.

* **문서**
  * 플러그인 카운트 21개 → 22개로 업데이트
  * 자동 코드 리뷰어 가이드라인 추가 (일반, 웹, ML 도메인별)
  * 프로젝트 초기화 흐름 및 절차 상세 문서화

* **Chores**
  * 플러그인 메타데이터 및 버전 정보 갱신 (v1.31.0)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/YoungjaeDev/my-claude-plugins/pull/24?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->