### PR TITLE
feat(github-dev): post-merge Step 5.8 conditional wiki ingest chain

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Personal Claude Code plugin collection with 22 specialized plugins",
-    "version": "1.34.0"
+    "version": "1.35.0"
   },
   "plugins": [
     {
@@ -19,7 +19,7 @@
       "name": "github-dev",
       "source": "./plugins/github-dev",
       "description": "GitHub workflow: commit, PR, issue, worktree, unified CodeRabbit + ChatGPT-Codex cr-fix pipeline (now a multi-file skill: wait + auto-fetch + apply + push loop with branch-protection-gated auto-merge, CR-engagement guard, Codex review-id discovery + dedupe, CR Nitpick + Codex P3 silent skip, optional --skip-minor; rate-limit early-escape with auto fallback to local CodeRabbit CLI or Codex-only via --cr-source), project tracking, release",
-      "version": "1.22.0",
+      "version": "1.23.0",
       "category": "github"
     },
     {

--- a/plugins/github-dev/.claude-plugin/plugin.json
+++ b/plugins/github-dev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "github-dev",
-  "version": "1.22.0",
+  "version": "1.23.0",
   "description": "GitHub workflow automation commands for Claude Code",
   "commands": [
     "./commands/commit-and-push.md",

--- a/plugins/github-dev/commands/post-merge.md
+++ b/plugins/github-dev/commands/post-merge.md
@@ -127,6 +127,12 @@ Perform local branch cleanup and configuration updates after a PR has been merge
    - The schema and update mechanics are owned by the `spec-state:state-tracker` skill — invoke it (`/spec-state:state-tracker complete <spec-path>`) rather than direct JSON edit if the plugin is installed; otherwise apply a direct JSON edit using the schema documented in `plugins/spec-state/skills/state-tracker/SKILL.md`.
    - Skip entirely if `.claude/state/` directory does not exist.
 
+5.8. **Trigger wiki ingest (if a wiki layer exists)**
+   - Resolve the wiki root in order: `.llmwiki/wiki/` → `.claude/wiki/` → `.codex/wiki/`. Skip silently if none resolves (llm-wiki not in use — no hard dependency).
+   - Skip for trivial merges (typo / dep-bump / formatting — reuse `post-merge-wiki`'s own "Do NOT use" list).
+   - Otherwise surface via `AskUserQuestion` whether to run `/llm-wiki:post-merge-wiki` (that skill derives + gates the ingest candidates itself). Invoke on accept; else note as a manual follow-up.
+   - Skip silently if the `post-merge-wiki` skill is not installed.
+
 6. **Integrate Learnings into Configuration Files**
 
    > **Core Principle: No Stamps, Topical Names, Current State Only**


### PR DESCRIPTION
## Summary

Makes `post-merge-wiki` a first-class part of the `github-dev:post-merge` flow. Previously post-merge had **zero** wiki integration — the only nudge was the `wiki_post_commit_hint.sh` PostToolUse hook, which fires on local CLI merges only and never on GitHub-UI merges.

Adds a conditional **Step 5.8** to `plugins/github-dev/commands/post-merge.md`, inserted between Step 5.7 (spec-state) and Step 6, mirroring the spec-state "if present / skip if absent" pattern.

## Step 5.8 behavior

- Resolve the wiki root in order: `.llmwiki/wiki/` -> `.claude/wiki/` -> `.codex/wiki/`. Skip silently if none resolves (no hard dependency on llm-wiki).
- Skip trivial merges (typo / dep-bump / formatting — reuses `post-merge-wiki`'s own "Do NOT use" list).
- Otherwise surface via `AskUserQuestion` whether to run `/llm-wiki:post-merge-wiki`. Invoke on accept; else note as manual follow-up.
- Skip silently if the `post-merge-wiki` skill is not installed.

The hook is unchanged and complementary: hook = raw CLI merges, Step 5.8 = the post-merge workflow incl. UI merges.

## Versions

- `github-dev` 1.22.0 -> **1.23.0** (MINOR — new capability)
- matching `marketplace.json` entry -> 1.23.0
- `metadata.version` 1.34.0 -> **1.35.0**

## Verification

- `post-merge.md` reads cleanly with 5.7 -> 5.8 -> 6 ordering.
- Wiki-root resolution: repo with `.llmwiki/wiki/` resolves to it; repo with no wiki layer skips silently.
- `plugin.json` == `marketplace.json` for github-dev (1.23.0); JSON valid.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 병합 후 처리 워크플로우에 wiki ingest 기능이 추가되었습니다. 여러 위키 경로를 자동으로 감지하고 필요 시 사용자 확인 후 실행됩니다.

* **업데이트**
  * 플러그인 버전이 1.35.0으로 업그레이드되었습니다.
  * github-dev 플러그인 버전이 1.23.0으로 업데이트되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/YoungjaeDev/my-claude-plugins/pull/28?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->