### PR TITLE
chore: post-v2 maintenance — docs-forge frontmatter + settings.json local

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Personal Claude Code plugin collection with 22 specialized plugins",
-    "version": "1.35.0"
+    "version": "1.36.0"
   },
   "plugins": [
     {
@@ -103,7 +103,7 @@
       "name": "docs-forge",
       "source": "./plugins/docs-forge",
       "description": "README/CHANGELOG generation with CRO best practices",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "category": "documentation"
     },
     {

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -17,7 +17,12 @@
       "./plugins/workflow-viz",
       "./plugins/rules-forge",
       "./plugins/tcrei-prompt",
-      "./plugins/codex-bridge"
+      "./plugins/codex-bridge",
+      "./plugins/llm-wiki",
+      "./plugins/spec-state",
+      "./plugins/project-init",
+      "./plugins/paper-search-tools",
+      "./plugins/docs-forge"
     ]
   }
 }

--- a/plugins/docs-forge/.claude-plugin/plugin.json
+++ b/plugins/docs-forge/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "docs-forge",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "README and CHANGELOG generation with CRO best practices"
 }

--- a/plugins/docs-forge/skills/changelog-guide/SKILL.md
+++ b/plugins/docs-forge/skills/changelog-guide/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: changelog-guide
+description: CHANGELOG format and automation reference — writing patterns based on Keep a Changelog and Conventional Commits. Loaded by the docs-forge changelog workflow.
+---
+
 # CHANGELOG Guide
 
 This skill provides CHANGELOG writing patterns based on Keep a Changelog and Conventional Commits.

--- a/plugins/docs-forge/skills/readme-guide/SKILL.md
+++ b/plugins/docs-forge/skills/readme-guide/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: readme-guide
+description: README patterns and templates reference — writing best practices derived from awesome-readme examples. Loaded by the docs-forge readme workflow.
+---
+
 # README Guide
 
 This skill provides README writing patterns and best practices derived from awesome-readme examples.


### PR DESCRIPTION
## Summary

Post-llm-wiki-v2 maintenance bundle. Two committed cleanups + one local-only reconciliation.

### 1. docs-forge frontmatter (committed)
`changelog-guide/SKILL.md` and `readme-guide/SKILL.md` previously started with an H1 and had **no YAML frontmatter**, so codex-bridge's `codex-sync` could not parse a `name` and silently skipped them (`skipped: 2` every run). Added minimal `name` + `description` frontmatter to each.

- Dry-run before: `skipped: 2`
- Dry-run after: `synced: 53, skipped: 0, errors: 0`

### 2. settings.json local completion (committed)
`.claude/settings.json` `local` listed 17 of 22 plugins. Added the 5 missing: `llm-wiki`, `spec-state`, `project-init`, `paper-search-tools`, `docs-forge`. Lets the dev repo load these from local source (incl. llm-wiki **v2**) after a Claude Code restart.

> Caveat to verify after restart: if any of the 5 are also cache-installed, confirm no double-load.

### 3. Serena memory reconciliation (LOCAL ONLY — not in this PR)
`.serena/memories/project-structure.md` was reconciled to current reality (renamed oh-my-claudecode -> my-claude-plugins, removed phantom `omc`/`interactive-review`/`prd-suite`, added `spec-state`/`project-init`/`llm-wiki` + `.llmwiki/` note, fixed count to 22). **`.serena/` is gitignored**, so this is a local working-tree improvement and is intentionally NOT committed. Verified locally: plugin set matches `marketplace.json` exactly (22, no phantoms).

## Versions
- `docs-forge` 0.2.0 -> **0.2.1** (PATCH) + matching marketplace entry
- `metadata.version` 1.35.0 -> **1.36.0** (one past PR #28, per the version contract)

## Verification
- `node plugins/codex-bridge/scripts/sync.mjs --dry-run` -> `skipped: 0` (was 2)
- `plugin.json` == `marketplace.json` for docs-forge (0.2.1); all JSON valid
- settings.json local = 22, valid JSON
- Serena (local) plugin set == marketplace (22, no phantoms)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **설명서**
  * 문서 인식 메타데이터가 추가되어 설명서 관리가 개선되었습니다.

* **기타**
  * 플러그인 시스템 버전이 1.35.0에서 1.36.0으로 업데이트되었습니다.
  * 로컬 플러그인 구성이 확장되었습니다.
  * docs-forge 플러그인이 0.2.1로 업데이트되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/YoungjaeDev/my-claude-plugins/pull/29?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->