### PR TITLE
fix(github-dev): cr-fix Step 6 false-clean on CR rate-limit + Step 5c codex re-probe

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Personal Claude Code plugin collection with 22 specialized plugins",
-    "version": "1.36.0"
+    "version": "1.38.0"
   },
   "plugins": [
     {
@@ -19,7 +19,7 @@
       "name": "github-dev",
       "source": "./plugins/github-dev",
       "description": "GitHub workflow: commit, PR, issue, worktree, unified CodeRabbit + ChatGPT-Codex cr-fix pipeline (now a multi-file skill: wait + auto-fetch + apply + push loop with branch-protection-gated auto-merge, CR-engagement guard, Codex review-id discovery + dedupe, CR Nitpick + Codex P3 silent skip, optional --skip-minor; rate-limit early-escape with auto fallback to local CodeRabbit CLI or Codex-only via --cr-source), project tracking, release",
-      "version": "1.23.0",
+      "version": "1.24.0",
       "category": "github"
     },
     {

--- a/plugins/github-dev/.claude-plugin/plugin.json
+++ b/plugins/github-dev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "github-dev",
-  "version": "1.23.0",
+  "version": "1.24.0",
   "description": "GitHub workflow automation commands for Claude Code",
   "commands": [
     "./commands/commit-and-push.md",

--- a/plugins/github-dev/skills/cr-fix/SKILL.md
+++ b/plugins/github-dev/skills/cr-fix/SKILL.md
@@ -155,7 +155,10 @@ s=$(gh api "repos/$OWNER/$REPO/commits/$CUR_SHA/status" \
 When `s == "success"` (CR status flipped to success before polling started), CR may still be rate-limited — the `CodeRabbit` commit status reports `success` with description `"Review completed"` even when the review payload is just a `Review limit reached` comment. The polling-time self-escape inside `poll-cr-status.sh` never runs in that path, so check the issue-comments stream once before treating the iter as clean:
 
 ```bash
-PUSH_TIME=${PUSH_TIME:-$(bash $SKILL_DIR/scripts/push-time.sh "$OWNER" "$REPO" "$CUR_SHA")}
+# Always recompute against the current SHA — Step 12 resets only TRACK_FILE,
+# so a stale PUSH_TIME from a previous iter would let sniff-cr-rate-limit.sh
+# match an old `Review limit reached` comment against the wrong push window.
+PUSH_TIME=$(bash $SKILL_DIR/scripts/push-time.sh "$OWNER" "$REPO" "$CUR_SHA")
 if [ "$s" = "success" ]; then
   if rl=$(bash $SKILL_DIR/scripts/sniff-cr-rate-limit.sh "$OWNER" "$REPO" "$PR_NUM" "$PUSH_TIME" 2>/dev/null); then
     s=rate_limited
@@ -274,7 +277,9 @@ codex_records=$(bash $SKILL_DIR/scripts/fetch-codex-comments.sh "$OWNER" "$REPO"
 Skip when `CR_SOURCE ∈ {cli, codex-only}`. Otherwise, if `(cr_records + codex_records) == 0`:
 
 ```bash
-PUSH_TIME=${PUSH_TIME:-$(bash $SKILL_DIR/scripts/push-time.sh "$OWNER" "$REPO" "$CUR_SHA")}
+# Always recompute PUSH_TIME against the current SHA so engagement-gate.sh
+# anchors its comment-window check to this iteration's push, not a stale one.
+PUSH_TIME=$(bash $SKILL_DIR/scripts/push-time.sh "$OWNER" "$REPO" "$CUR_SHA")
 cr_engagement=$(bash $SKILL_DIR/scripts/engagement-gate.sh "$OWNER" "$REPO" "$PR_NUM" "$PUSH_TIME")
 ```
 

--- a/plugins/github-dev/skills/cr-fix/SKILL.md
+++ b/plugins/github-dev/skills/cr-fix/SKILL.md
@@ -110,7 +110,7 @@ When `--cr-source=auto`, the PR has Codex active, AND the diff is small, silentl
 
 ```bash
 if [ "$ITER" = "1" ] && [ "$CR_SOURCE" = "auto" ] && [ "$SMALL_DIFF_LOC" -gt 0 ]; then
-  # Probe Codex engagement first; reuse the result for Step 6.
+  # Probe Codex engagement first; reuse the result for Step 5c / Step 6.
   codex_active=$(bash $SKILL_DIR/scripts/probe-codex-engagement.sh "$OWNER" "$REPO" "$PR_NUM")
   [ "$NO_CODEX" = "true" ] && codex_active=disabled
   if [ "$codex_active" = "active" ]; then
@@ -125,11 +125,9 @@ if [ "$ITER" = "1" ] && [ "$CR_SOURCE" = "auto" ] && [ "$SMALL_DIFF_LOC" -gt 0 ]
 fi
 ```
 
-## Step 6: Wait phase — CodeRabbit
+### Step 5c: Codex re-probe (decoupled from CR wait)
 
-Skip entirely when `CR_SOURCE ∈ {cli, codex-only}`. Otherwise:
-
-**Codex auto-detect**: refresh `codex_active` for this iter. First iter probes always; later iters re-probe only if cache is still `inactive` (sticky `active`/`disabled`). See `references/codex-state-machine.md`.
+Refresh `codex_active` once per iter **before** the CR status check. Codex submission can lag push by 1-3 minutes, so the iter-1 probe done in Step 5b (or here on non-auto sources) often returns `inactive` while a Codex review is still in flight. Re-probing here — instead of nesting the probe inside the CR polling block — ensures Codex output is surfaced even when CR returns `state=success` up-front and Step 6's polling path is skipped. Sticky semantics: `active` and `disabled` never flip back; only `inactive` is re-probed. See `references/codex-state-machine.md`.
 
 ```bash
 if [ "$ITER" = "1" ] && [ "$codex_active" = "unknown" ]; then
@@ -141,12 +139,33 @@ elif [ "$codex_active" = "inactive" ]; then
 fi
 ```
 
+## Step 6: Wait phase — CodeRabbit
+
+Skip entirely when `CR_SOURCE ∈ {cli, codex-only}`. Otherwise:
+
 **CR status probe + poll** (single object via `[ ... ][0]` to dodge multi-status races):
 
 ```bash
 s=$(gh api "repos/$OWNER/$REPO/commits/$CUR_SHA/status" \
   --jq '[.statuses[] | select(.context | test("CodeRabbit"; "i"))][0] // empty | .state')
 ```
+
+### Step 6a: Rate-limit sniff on up-front `success`
+
+When `s == "success"` (CR status flipped to success before polling started), CR may still be rate-limited — the `CodeRabbit` commit status reports `success` with description `"Review completed"` even when the review payload is just a `Review limit reached` comment. The polling-time self-escape inside `poll-cr-status.sh` never runs in that path, so check the issue-comments stream once before treating the iter as clean:
+
+```bash
+PUSH_TIME=${PUSH_TIME:-$(bash $SKILL_DIR/scripts/push-time.sh "$OWNER" "$REPO" "$CUR_SHA")}
+if [ "$s" = "success" ]; then
+  if rl=$(bash $SKILL_DIR/scripts/sniff-cr-rate-limit.sh "$OWNER" "$REPO" "$PR_NUM" "$PUSH_TIME" 2>/dev/null); then
+    s=rate_limited
+    rate_limit_hits=$((rate_limit_hits + 1))
+    # Fall through to Step 7c (rate-limit fallback table).
+  fi
+fi
+```
+
+The sniff is one extra `gh pr view --json comments,reviews` per iter — unconditional on the success branch, no flag. Detects the literal `Review limit reached` marker (case-insensitive) along with the other 2 patterns documented in `references/rate-limit-fallback.md`. The follow-up `s=rate_limited` reuses the existing Step 6 termination branch so 7c handles the fallback uniformly.
 
 If `s` is not yet `success`/`failure`, compute `PUSH_TIME` then spawn the poller:
 


### PR DESCRIPTION
## Summary

Closes two structural holes in `github-dev:cr-fix` Step 6 that combined to declare a PR clean while CR was rate-limited AND Codex had submitted P1 findings ~2 minutes after push.

- **Step 6a (new sub-step)**: when the CR commit status reports `state=success` up-front, run `scripts/sniff-cr-rate-limit.sh` against the PR issue-comments stream before treating the iter as clean. If a rate-limit marker is detected (including the literal `Review limit reached` body), set `s=rate_limited` and fall through to the existing Step 7c fallback table. One extra `gh pr view` call per success iter, unconditional, no flag.
- **Step 5c (new step)**: lift the Codex re-probe block out of Step 6's polling pseudo-code into a standalone step that runs **before** the CR status check, regardless of whether polling will be needed. Spec calls out the 1-3 min iter-1 timing race that motivated the decoupling. Sticky `active`/`disabled` semantics preserved.

## Evidence — PR #30 incident

Push at `2026-05-29T13:07:51Z` to https://github.com/YoungjaeDev/my-claude-plugins/pull/30 . Observed timeline:

| Time | Event | Source |
|---|---|---|
| `13:07:51Z` | Push of head SHA | git |
| `13:07:54Z` | `coderabbitai[bot]` posts comment with body starting `## Review limit reached` | PR issue-comments |
| `13:07:55Z` | `CodeRabbit` commit status flips to `state=success`, `description="Review completed"` | `/commits/{sha}/statuses` |
| `13:09:36Z` | `chatgpt-codex-connector[bot]` submits review with 2 P1 findings | `/pulls/30/reviews` |

What cr-fix did pre-fix:
1. Step 6 saw `s=success` immediately, took the success branch to Step 6b.
2. Step 6's nested Codex re-probe was bypassed along with polling, so `codex_active=inactive` (frozen from iter-1 Step 5b probe at push+0s) — Step 6b skipped review-id discovery.
3. Step 8c engagement-gate counted the rate-limit comment as `cr_engagement=1`, declared `final_state=clean`, exited the loop.
4. Net result: rate-limit silently hidden behind "success", 2 substantive P1 findings never surfaced.

## What changes

- `plugins/github-dev/skills/cr-fix/SKILL.md` — adds Step 5c (decoupled Codex re-probe) and Step 6a (rate-limit sniff on up-front success); removes the nested codex auto-detect block previously inside Step 6.
- `plugins/github-dev/.claude-plugin/plugin.json` — version `1.23.0` → `1.24.0` (MINOR: spec-level edge-case handling, no CLI surface change).
- `.claude-plugin/marketplace.json` — `github-dev` entry bumped to match; `metadata.version` `1.36.0` → `1.38.0` (jumped past concurrent PR #30's `1.37.0` bump per `.claude/rules/plugin-versioning.md` concurrent-branch guidance).

## Out of scope

- `--cr-source=cli` and `--cr-source=codex-only` paths unchanged (Step 6 already skipped entirely for those modes).
- Step 7c rate-limit fallback table unchanged.
- `sniff-cr-rate-limit.sh` already matches `Review limit reached`; no script edit needed.

## Test plan

Manual rebroadcast of the PR #30 timeline against the patched skill:

- [ ] On a PR where CR posts a `Review limit reached` body within 3s of push AND the commit status flips to `state=success`, confirm cr-fix logs `cr-source: auto → cli` (or `→ codex-only`) instead of declaring `final_state=clean`. Trigger: re-run `/github-dev:cr-fix` against PR #30 after the patch lands.
- [ ] On the same PR, confirm Step 6b discovers and surfaces the Codex review submitted ~2 min after push (i.e. `codex_active` flips from `inactive` to `active` between iter 1 and iter 2, OR the re-probe inside Step 5c catches it before Step 6 runs).
- [ ] On a healthy PR with no rate-limit (`success` is genuinely a clean review), confirm cr-fix still reaches `final_state=clean` and does NOT regress into a false rate-limit branch — the extra sniff call is one `gh pr view` per success iter.
- [ ] `python3 -c "import json; json.load(open('plugins/github-dev/.claude-plugin/plugin.json')); json.load(open('.claude-plugin/marketplace.json'))"` parses both.
- [ ] `bash -n plugins/github-dev/skills/cr-fix/scripts/sniff-cr-rate-limit.sh` (script unchanged but verified).