### PR TITLE
Post-v2 harness maintenance: memory nudge · post-merge trim · wiki autonomy · state-tracker doc

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Personal Claude Code plugin collection with 22 specialized plugins",
-    "version": "1.36.0"
+    "version": "1.37.0"
   },
   "plugins": [
     {
       "name": "core-config",
       "source": "./plugins/core-config",
       "description": "Python auto-format + cross-platform notifications. Work guidelines live in ~/.claude/CLAUDE.md (SSOT).",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "category": "core"
     },
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -19,7 +19,7 @@
       "name": "github-dev",
       "source": "./plugins/github-dev",
       "description": "GitHub workflow: commit, PR, issue, worktree, unified CodeRabbit + ChatGPT-Codex cr-fix pipeline (now a multi-file skill: wait + auto-fetch + apply + push loop with branch-protection-gated auto-merge, CR-engagement guard, Codex review-id discovery + dedupe, CR Nitpick + Codex P3 silent skip, optional --skip-minor; rate-limit early-escape with auto fallback to local CodeRabbit CLI or Codex-only via --cr-source), project tracking, release",
-      "version": "1.23.0",
+      "version": "1.23.1",
       "category": "github"
     },
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -152,7 +152,7 @@
       "name": "spec-state",
       "source": "./plugins/spec-state",
       "description": "Spec/issue/PR work-pipeline aggregate. state-tracker skill manages .claude/state/spec.json (read/init/start/complete). Called by github-dev:post-merge.",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "category": "workflow"
     },
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -145,7 +145,7 @@
       "name": "llm-wiki",
       "source": "./plugins/llm-wiki",
       "description": "Karpathy LLM-Wiki 3-layer: 6 skills (query/ingest/lint/bootstrap/migrate/post-merge-wiki) + 3 soft-hint hooks + bootstrap templates. Neutral .llmwiki/ root (codex-bridge .claude/->.codex/ can't fork it); resolves .llmwiki/wiki -> legacy .claude/wiki -> .codex/wiki.",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "category": "memory"
     },
     {

--- a/plugins/core-config/.claude-plugin/plugin.json
+++ b/plugins/core-config/.claude-plugin/plugin.json
@@ -5,6 +5,7 @@
   "hooks": {
     "UserPromptSubmit": [
       {
+        "matcher": "",
         "hooks": [
           {
             "type": "command",

--- a/plugins/core-config/.claude-plugin/plugin.json
+++ b/plugins/core-config/.claude-plugin/plugin.json
@@ -1,8 +1,19 @@
 {
   "name": "core-config",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Core development configuration: Python auto-format + cross-platform notifications. Work guidelines live in ~/.claude/CLAUDE.md (SSOT).",
   "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/memory_nudge.sh",
+            "timeout": 5000
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Write|Edit",

--- a/plugins/core-config/CLAUDE.md
+++ b/plugins/core-config/CLAUDE.md
@@ -8,6 +8,9 @@ Development workflow essentials: Python formatting and notifications.
 |------|---------|-------------|
 | `auto-format-python.py` | Post Write/Edit | Auto-format Python with ruff |
 | `notify_osc.sh` | Stop/Notification | Terminal OSC 777 notifications |
+| `memory_nudge.sh` | UserPromptSubmit | Soft memory-discipline reminder (rate-limited ~3h per cwd) |
+
+`memory_nudge.sh` does **not** re-inject `~/.claude/CLAUDE.md` — that was the `inject-guidelines` `UserPromptSubmit` hook removed in v1.4.0, because CLAUDE.md is native-loaded once per session and re-injecting it every prompt wasted context. Instead it emits a rate-limited 4-line soft hint nudging the LLM to *recall* and *save* memory it already has loaded (MEMORY.md index + the `# Memory` section of `~/.claude/CLAUDE.md`). Quiet by default; output becomes `additionalContext`. Disable by removing the `UserPromptSubmit` block from `plugin.json`.
 
 ## Guidelines
 

--- a/plugins/core-config/hooks/memory_nudge.sh
+++ b/plugins/core-config/hooks/memory_nudge.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# UserPromptSubmit hook — soft memory-discipline reminder.
+# Quiet by default. Anything printed to stdout becomes additionalContext for the LLM.
+# Rate-limited to once per ~3h per workspace via /tmp marker.
+#
+# This does NOT re-inject CLAUDE.md (that was the removed `inject-guidelines`
+# anti-pattern — ~/.claude/CLAUDE.md is native-loaded once per session). It only
+# nudges the LLM to USE the memory Claude Code already auto-loads.
+
+set -u
+exec 2>/dev/null  # discard stderr — hooks should never spam the user
+
+export LC_ALL=C.UTF-8
+
+# Rate-limit: only emit once per window per cwd (window tunable)
+WINDOW=10800  # ~3h
+marker="/tmp/memory_nudge.$(printf '%s' "$PWD" | cksum | cut -d' ' -f1)"
+if [[ -f "$marker" ]]; then
+  age=$(( $(date +%s) - $(stat -c %Y "$marker" 2>/dev/null || stat -f %m "$marker" 2>/dev/null || echo 0) ))
+  [[ $age -lt $WINDOW ]] && exit 0
+fi
+touch "$marker"
+
+cat <<'EOF'
+[memory-hint] Project + user memory is loaded (MEMORY.md index + ~/.claude/CLAUDE.md "# Memory").
+- Recall relevant memories before deciding — they hold prior decisions and user preferences.
+- Save durable user facts / workflow feedback / project constraints to memory as you learn them (one fact per file + a MEMORY.md pointer).
+- Correct or delete memories that prove wrong; don't save what the repo or git already records.
+EOF
+
+exit 0

--- a/plugins/github-dev/.claude-plugin/plugin.json
+++ b/plugins/github-dev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "github-dev",
-  "version": "1.23.0",
+  "version": "1.23.1",
   "description": "GitHub workflow automation commands for Claude Code",
   "commands": [
     "./commands/commit-and-push.md",

--- a/plugins/github-dev/commands/post-merge.md
+++ b/plugins/github-dev/commands/post-merge.md
@@ -202,6 +202,13 @@ Perform local branch cleanup and configuration updates after a PR has been merge
      - `GEMINI.md` - Google Gemini CLI specific instructions
      - `.claude/rules/*.md` - Modular rule files
 
+   - **Expected root config structure** (CLAUDE.md, AGENTS.md, GEMINI.md):
+     1. Project Context - Business goal + tech stack (1-2 sentences)
+     2. Commands - Package manager and run commands
+     3. Golden Rules - Immutable / Do's / Don'ts
+     4. Modular Rules - `See @.claude/rules/[module].md` references
+     5. Project-Specific - Data locations, key modules, tracking, etc.
+
    - **Classification and Placement** (applies to all config files):
 
      | Learning Type | Target Section | Action |
@@ -233,7 +240,17 @@ Perform local branch cleanup and configuration updates after a PR has been merge
    - **Modular Rule Files** (.claude/rules/*.md):
      - Check if relevant module file exists
      - Propose path-specific rules with frontmatter: `paths: src/[module]/**`
-     - Follow structure: Role, Key Components, Do's, Don'ts
+     - Follow this structure:
+       ```markdown
+       ---
+       paths: src/[module]/**  # Optional: conditional loading
+       ---
+       # [Module] Rules
+       Role description (1-2 lines)
+       ## Key Components
+       ## Do's
+       ## Don'ts
+       ```
      - **Always confirm with user before creating new rule files**
 
    - **Pre-presentation validation (stamp self-check)**:
@@ -390,70 +407,3 @@ After Step 6 integration is applied, measure normative docs and offer split/impr
    - Stage only modified files: `git add CLAUDE.md AGENTS.md GEMINI.md README.md .serena/memories/ 2>/dev/null || true`
 
 > Follow ~/.claude/CLAUDE.md and project CLAUDE.md.
-
-## Configuration File Integration Guide
-
-The following guidelines apply to CLAUDE.md, AGENTS.md, GEMINI.md, and `.claude/rules/*.md`:
-
-### Expected File Structure
-
-**Root Config (CLAUDE.md, AGENTS.md, GEMINI.md)**:
-1. Project Context - Business goal + tech stack (1-2 sentences)
-2. Commands - Package manager and run commands
-3. Golden Rules - Immutable / Do's / Don'ts
-4. Modular Rules - `See @.claude/rules/[module].md` references
-5. Project-Specific - Data locations, key modules, tracking, etc.
-
-**Modular Rules (.claude/rules/*.md)**:
-```markdown
----
-paths: src/[module]/**  # Optional: conditional loading
----
-# [Module] Rules
-Role description (1-2 lines)
-## Key Components
-## Do's
-## Don'ts
-```
-
-### Anti-Patterns (NEVER do these)
-
-→ See **Core Principle: No Stamps, Topical Names, Current State Only** at the top of Step 6.
-
-Summary:
-- Never cite a PR or issue inside a normative doc (inline, header, or footnote) -- exception: sections marked `<!-- history-allowed -->` (see Step 6 Core Principle exception)
-- No `## Post-Merge` style changelog sections; no `post_merge_prN.md` style PR-specific memory files
-- No append-only patterns -- update existing sections in place
-- No historical narrative -- write in current-state form
-
-### Correct Integration Examples
-
-**Instead of**:
-```markdown
-## Post-Merge Notes (PR #130)
-- Preview Mode removed. Dispatcher is direct-send only.
-- Admin Nav changed from 4 tabs to 3 tabs.
-```
-
-**Do this**:
-```markdown
-## Golden Rules
-### Don'ts
-- Never reintroduce preview branching (Dispatcher is registerSendFunction() + direct-send only)
-
-## Key Modules
-| apps/electron-admin/ | Electron admin app (...3 nav tabs: Dashboard / AI / Settings...) |
-```
-
-### Examples of Content to Remove
-- Temporary notes like `TODO: remove after #123 is resolved`
-- Temporary workaround descriptions for specific issues
-- Known issues lists that have been resolved
-- Any existing `## Post-Merge Notes (PR #N)` sections (migrate content first)
-
-### Examples of Content to Modify
-- Changed directory structure descriptions
-- Updated dependency information
-- Commands or configurations that are no longer valid
-- Module descriptions that no longer match reality
-- Test counts that have changed

--- a/plugins/llm-wiki/.claude-plugin/plugin.json
+++ b/plugins/llm-wiki/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "llm-wiki",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Karpathy LLM-Wiki 3-layer system: 6 skills (query/ingest/lint/bootstrap/migrate/post-merge-wiki) + 3 soft-hint hooks (stale check, post-commit hint, session-start lint hint). Uses the neutral .llmwiki/ root (so codex-bridge's .claude/->.codex/ transform can't fork it); resolves .llmwiki/wiki -> legacy .claude/wiki -> .codex/wiki. For spec/issue/PR work-pipeline state see the spec-state plugin.",
   "hooks": {
     "UserPromptSubmit": [

--- a/plugins/llm-wiki/skills/post-merge-wiki/SKILL.md
+++ b/plugins/llm-wiki/skills/post-merge-wiki/SKILL.md
@@ -56,12 +56,15 @@ Do NOT use:
    - New pages inside existing domains (rare)
    - New domain dir (needs user approval — surface as a question, do not auto-create)
 
-4. **Present the candidates to the user via AskUserQuestion**:
-   - Show the list with 1-line summaries
-   - Let user pick which to ingest, which to skip
-   - Multi-select OK
+4. **Triage candidates by autonomy boundary** (see the table below):
+   - **Auto-ingest** high-confidence within-domain candidates — an existing-page update or a new page inside an existing domain, each tied to a concrete file from `git show --name-only`. No prompt; these land autonomously and appear in the Step 6 final report.
+   - **Gate via `AskUserQuestion`** only the candidates that cross an autonomy boundary:
+     - a new domain dir (`ingest-finding` would create a top-level domain)
+     - a `> Contradicts:` that needs resolution against an existing page
+     - a `rules/*.md` invariant change (alert only — never auto-edit)
+   - Show 1-line summaries; multi-select OK. If nothing is gated, skip the prompt and proceed straight to ingest.
 
-5. **For each accepted candidate**: invoke `/llm-wiki:ingest-finding` (or call its steps inline if already loaded). The ingest skill handles the diff-log + cross-update discipline, and applies v2 frontmatter defaults (`status: active`, inferred `volatility:`, `sources:`) to any new page it creates.
+5. **For each candidate cleared to ingest** (auto-ingested within-domain candidates + any gated candidate the user accepted): invoke `/llm-wiki:ingest-finding` (or call its steps inline if already loaded). The ingest skill handles the diff-log + cross-update discipline, and applies v2 frontmatter defaults (`status: active`, inferred `volatility:`, `sources:`) to any new page it creates.
 
 6. **Final report**:
    - Pages updated (with `last_verified:` bump count)
@@ -78,8 +81,9 @@ Do NOT use:
 | Update existing wiki page (via `ingest-finding`) | ✅ | — |
 | Add new wiki page inside existing domain | ✅ | — |
 | Add new wiki domain dir | ❌ | ✅ |
+| Resolve a `> Contradicts:` against an existing page | ❌ | ✅ |
 | Modify `rules/*.md` invariant | ❌ (alert only) | ✅ |
-| Skip a candidate the user didn't review | ❌ | ✅ |
+| Skip a *gated* candidate the user didn't review | ❌ | ✅ |
 
 ## Output format
 
@@ -90,7 +94,7 @@ Candidates (file → finding → evidence):
 - <touched-file> → <1-line finding> → <evidence-file>
 - ...
 
-Accepted: <list> | Skipped: <list>
+Auto-ingested: <list> | Gated→accepted: <list> | Skipped: <list>
 
 Result:
 - Pages updated: <domain>/<page>.md (last_verified bumped)
@@ -108,7 +112,7 @@ Candidates (file → finding → evidence):
 - src/providers/x.py → provider X returns null on >8KB inputs → src/providers/x.py
 - src/cache.py → no lore (mechanical refactor) → (dropped)
 
-Accepted: backend/provider-x.md | Skipped: cache refactor
+Auto-ingested: backend/provider-x.md | Gated→accepted: (none) | Skipped: cache refactor
 
 Result:
 - Pages updated: (none)
@@ -123,12 +127,12 @@ Result:
 - Pages touched have `last_verified: <today>`
 - New pages carry v2 frontmatter defaults (`status: active`, inferred `volatility:`, `sources:`)
 - No raw `[[wikilink]]` introduced (typed grammar only)
-- User explicitly approved the candidate list before any wiki edit
+- User approved any *gated* candidate (new domain / contradiction / `rules/*.md`); within-domain ingests proceed autonomously and appear in the Step 6 final report
 - Every ingested candidate maps to a concrete file in `git show --name-only`
 
 ## Anti-patterns
 
-- **Auto-ingest without user review** — surprise edits to lore erode trust.
+- **Auto-create a new domain / resolve a contradiction / change a `rules/*.md` invariant without review** — these cross an autonomy boundary and erode trust. (Within-domain ingests — existing-page updates and new pages inside an existing domain — are *intended* to proceed autonomously; see the autonomy table.)
 - **Ingest every trivial fix** — wiki becomes a churn log instead of a synthesis layer.
 - **Skip the diff log** — `ingest-finding` requires the resolved root's `log.md` entry first; don't shortcut it here either.
 - **Run before `github-dev:post-merge`** — branch cleanup + milestone state must settle first.

--- a/plugins/spec-state/.claude-plugin/plugin.json
+++ b/plugins/spec-state/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "spec-state",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Spec/issue/PR work-pipeline aggregate. Manages .claude/state/spec.json with read/init/start/complete ops. Called by github-dev:post-merge. No hooks."
 }

--- a/plugins/spec-state/CLAUDE.md
+++ b/plugins/spec-state/CLAUDE.md
@@ -50,6 +50,15 @@ Cache is regeneratable any time. Direct JSON edits are allowed but rare — pref
 - `github-dev:post-merge` auto-calls `complete <spec-path>` after a merge to update the cache.
 - `llm-wiki` is independent — wiki lore (`.llmwiki/wiki/log.md`) tracks knowledge events; spec-state tracks the work pipeline.
 
+## Wiring status
+
+The write-side wiring is intentionally asymmetric:
+
+- **`complete` is auto-wired** — `github-dev:post-merge` Step 5.7 fires `complete <spec-path>` after a merge.
+- **`start` / `init` are NOT auto-wired** into `resolve-issue` / `decompose-issue`. They run manually, or as part of the `superpowers:writing-plans` chain.
+
+Consequence: `.claude/state/spec.json` stays absent until the first `start` / `init` in a repo. This dormancy is **by design**, not a bug — the cache materializes only once a tracked spec begins, and `complete` no-ops gracefully when the file is absent (see Conditional behavior). There is no overlap with `llm-wiki`: that plugin tracks durable knowledge lore, spec-state tracks transient work-pipeline state.
+
 ## Conditional behavior
 
 Safe to install in any repo. Skill operations no-op gracefully when `.claude/state/spec.json` (and `.claude/spec/`) are absent — `read` prints empty state, `init` requires user confirmation.

--- a/plugins/spec-state/CLAUDE.md
+++ b/plugins/spec-state/CLAUDE.md
@@ -57,7 +57,7 @@ The write-side wiring is intentionally asymmetric:
 - **`complete` is auto-wired** — `github-dev:post-merge` Step 5.7 fires `complete <spec-path>` after a merge.
 - **`start` / `init` are NOT auto-wired** into `resolve-issue` / `decompose-issue`. They run manually, or as part of the `superpowers:writing-plans` chain.
 
-Consequence: `.claude/state/spec.json` stays absent until the first `start` / `init` in a repo. This dormancy is **by design**, not a bug — the cache materializes only once a tracked spec begins, and `complete` no-ops gracefully when the file is absent (see Conditional behavior). There is no overlap with `llm-wiki`: that plugin tracks durable knowledge lore, spec-state tracks transient work-pipeline state.
+Consequence: `.claude/state/spec.json` stays absent until the first `start` / `init` in a repo. This dormancy is **by design**, not a bug — the cache materializes only once a tracked spec begins, and `github-dev:post-merge` Step 5.7 only fires `complete` when `.claude/state/` already exists, so the auto-call never hits a missing file. There is no overlap with `llm-wiki`: that plugin tracks durable knowledge lore, spec-state tracks transient work-pipeline state.
 
 ## Conditional behavior
 


### PR DESCRIPTION
Post-v2 harness maintenance bundle — four independent changes, one commit each (PR #29 bundle precedent).

## Changes

1. **core-config 1.4.0 → 1.5.0** (`feat`) — new `memory_nudge.sh` `UserPromptSubmit` hook. Rate-limited (~3h/cwd) 4-line soft hint nudging recall/save discipline for already-loaded memory. Modeled on `wiki_stale_check.sh` (quiet by default, `/tmp` marker via `cksum`, POSIX `stat`/`date` fallbacks). Does **not** re-inject CLAUDE.md — that was the `inject-guidelines` anti-pattern removed in 1.4.0.

2. **github-dev 1.23.0 → 1.23.1** (`docs`) — trim the `post-merge.md` "Configuration File Integration Guide" appendix, which duplicated Step 6 (Anti-Patterns / Correct Integration Examples / Content to Remove+Modify). The unique "Expected File Structure" block is preserved by folding it into Step 6. No control-flow change. 459 → 409 lines, 29.2KB → 27.6KB.

3. **llm-wiki 1.2.0 → 1.3.0** (`feat`) — relax `post-merge-wiki` Step 4: auto-ingest high-confidence within-domain candidates (each tied to a concrete file from `git show --name-only`); gate via `AskUserQuestion` only boundary-crossing candidates (new domain / `> Contradicts:` resolution / `rules/*.md` change). Aligns the skill with its own autonomy table and `ingest-finding`'s boundary. The `post-merge` Step 5.8 run-gate (whether to run the skill at all) is unchanged.

4. **spec-state 1.0.1 → 1.0.2** (`docs`) — document the intentional write-side asymmetry: `complete` is auto-wired (post-merge 5.7), `start`/`init` are not. Dormancy until first `start`/`init` is by design. No behavior change.

## Versioning (ACTION REQUIRED AT MERGE)

`metadata.version` is set to a **working value of 1.37.0** (base `origin/main` = 1.36.0 + 1). It is **NOT** the final value. Per `.claude/rules/plugin-versioning.md`, re-check `metadata.version` against `origin/main` immediately before merge and bump past whatever has already landed.

In-flight contenders that also bump `metadata.version`: PR #30 (code-scout v2.1, claims 1.37.0), PR #31, PR #23. Two branches both landing 1.37.0 merge with **no git conflict** (identical values) → main silently ends a release short. After this PR merges, verify `metadata.version` advanced past every concurrent release.

Per-plugin `plugin.json` ↔ `marketplace.json` versions are synced and verified. Plugin count unchanged (no plugin added/removed).

## Verification

- codex-bridge suite: 122/122 pass
- `codex-sync --dry-run`: `synced: 53, skipped: 0, errors: 0`
- `memory_nudge.sh`: `bash -n` clean; fires once then silent within window; emits no CLAUDE.md body
- `post-merge.md`: Core Principle intact, Expected File Structure folded into Step 6, appendix removed