### PR TITLE
feat(codex-bridge): --emit plugin mode (Codex native plugin packages)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Personal Claude Code plugin collection with 22 specialized plugins",
-    "version": "1.39.0"
+    "version": "1.40.0"
   },
   "plugins": [
     {
@@ -137,8 +137,8 @@
     {
       "name": "codex-bridge",
       "source": "./plugins/codex-bridge",
-      "description": "Sync my-claude-plugins skills, commands, and subagents to Codex (~/.agents/skills/ for skills+commands, ~/.codex/agents/*.toml for subagents — USER scope) so they become callable as native $skill-name / subagent. Body-only transform with bridge_source provenance marker.",
-      "version": "1.4.0",
+      "description": "Sync my-claude-plugins skills, commands, and subagents to Codex. User mode (~/.agents/skills/ + ~/.codex/agents/*.toml — USER scope, native $skill-name) or plugin emit (--emit plugin builds committable Codex plugin packages under codex/plugins/** + .agents/plugins/marketplace.json for `codex plugin marketplace add`). Body-only transform with bridge_source provenance marker.",
+      "version": "1.5.0",
       "category": "integration"
     },
     {

--- a/README.md
+++ b/README.md
@@ -367,9 +367,22 @@ OMC 플러그인 skill 들 (`plugins/*/skills/**/SKILL.md`)을 Codex CLI 가 네
 - Claude Code: `$codex-sync [options]`
 - Direct CLI: `node plugins/codex-bridge/scripts/sync.mjs [options]`
 
-**CLI options:** `--dry-run`, `--verbose`, `--config <path>`, `--plugin <list>`, `--no-prune`, `--report <path>`
+**CLI options:** `--emit <user|plugin>`, `--dry-run`, `--verbose`, `--config <path>`, `--plugin <list>`, `--no-prune`, `--report <path>`
 
-**Requirements:** Node 18+, Codex CLI 0.120.0+
+**Plugin emit (`--emit plugin`):** 개별 파일 복사 대신 **Codex 네이티브 plugin 패키지**를 repo 안에 빌드 → `codex plugin marketplace add` 1줄 설치 + `git pull` 업데이트. `$HOME` 미접촉(순수 repo 산출물).
+
+```bash
+node plugins/codex-bridge/scripts/sync.mjs --emit plugin        # 전체 빌드
+# 원격 1줄 설치 (push 후):
+codex plugin marketplace add YoungjaeDev/my-claude-plugins
+codex plugin add <plugin>@my-claude-plugins
+```
+
+산출물: `.agents/plugins/marketplace.json`(카탈로그) + `codex/plugins/<plugin>/{.codex-plugin/plugin.json, skills/, AGENTS.md}`. commands→`<plugin>-<command>` skill wrap, agents/hooks→`AGENTS.md` 문서화(Codex plugin.json 은 `agents`/Claude-hook 미지원). transform scope: plugin-local `/<plugin>:skill` 보존, 외부 참조만 `$skill` 평탄화.
+
+**Codex 마켓플레이스 범위:** 20개 plugin 등록. `midjourney`(config `exclude`), `core-config`(호출 가능한 skill 없음 — hooks 전용)는 제외. user-mode `~/.agents/skills/` 동기화는 영향 없음(backward compat).
+
+**Requirements:** Node 18+, Codex CLI 0.120.0+ (plugin emit 빌드는 코어; 설치/검증은 0.134.0 에서 확인)
 
 </details>
 

--- a/plugins/codex-bridge/.claude-plugin/plugin.json
+++ b/plugins/codex-bridge/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "codex-bridge",
-  "version": "1.4.0",
-  "description": "Sync my-claude-plugins skills, commands, and subagents to Codex (~/.agents/skills/ for skills+commands, ~/.codex/agents/*.toml for subagents) with body-only transform and bridge_source provenance marker"
+  "version": "1.5.0",
+  "description": "Sync my-claude-plugins skills, commands, and subagents to Codex — user mode (~/.agents/skills/ + ~/.codex/agents/*.toml) or plugin emit (--emit plugin builds committable Codex plugin packages: codex/plugins/** + .agents/plugins/marketplace.json for `codex plugin marketplace add`). Body-only transform with bridge_source provenance marker"
 }

--- a/plugins/codex-bridge/CLAUDE.md
+++ b/plugins/codex-bridge/CLAUDE.md
@@ -20,9 +20,19 @@ my-claude-plugins 의 skill / command / subagent 를 Codex CLI 가 네이티브�
 1. Claude Code skill: `/codex-bridge:codex-sync` (이 플러그인 활성화 시)
 2. Direct CLI: `node plugins/codex-bridge/scripts/sync.mjs [options]`
 
+## Emit modes
+
+- **`--emit user`** (기본): `~/.agents/skills/`(skills+commands) + `~/.codex/agents/*.toml`(subagents) 로 복사. 개별 파일 sync, 머신마다 재실행 필요.
+- **`--emit plugin`**: repo 안에 Codex 네이티브 plugin 패키지 빌드 → `codex plugin marketplace add` 로 통째 설치. `$HOME` 미접촉(순수 repo 산출물).
+  - `.agents/plugins/marketplace.json` (카탈로그) + `codex/plugins/<plugin>/{.codex-plugin/plugin.json, skills/, AGENTS.md}`
+  - commands → `<plugin>-<command>` skill wrap, agents/hooks → `AGENTS.md` 문서화 (Codex plugin.json 은 `agents`/Claude-hook 미지원)
+  - transform scope: plugin-local `/<plugin>:skill` 보존, 외부 참조만 `$skill` 평탄화 (`scope: "external-only"`)
+  - config `emitMode` / `pluginBuildRoot` 로도 제어 (CLI `--emit` 우선)
+
 ## CLI Options
 
 ```
+--emit <user|plugin>   출력 타깃 (기본 user). plugin = repo 안 Codex plugin 패키지 빌드
 --dry-run              파일 변경 없이 계획만 출력
 --verbose              파일별 행위 + 진단 출력 (resolved pluginsDir, layout, counts)
 --config <path>        커스텀 config 경로

--- a/plugins/codex-bridge/codex-bridge.config.json
+++ b/plugins/codex-bridge/codex-bridge.config.json
@@ -1,10 +1,12 @@
 {
-  "_comment": "Default config for codex-bridge. Override via --config <path>. scope=user → $HOME/.agents/skills for skills/commands and $HOME/.codex/agents for subagent .toml files (OpenAI USER scope). Set target.agentsHome / target.agentsTomlHome to override (testing).",
+  "_comment": "Default config for codex-bridge. Override via --config <path>. scope=user → $HOME/.agents/skills for skills/commands and $HOME/.codex/agents for subagent .toml files (OpenAI USER scope). Set target.agentsHome / target.agentsTomlHome to override (testing). emitMode='plugin' (or --emit plugin) builds Codex plugin packages under pluginBuildRoot (null → repo root) instead of $HOME.",
   "target": {
     "scope": "user",
     "agentsHome": null,
     "agentsTomlHome": null
   },
+  "emitMode": "user",
+  "pluginBuildRoot": null,
   "collisionFallbackPrefix": "bridge-",
   "exclude": [
     "plugins/midjourney/**"
@@ -18,7 +20,8 @@
         "from": "(?<![:/.\\w])\\/([a-z][a-z0-9-]*):([a-z][a-z0-9-]*)",
         "to": "$$$2",
         "mode": "regex",
-        "flags": "g"
+        "flags": "g",
+        "scope": "external-only"
       }
     ],
     "textExtensions": [".md", ".yml", ".yaml", ".json", ".sh", ".mjs", ".js", ".py", ".ts"]

--- a/plugins/codex-bridge/scripts/sync.mjs
+++ b/plugins/codex-bridge/scripts/sync.mjs
@@ -17,6 +17,10 @@ export const DEFAULT_RULES = [
     to: '$$$2',
     mode: 'regex',
     flags: 'g',
+    // In plugin emit mode, preserve `/<currentPlugin>:skill` (plugin-local
+    // cross-reference) and only flatten references to OTHER plugins to `$skill`.
+    // Ignored in user mode — there every namespace ref is flattened.
+    scope: 'external-only',
   },
 ];
 
@@ -24,7 +28,12 @@ function escapeRegex(s) {
   return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
-export function applyTransforms(input, rules) {
+// context: { emitMode?: 'user'|'plugin', currentPlugin?: string }
+// A regex rule may carry `scope: 'external-only'`. In plugin emit mode such a
+// rule preserves matches whose first capture group equals `currentPlugin`
+// (a plugin-local reference) and only rewrites matches pointing at other
+// plugins. In user mode (default) scope is ignored — behaviour is unchanged.
+export function applyTransforms(input, rules, context = {}) {
   let out = input;
   for (const rule of rules) {
     if (rule.mode === 'literal') {
@@ -34,19 +43,28 @@ export function applyTransforms(input, rules) {
       out = out.replace(re, rule.to);
     } else if (rule.mode === 'regex') {
       const re = new RegExp(rule.from, rule.flags ?? 'g');
-      out = out.replace(re, rule.to);
+      if (rule.scope === 'external-only' && context.emitMode === 'plugin' && context.currentPlugin) {
+        const singleRe = new RegExp(rule.from, (rule.flags ?? 'g').replace('g', ''));
+        out = out.replace(re, (match, p1) => {
+          // p1 is the first capture group; by convention the plugin namespace.
+          if (p1 === context.currentPlugin) return match; // preserve plugin-local ref
+          return match.replace(singleRe, rule.to);
+        });
+      } else {
+        out = out.replace(re, rule.to);
+      }
     }
   }
   return out;
 }
 
-export function transformSkillContent(content, rules) {
+export function transformSkillContent(content, rules, context = {}) {
   const match = FRONTMATTER_RE.exec(content);
   if (!match) {
-    return applyTransforms(content, rules);
+    return applyTransforms(content, rules, context);
   }
   const [, raw, body] = match;
-  return `---\n${raw}\n---\n${applyTransforms(body, rules)}`;
+  return `---\n${raw}\n---\n${applyTransforms(body, rules, context)}`;
 }
 
 const TEXT_EXTENSIONS = new Set(['.md', '.yml', '.yaml', '.json', '.sh', '.mjs', '.js', '.py', '.ts']);
@@ -152,29 +170,29 @@ async function moveOrCopy(from, to) {
   }
 }
 
-async function renderSkillTree(sourceDir, dstDir, rules, skillMdOverride) {
+async function renderSkillTree(sourceDir, dstDir, rules, skillMdOverride, context = {}) {
   const entries = await fs.readdir(sourceDir, { withFileTypes: true });
   await fs.mkdir(dstDir, { recursive: true });
   for (const entry of entries) {
     const srcPath = path.join(sourceDir, entry.name);
     const dstPath = path.join(dstDir, entry.name);
     if (entry.isDirectory()) {
-      await renderSkillTree(srcPath, dstPath, rules, null);
+      await renderSkillTree(srcPath, dstPath, rules, null, context);
     } else if (entry.isFile()) {
       if (entry.name === 'SKILL.md' && skillMdOverride != null) {
         await fs.writeFile(dstPath, skillMdOverride, 'utf-8');
       } else {
-        await renderFile(srcPath, dstPath, rules);
+        await renderFile(srcPath, dstPath, rules, context);
       }
     }
   }
 }
 
-async function renderFile(srcPath, dstPath, rules) {
+async function renderFile(srcPath, dstPath, rules, context = {}) {
   const ext = path.extname(srcPath).toLowerCase();
   if (TEXT_EXTENSIONS.has(ext)) {
     const content = await fs.readFile(srcPath, 'utf-8');
-    await fs.writeFile(dstPath, applyTransforms(content, rules), 'utf-8');
+    await fs.writeFile(dstPath, applyTransforms(content, rules, context), 'utf-8');
   } else {
     await fs.copyFile(srcPath, dstPath);
   }
@@ -199,6 +217,13 @@ export const DEFAULT_CONFIG = {
     agentsHome: null,
     agentsTomlHome: null,
   },
+  // Emit target: 'user' → copy into $HOME (~/.agents/skills, ~/.codex/agents);
+  // 'plugin' → build Codex plugin packages under pluginBuildRoot (repo). CLI
+  // --emit overrides this. Default 'user' keeps backward-compatible behaviour.
+  emitMode: 'user',
+  // Repo root for plugin emit output (codex/plugins/** + .agents/plugins/
+  // marketplace.json). null → derived from the resolved plugins dir parent.
+  pluginBuildRoot: null,
   collisionFallbackPrefix: 'bridge-',
   exclude: [],
   transform: {
@@ -235,6 +260,12 @@ function mergeConfig(base, override) {
   if (override.target && typeof override.target === 'object') {
     out.target = { ...out.target, ...override.target };
   }
+  if (typeof override.emitMode === 'string') {
+    out.emitMode = override.emitMode;
+  }
+  if (typeof override.pluginBuildRoot === 'string' || override.pluginBuildRoot === null) {
+    out.pluginBuildRoot = override.pluginBuildRoot;
+  }
   if (typeof override.collisionFallbackPrefix === 'string') {
     out.collisionFallbackPrefix = override.collisionFallbackPrefix;
   }
@@ -266,8 +297,10 @@ function globToRegex(pattern) {
 
 const KNOWN_FLAGS = new Set([
   '--dry-run', '--verbose', '--no-prune', '--help', '-h',
-  '--config', '--plugin', '--report', '--plugins-dir',
+  '--config', '--plugin', '--report', '--plugins-dir', '--emit',
 ]);
+
+const EMIT_MODES = new Set(['user', 'plugin']);
 
 export function parseArgs(argv) {
   const out = {
@@ -279,6 +312,7 @@ export function parseArgs(argv) {
     plugins: null,
     reportPath: null,
     pluginsDir: null,
+    emit: null,
   };
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
@@ -286,6 +320,14 @@ export function parseArgs(argv) {
       throw new Error(`Unknown argument: ${arg}`);
     }
     switch (arg) {
+      case '--emit': {
+        const value = argv[++i];
+        if (!value || !EMIT_MODES.has(value)) {
+          throw new Error("--emit requires a mode: 'user' or 'plugin'");
+        }
+        out.emit = value;
+        break;
+      }
       case '--dry-run': out.dryRun = true; break;
       case '--verbose': out.verbose = true; break;
       case '--no-prune': out.noPrune = true; break;
@@ -602,12 +644,40 @@ export async function main(argv) {
     return 2;
   }
 
+  const logger = args.verbose ? defaultLogger() : quietLogger();
+
+  const emitMode = args.emit ?? config.emitMode ?? 'user';
+
+  if (emitMode === 'plugin') {
+    const buildRoot = config.pluginBuildRoot
+      ? path.resolve(config.pluginBuildRoot)
+      : path.dirname(pluginsDir);
+
+    if (args.verbose) {
+      process.stderr.write(`[codex-bridge] emit mode: plugin → buildRoot ${buildRoot}\n`);
+    }
+
+    const report = await emitPlugins({
+      pluginsDir,
+      buildRoot,
+      config,
+      dryRun: args.dryRun,
+      pluginFilter: args.plugins,
+      logger,
+    });
+
+    if (args.reportPath) {
+      await fs.writeFile(args.reportPath, JSON.stringify(report, null, 2), 'utf-8');
+    }
+
+    printPluginSummary(report);
+    return report.errors.length > 0 ? 1 : 0;
+  }
+
   const targetDir = config.target.agentsHome
     ?? path.join(os.homedir(), '.agents', 'skills');
   const agentsTomlDir = config.target.agentsTomlHome
     ?? path.join(os.homedir(), '.codex', 'agents');
-
-  const logger = args.verbose ? defaultLogger() : quietLogger();
 
   const report = await syncAll({
     pluginsDir,
@@ -658,6 +728,10 @@ function printHelp() {
   const help = `Usage: node sync.mjs [options]
 
 Options:
+  --emit <user|plugin>   Output target. 'user' (default) copies into $HOME
+                         (~/.agents/skills, ~/.codex/agents). 'plugin' builds
+                         committable Codex plugin packages under the repo
+                         (codex/plugins/** + .agents/plugins/marketplace.json).
   --dry-run              Plan without writing files
   --verbose              Per-file logs + diagnostic (resolved pluginsDir, layout, counts)
   --config <path>        Custom config path (default: codex-bridge.config.json)
@@ -1196,6 +1270,340 @@ export async function syncCommand(cmd, targetRoot, rules, options = {}) {
   }
 
   return { status: 'synced', path: targetSkillMd, bridgeSource: marker };
+}
+
+// ---------------------------------------------------------------------------
+// Plugin emit (`--emit plugin`)
+//
+// Builds Codex-native plugin packages from the Claude source plugins into the
+// repo (committable, installable via `codex plugin marketplace add`). Pure repo
+// output — no $HOME side effects (that is user-mode's job, left untouched).
+//
+//   <buildRoot>/.agents/plugins/marketplace.json   — Codex catalog (all plugins)
+//   <buildRoot>/codex/plugins/<plugin>/
+//       .codex-plugin/plugin.json                  — name/version/description/skills
+//       skills/<name>/SKILL.md                     — transformed skills + wrapped commands
+//       AGENTS.md                                  — subagent + hook documentation
+// ---------------------------------------------------------------------------
+
+async function readJsonFile(p) {
+  try {
+    return JSON.parse(await fs.readFile(p, 'utf-8'));
+  } catch (err) {
+    if (err.code === 'ENOENT') return null;
+    throw err;
+  }
+}
+
+// Map a Claude `.claude-plugin/plugin.json` to a Codex `.codex-plugin/plugin.json`.
+// Required Codex fields: name, version, description. `skills` points at the
+// bundled skills directory (string form, matching OpenAI's own plugins).
+export function generatePluginJson(pluginName, source = {}) {
+  return {
+    name: source.name ?? pluginName,
+    version: source.version ?? '0.0.0',
+    description: source.description ?? `${pluginName} plugin.`,
+    skills: './skills/',
+  };
+}
+
+// Build the Codex marketplace catalog. `plugins` is an ordered list of
+// { name, description?, category? }. `source.path` is repo-root relative
+// (verified: `codex plugin marketplace add <repo>` reads
+// `<repo>/.agents/plugins/marketplace.json` and resolves source paths from
+// the repo root).
+export function generateMarketplaceJson(plugins, options = {}) {
+  const pathBase = options.pluginPathBase ?? './codex/plugins';
+  return {
+    name: options.name ?? 'my-claude-plugins',
+    interface: { displayName: options.displayName ?? 'My Claude Plugins (Codex)' },
+    plugins: plugins.map((p) => {
+      const entry = {
+        name: p.name,
+        source: { source: 'local', path: `${pathBase}/${p.name}` },
+      };
+      if (p.description) entry.description = flattenDescription(p.description);
+      if (p.category) entry.category = p.category;
+      return entry;
+    }),
+  };
+}
+
+// Per-plugin AGENTS.md. Documents bundled skills, plus the two components Codex
+// plugin.json cannot carry: subagents (served via user-mode ~/.codex/agents/*.toml)
+// and Claude hooks (inert under Codex — documented only).
+export function buildPluginAgentsDoc(pluginName, { skillCount = 0, commandCount = 0, agents = [], hooks = [] } = {}) {
+  const lines = [];
+  lines.push(`# ${pluginName} — Codex package notes`);
+  lines.push('');
+  lines.push(`Generated by codex-bridge plugin emit. Source of truth: \`my-claude-plugins/plugins/${pluginName}\`.`);
+  lines.push('');
+  lines.push('## Skills');
+  lines.push('');
+  const totalSkills = skillCount + commandCount;
+  lines.push(`This plugin bundles ${totalSkills} skill(s) under \`skills/\`, callable in Codex as \`$<name>\`` +
+    (commandCount > 0 ? ` (${commandCount} of them are wrapped Claude commands, named \`${pluginName}-<command>\`).` : '.'));
+  lines.push('');
+
+  if (agents.length > 0) {
+    lines.push('## Subagents (not installed by `codex plugin add`)');
+    lines.push('');
+    lines.push('Codex `plugin.json` has no `agents` field, so these Claude Code subagents are');
+    lines.push('not bundled. To use them in Codex, run the user-mode bridge sync');
+    lines.push('(`node plugins/codex-bridge/scripts/sync.mjs`), which writes them to');
+    lines.push('`~/.codex/agents/<plugin>-<agent>.toml`.');
+    lines.push('');
+    lines.push('| Agent | Codex subagent | Description |');
+    lines.push('|-------|----------------|-------------|');
+    for (const a of agents) {
+      const desc = (a.description ?? '').replace(/\|/g, '\\|');
+      lines.push(`| ${a.agentName} | ${pluginName}-${a.agentName} | ${desc} |`);
+    }
+    lines.push('');
+  }
+
+  if (hooks.length > 0) {
+    lines.push('## Hooks (Claude Code only — inert under Codex)');
+    lines.push('');
+    lines.push('This plugin defines Claude Code hooks. The Codex hook lifecycle is not yet');
+    lines.push('mapped, so they are documented here only and do nothing under Codex:');
+    lines.push('');
+    for (const h of hooks) {
+      lines.push(`- \`${h}\``);
+    }
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}
+
+function hookEventSummary(hooks) {
+  if (!hooks || typeof hooks !== 'object') return [];
+  const out = [];
+  for (const [event, entries] of Object.entries(hooks)) {
+    const count = Array.isArray(entries)
+      ? entries.reduce((n, e) => n + (Array.isArray(e.hooks) ? e.hooks.length : 0), 0)
+      : 0;
+    out.push(`${event} (${count} command${count === 1 ? '' : 's'})`);
+  }
+  return out;
+}
+
+export async function emitPlugins(options) {
+  const {
+    pluginsDir,
+    buildRoot,
+    config,
+    dryRun = false,
+    pluginFilter = null,
+    logger = defaultLogger(),
+  } = options;
+
+  const rules = config.transform.rules;
+  const pluginsRoot = path.dirname(pluginsDir);
+
+  const allSkills = await discoverSkills(pluginsDir);
+  const allCommands = await discoverCommands(pluginsDir);
+  const allAgents = await discoverAgents(pluginsDir);
+
+  const skillExcluded = (s) => {
+    const rel = path.relative(pluginsRoot, s.skillDir).split(path.sep).join('/');
+    return isExcluded(rel, config.exclude) || isExcluded(`${rel}/SKILL.md`, config.exclude);
+  };
+  const pluginExcluded = (name) => isExcluded(`plugins/${name}/**`, config.exclude);
+
+  // Group by plugin (exclude applied; pluginFilter NOT applied so the
+  // marketplace catalog stays complete even on a filtered rebuild).
+  const byPlugin = new Map();
+  const bucket = (name) => {
+    if (!byPlugin.has(name)) byPlugin.set(name, { skills: [], commands: [], agents: [] });
+    return byPlugin.get(name);
+  };
+  for (const s of allSkills) {
+    if (pluginExcluded(s.pluginName) || skillExcluded(s)) continue;
+    bucket(s.pluginName).skills.push(s);
+  }
+  for (const c of allCommands) {
+    if (pluginExcluded(c.pluginName)) continue;
+    bucket(c.pluginName).commands.push(c);
+  }
+  for (const a of allAgents) {
+    if (pluginExcluded(a.pluginName)) continue;
+    bucket(a.pluginName).agents.push(a);
+  }
+
+  const allNames = [...byPlugin.keys()].sort();
+  const buildNames = pluginFilter ? allNames.filter((n) => pluginFilter.includes(n)) : allNames;
+
+  const rootMp = await readJsonFile(path.join(pluginsRoot, '.claude-plugin', 'marketplace.json'));
+  const metaByName = new Map();
+  if (rootMp && Array.isArray(rootMp.plugins)) {
+    for (const p of rootMp.plugins) metaByName.set(p.name, { description: p.description, category: p.category });
+  }
+
+  const codexPluginsDir = path.join(buildRoot, 'codex', 'plugins');
+  const report = {
+    dryRun,
+    buildRoot,
+    codexPluginsDir,
+    marketplacePath: path.join(buildRoot, '.agents', 'plugins', 'marketplace.json'),
+    plugins: [],
+    removed: [],
+    errors: [],
+  };
+
+  const context = (name) => ({ emitMode: 'plugin', currentPlugin: name });
+
+  for (const name of buildNames) {
+    const group = byPlugin.get(name);
+    const contentRoot = await resolvePluginContentDir(path.join(pluginsDir, name));
+    const sourcePluginJson = contentRoot
+      ? await readJsonFile(path.join(contentRoot, '.claude-plugin', 'plugin.json'))
+      : null;
+    const hooks = hookEventSummary(sourcePluginJson?.hooks);
+
+    const summary = {
+      name,
+      skills: group.skills.length,
+      commands: group.commands.length,
+      agents: group.agents.length,
+      hooks: hooks.length,
+    };
+
+    if (dryRun) {
+      logger.info(`[dry-run] would emit plugin ${name}: ${summary.skills} skills, ${summary.commands} commands → wrapped, ${summary.agents} agents → AGENTS.md${hooks.length ? `, ${hooks.length} hook event(s) → doc` : ''}`);
+      report.plugins.push(summary);
+      continue;
+    }
+
+    try {
+      await fs.mkdir(codexPluginsDir, { recursive: true });
+      const stagingDir = await fs.mkdtemp(path.join(codexPluginsDir, `.staging-plugin-${name}-`));
+      try {
+        // .codex-plugin/plugin.json
+        const codexPluginJson = generatePluginJson(name, sourcePluginJson ?? {});
+        await fs.mkdir(path.join(stagingDir, '.codex-plugin'), { recursive: true });
+        await fs.writeFile(
+          path.join(stagingDir, '.codex-plugin', 'plugin.json'),
+          `${JSON.stringify(codexPluginJson, null, 2)}\n`,
+          'utf-8',
+        );
+
+        const skillsOut = path.join(stagingDir, 'skills');
+        const ctx = context(name);
+
+        // skills → skills/<name>/ (full tree, transformed)
+        for (const skill of group.skills) {
+          const sourceContent = await fs.readFile(skill.skillPath, 'utf-8');
+          const parsed = parseFrontmatter(sourceContent);
+          if (!parsed) {
+            logger.warn(`[codex-bridge] ${name}/${skill.skillName}: source SKILL.md has no frontmatter, skipping`);
+            continue;
+          }
+          const transformed = transformSkillContent(sourceContent, rules, ctx);
+          const normalized = normalizeFrontmatterDescription(transformed);
+          const withMarker = injectBridgeSource(normalized, `${name}/${skill.skillName}`);
+          await renderSkillTree(skill.skillDir, path.join(skillsOut, skill.skillName), rules, withMarker, ctx);
+        }
+
+        // commands → skills/<plugin>-<command>/SKILL.md (wrapped)
+        for (const cmd of group.commands) {
+          const sourceContent = await fs.readFile(cmd.sourcePath, 'utf-8');
+          const synthesized = commandToSkillContent(sourceContent, cmd.pluginName, cmd.commandName);
+          const transformed = transformSkillContent(synthesized, rules, ctx);
+          const cmdDir = path.join(skillsOut, cmd.targetSkillName);
+          await fs.mkdir(cmdDir, { recursive: true });
+          await fs.writeFile(path.join(cmdDir, 'SKILL.md'), transformed, 'utf-8');
+        }
+
+        // AGENTS.md (subagent + hook documentation)
+        const agentDocs = [];
+        for (const ag of group.agents) {
+          const agContent = await fs.readFile(ag.sourcePath, 'utf-8');
+          const agParsed = parseFrontmatter(agContent);
+          agentDocs.push({
+            agentName: ag.agentName,
+            description: agParsed?.description ? flattenDescription(agParsed.description) : '',
+          });
+        }
+        const agentsMd = buildPluginAgentsDoc(name, {
+          skillCount: group.skills.length,
+          commandCount: group.commands.length,
+          agents: agentDocs,
+          hooks,
+        });
+        await fs.writeFile(path.join(stagingDir, 'AGENTS.md'), `${agentsMd}\n`, 'utf-8');
+
+        const pluginOutDir = path.join(codexPluginsDir, name);
+        await fs.rm(pluginOutDir, { recursive: true, force: true });
+        await moveOrCopy(stagingDir, pluginOutDir);
+        logger.info(`[codex-bridge] emitted plugin ${name} → ${pluginOutDir}`);
+        report.plugins.push(summary);
+      } catch (err) {
+        await fs.rm(stagingDir, { recursive: true, force: true }).catch(() => {});
+        throw err;
+      }
+    } catch (err) {
+      logger.warn(`[codex-bridge] error emitting plugin ${name}: ${err.message}`);
+      report.errors.push({ name, error: err.message });
+    }
+  }
+
+  // Orphan prune of plugin dirs no longer in the catalog (full builds only).
+  if (!dryRun && !pluginFilter) {
+    const existing = await fs.readdir(codexPluginsDir, { withFileTypes: true }).catch((err) => {
+      if (err.code === 'ENOENT') return [];
+      throw err;
+    });
+    const valid = new Set(allNames);
+    for (const entry of existing) {
+      if (!entry.isDirectory() || entry.name.startsWith('.staging-')) continue;
+      if (!valid.has(entry.name)) {
+        await fs.rm(path.join(codexPluginsDir, entry.name), { recursive: true, force: true });
+        report.removed.push(entry.name);
+        logger.info(`[codex-bridge] pruned orphan plugin package ${entry.name}`);
+      }
+    }
+  }
+
+  // marketplace.json (full catalog — all non-excluded plugins)
+  const mpPlugins = [];
+  for (const name of allNames) {
+    let meta = metaByName.get(name);
+    if (!meta || !meta.description) {
+      const contentRoot = await resolvePluginContentDir(path.join(pluginsDir, name));
+      const pj = contentRoot ? await readJsonFile(path.join(contentRoot, '.claude-plugin', 'plugin.json')) : null;
+      meta = { description: meta?.description ?? pj?.description, category: meta?.category };
+    }
+    mpPlugins.push({ name, description: meta.description, category: meta.category });
+  }
+  const marketplaceJson = generateMarketplaceJson(mpPlugins, {
+    name: rootMp?.name ?? 'my-claude-plugins',
+    displayName: rootMp?.metadata?.description ? 'My Claude Plugins (Codex)' : undefined,
+  });
+  report.catalogCount = mpPlugins.length;
+
+  if (dryRun) {
+    logger.info(`[dry-run] would write marketplace.json with ${mpPlugins.length} plugin(s) → ${report.marketplacePath}`);
+  } else {
+    const mpDir = path.dirname(report.marketplacePath);
+    await fs.mkdir(mpDir, { recursive: true });
+    const stagingMp = path.join(mpDir, `.staging-marketplace-${process.pid}.json`);
+    await fs.writeFile(stagingMp, `${JSON.stringify(marketplaceJson, null, 2)}\n`, 'utf-8');
+    await moveOrCopy(stagingMp, report.marketplacePath);
+    logger.info(`[codex-bridge] wrote marketplace catalog (${mpPlugins.length} plugins) → ${report.marketplacePath}`);
+  }
+
+  return report;
+}
+
+function printPluginSummary(report) {
+  const lines = [`[codex-bridge] plugin build root: ${report.buildRoot}`];
+  lines.push(`  emitted: ${report.plugins.length} plugin package(s)`);
+  lines.push(`  catalog: ${report.catalogCount ?? report.plugins.length} plugin(s) in marketplace.json`);
+  if (report.removed.length) lines.push(`  pruned: ${report.removed.length} orphan package(s)`);
+  if (report.errors.length) lines.push(`  errors: ${report.errors.length}`);
+  process.stderr.write(`${lines.join('\n')}\n`);
 }
 
 const isMainModule = (() => {

--- a/plugins/codex-bridge/skills/codex-sync/SKILL.md
+++ b/plugins/codex-bridge/skills/codex-sync/SKILL.md
@@ -58,6 +58,7 @@ $codex-sync --dry-run
 
 | Flag | 동작 |
 |------|-----|
+| `--emit <user\|plugin>` | 출력 타깃. `user`(기본)=`~/.agents/skills`·`~/.codex/agents`로 복사. `plugin`=repo 안에 Codex plugin 패키지 빌드(`codex/plugins/**`+`.agents/plugins/marketplace.json`) |
 | `--dry-run` | 파일 변경 없이 계획만 출력 |
 | `--verbose` | 파일별 행위 + 진단 출력 (resolved pluginsDir, layout 종류, plugin/skill/command counts) |
 | `--config <path>` | 커스텀 config 경로 (기본: `codex-bridge.config.json`) |
@@ -183,6 +184,50 @@ Windows 경로도 지원 (Node `path.resolve` 가 OS 별 separator 정규화).
 - 마커 있음 → overwrite (codex-bridge-managed 이므로 안전)
 - 다른 plugin 에서 동일 이름 → last-wins (경고)
 
+## Plugin emit mode (`--emit plugin`)
+
+User-mode 가 개별 파일을 `$HOME` 에 흩뿌리는 것과 달리, plugin emit 은 **Codex 네이티브 plugin 패키지**를 repo 안에 빌드해 `codex plugin marketplace add` 로 통째 설치/업데이트 가능하게 만든다. **`$HOME` 을 건드리지 않는다** (순수 repo 산출물).
+
+```bash
+node plugins/codex-bridge/scripts/sync.mjs --emit plugin            # 전체 빌드
+node plugins/codex-bridge/scripts/sync.mjs --emit plugin --dry-run --verbose
+node plugins/codex-bridge/scripts/sync.mjs --emit plugin --plugin council   # 일부만 재빌드
+```
+
+### 출력 레이아웃 (repo-root 기준)
+
+```
+.agents/plugins/marketplace.json      # Codex 카탈로그 (전체 plugin 등록)
+codex/plugins/<plugin>/
+├── .codex-plugin/plugin.json         # name/version/description (원본 .claude-plugin/plugin.json 매핑) + skills:"./skills/"
+├── skills/<name>/SKILL.md            # 변환된 skill + wrapped command(<plugin>-<command>)
+└── AGENTS.md                         # subagent + hook 문서화
+```
+
+### 컴포넌트 매핑
+
+| 컴포넌트 | plugin emit 처리 |
+|---|---|
+| skill | `skills/<name>/SKILL.md` 로 변환 (frontmatter 불변, body transform, `bridge_source` 마커) |
+| command | `<plugin>-<command>` skill 로 wrap → `skills/` 에 배치 |
+| agent | Codex plugin.json 에 `agents` 필드 없음 → `AGENTS.md` 에 문서화 (실제 호출은 user-mode `~/.codex/agents/*.toml` 경유) |
+| hook | Codex hook lifecycle 미검증 → `AGENTS.md` 에 "Claude 전용, Codex 에서 inert" 로 문서화 (plugin.json 에 주입 안 함) |
+
+### transform scope 분리
+
+plugin 모드에서 namespace rule 은 `scope: "external-only"` 로 동작한다: `/<현재plugin>:skill` 같은 **plugin-local 참조는 보존**하고, `/<다른plugin>:skill` 같은 **외부 참조만 `$skill` 로 평탄화**한다. user-mode 는 scope 를 무시하고 모든 참조를 평탄화한다(기존 동작).
+
+### 설치 (Codex CLI)
+
+```bash
+# 원격 1줄 설치
+codex plugin marketplace add YoungjaeDev/my-claude-plugins
+codex plugin add <plugin>@my-claude-plugins
+# git pull 로 업데이트: codex plugin marketplace upgrade
+```
+
+`source.path` base 는 **repo-root** 다 (실측 확인: `codex plugin marketplace add <repo>` 가 `<repo>/.agents/plugins/marketplace.json` 을 읽고 source path 를 repo-root 에서 resolve).
+
 ## Out of Scope
 
 추후 작업:
@@ -190,6 +235,7 @@ Windows 경로도 지원 (Node `path.resolve` 가 OS 별 separator 정규화).
 - Project-level `.agents/skills/` 타깃
 - Collision-fallback 프리픽스 자동 부여
 - agent `model` / `tools` 의 Codex 호환 매핑 (현재 `# original-*` 주석으로만 보존)
+- Codex hook lifecycle 정식 매핑 (공식 spec 공개 대기 — 현재는 AGENTS.md 문서화)
 
 ## 참조
 

--- a/plugins/codex-bridge/tests/plugin-emit.test.mjs
+++ b/plugins/codex-bridge/tests/plugin-emit.test.mjs
@@ -1,0 +1,354 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+
+import {
+  applyTransforms,
+  transformSkillContent,
+  generatePluginJson,
+  generateMarketplaceJson,
+  buildPluginAgentsDoc,
+  emitPlugins,
+  parseArgs,
+  loadConfig,
+  DEFAULT_RULES,
+  DEFAULT_CONFIG,
+} from '../scripts/sync.mjs';
+
+// ---------------------------------------------------------------------------
+// transform scope (external-only)
+// ---------------------------------------------------------------------------
+
+test('applyTransforms: scope external-only preserves plugin-local ref in plugin mode', () => {
+  const out = applyTransforms('see /llm-wiki:query-wiki here', DEFAULT_RULES, {
+    emitMode: 'plugin',
+    currentPlugin: 'llm-wiki',
+  });
+  assert.equal(out, 'see /llm-wiki:query-wiki here');
+});
+
+test('applyTransforms: scope external-only flattens other-plugin ref in plugin mode', () => {
+  const out = applyTransforms('chains /github-dev:post-merge after', DEFAULT_RULES, {
+    emitMode: 'plugin',
+    currentPlugin: 'llm-wiki',
+  });
+  assert.equal(out, 'chains $post-merge after');
+});
+
+test('applyTransforms: mixed refs — local preserved, external flattened', () => {
+  const out = applyTransforms('/llm-wiki:ingest-finding then /github-dev:cr-fix', DEFAULT_RULES, {
+    emitMode: 'plugin',
+    currentPlugin: 'llm-wiki',
+  });
+  assert.equal(out, '/llm-wiki:ingest-finding then $cr-fix');
+});
+
+test('applyTransforms: user mode (default) flattens every ref (backward compat)', () => {
+  const out = applyTransforms('run /llm-wiki:query-wiki now', DEFAULT_RULES, {
+    emitMode: 'user',
+    currentPlugin: 'llm-wiki',
+  });
+  assert.equal(out, 'run $query-wiki now');
+});
+
+test('applyTransforms: no context behaves like user mode', () => {
+  assert.equal(
+    applyTransforms('run /llm-wiki:query-wiki now', DEFAULT_RULES),
+    'run $query-wiki now',
+  );
+});
+
+test('transformSkillContent: scope threads through body only', () => {
+  const src = [
+    '---',
+    'name: ingest-finding',
+    'description: mentions /llm-wiki:query-wiki',
+    '---',
+    'local /llm-wiki:query-wiki and external /github-dev:post-merge',
+  ].join('\n');
+  const out = transformSkillContent(src, DEFAULT_RULES, { emitMode: 'plugin', currentPlugin: 'llm-wiki' });
+  // frontmatter untouched
+  assert.match(out, /description: mentions \/llm-wiki:query-wiki/);
+  // body: local preserved, external flattened
+  assert.match(out, /local \/llm-wiki:query-wiki and external \$post-merge/);
+});
+
+// ---------------------------------------------------------------------------
+// generatePluginJson
+// ---------------------------------------------------------------------------
+
+test('generatePluginJson: maps name/version/description, sets skills', () => {
+  const out = generatePluginJson('council', {
+    name: 'council',
+    version: '1.1.0',
+    description: 'LLM Council',
+    skills: ['./skills/council-setup'],
+    commands: ['./commands/council.md'],
+  });
+  assert.deepEqual(out, {
+    name: 'council',
+    version: '1.1.0',
+    description: 'LLM Council',
+    skills: './skills/',
+  });
+});
+
+test('generatePluginJson: falls back when source fields missing', () => {
+  const out = generatePluginJson('foo', {});
+  assert.equal(out.name, 'foo');
+  assert.equal(out.version, '0.0.0');
+  assert.match(out.description, /foo plugin/);
+  assert.equal(out.skills, './skills/');
+});
+
+// ---------------------------------------------------------------------------
+// generateMarketplaceJson
+// ---------------------------------------------------------------------------
+
+test('generateMarketplaceJson: source uses {source:"local", path} repo-root relative', () => {
+  const mp = generateMarketplaceJson([
+    { name: 'council', description: 'desc', category: 'ai-models' },
+  ]);
+  assert.equal(mp.plugins.length, 1);
+  assert.deepEqual(mp.plugins[0].source, { source: 'local', path: './codex/plugins/council' });
+  assert.equal(mp.plugins[0].description, 'desc');
+  assert.equal(mp.plugins[0].category, 'ai-models');
+});
+
+test('generateMarketplaceJson: omits empty description/category, flattens block scalar', () => {
+  const mp = generateMarketplaceJson([{ name: 'x', description: '|\n  multi\n  line' }]);
+  assert.equal(mp.plugins[0].description, 'multi line');
+  assert.ok(!('category' in mp.plugins[0]));
+});
+
+test('generateMarketplaceJson: name/displayName options', () => {
+  const mp = generateMarketplaceJson([], { name: 'my-claude-plugins', displayName: 'X' });
+  assert.equal(mp.name, 'my-claude-plugins');
+  assert.equal(mp.interface.displayName, 'X');
+});
+
+// ---------------------------------------------------------------------------
+// buildPluginAgentsDoc
+// ---------------------------------------------------------------------------
+
+test('buildPluginAgentsDoc: documents agents table and toml note', () => {
+  const md = buildPluginAgentsDoc('code-scout', {
+    skillCount: 2,
+    agents: [{ agentName: 'github-scout', description: 'GitHub research' }],
+  });
+  assert.match(md, /# code-scout — Codex package notes/);
+  assert.match(md, /Subagents/);
+  assert.match(md, /~\/\.codex\/agents\/<plugin>-<agent>\.toml/);
+  assert.match(md, /\| github-scout \| code-scout-github-scout \| GitHub research \|/);
+});
+
+test('buildPluginAgentsDoc: documents hooks as Codex-inert', () => {
+  const md = buildPluginAgentsDoc('core-config', {
+    skillCount: 0,
+    hooks: ['PostToolUse (1 command)', 'Stop (1 command)'],
+  });
+  assert.match(md, /Hooks \(Claude Code only/);
+  assert.match(md, /PostToolUse \(1 command\)/);
+});
+
+test('buildPluginAgentsDoc: no agents/hooks → skills-only note', () => {
+  const md = buildPluginAgentsDoc('translator', { skillCount: 1 });
+  assert.match(md, /bundles 1 skill/);
+  assert.doesNotMatch(md, /Subagents/);
+  assert.doesNotMatch(md, /Hooks/);
+});
+
+// ---------------------------------------------------------------------------
+// parseArgs / loadConfig
+// ---------------------------------------------------------------------------
+
+test('parseArgs: --emit defaults to null (→ config/user)', () => {
+  assert.equal(parseArgs([]).emit, null);
+});
+
+test('parseArgs: --emit plugin / user', () => {
+  assert.equal(parseArgs(['--emit', 'plugin']).emit, 'plugin');
+  assert.equal(parseArgs(['--emit', 'user']).emit, 'user');
+});
+
+test('parseArgs: --emit rejects invalid mode', () => {
+  assert.throws(() => parseArgs(['--emit', 'bogus']), /user.*plugin|plugin.*user/i);
+  assert.throws(() => parseArgs(['--emit']), /--emit/);
+});
+
+test('loadConfig: defaults emitMode user, pluginBuildRoot null', async () => {
+  const cfg = await loadConfig(null);
+  assert.equal(cfg.emitMode, 'user');
+  assert.equal(cfg.pluginBuildRoot, null);
+});
+
+test('loadConfig: merges emitMode + pluginBuildRoot', async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-bridge-cfg-'));
+  try {
+    const p = path.join(tmp, 'config.json');
+    await fs.writeFile(p, JSON.stringify({ emitMode: 'plugin', pluginBuildRoot: '/build' }));
+    const cfg = await loadConfig(p);
+    assert.equal(cfg.emitMode, 'plugin');
+    assert.equal(cfg.pluginBuildRoot, '/build');
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// emitPlugins integration
+// ---------------------------------------------------------------------------
+
+async function makePlugin(repoRoot, name, { version = '1.0.0', description = `${name} plugin`, skills = {}, commands = {}, agents = {}, hooks = null } = {}) {
+  const base = path.join(repoRoot, 'plugins', name);
+  const pj = { name, version, description };
+  if (hooks) pj.hooks = hooks;
+  await fs.mkdir(path.join(base, '.claude-plugin'), { recursive: true });
+  await fs.writeFile(path.join(base, '.claude-plugin', 'plugin.json'), JSON.stringify(pj, null, 2));
+  for (const [sName, content] of Object.entries(skills)) {
+    const d = path.join(base, 'skills', sName);
+    await fs.mkdir(d, { recursive: true });
+    await fs.writeFile(path.join(d, 'SKILL.md'), content);
+  }
+  for (const [cName, content] of Object.entries(commands)) {
+    await fs.mkdir(path.join(base, 'commands'), { recursive: true });
+    await fs.writeFile(path.join(base, 'commands', `${cName}.md`), content);
+  }
+  for (const [aName, content] of Object.entries(agents)) {
+    await fs.mkdir(path.join(base, 'agents'), { recursive: true });
+    await fs.writeFile(path.join(base, 'agents', `${aName}.md`), content);
+  }
+}
+
+test('emitPlugins: builds plugin packages, marketplace, AGENTS.md, scope-correct refs', async () => {
+  const repo = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-bridge-emit-'));
+  try {
+    await makePlugin(repo, 'llm-wiki', {
+      version: '2.0.0',
+      description: 'LLM wiki system',
+      skills: {
+        'query-wiki': '---\nname: query-wiki\ndescription: query\n---\nbody\n',
+        'ingest-finding': '---\nname: ingest-finding\ndescription: ingest\n---\nsee /llm-wiki:query-wiki and /github-dev:post-merge and CLAUDE.md\n',
+      },
+      hooks: { PostToolUse: [{ matcher: 'Write', hooks: [{ type: 'command', command: 'x' }] }] },
+    });
+    await makePlugin(repo, 'github-dev', {
+      version: '1.5.0',
+      description: 'GitHub workflow',
+      commands: { 'post-merge': '---\ndescription: cleanup\n---\nrun /github-dev:cr-fix here\n' },
+      agents: { worker: '---\nname: worker\ndescription: does work\n---\nagent body\n' },
+    });
+
+    const config = JSON.parse(JSON.stringify(DEFAULT_CONFIG));
+    const report = await emitPlugins({
+      pluginsDir: path.join(repo, 'plugins'),
+      buildRoot: repo,
+      config,
+      logger: { warn() {}, info() {} },
+    });
+
+    assert.equal(report.errors.length, 0);
+    assert.equal(report.catalogCount, 2);
+
+    // plugin.json
+    const pj = JSON.parse(await fs.readFile(path.join(repo, 'codex/plugins/llm-wiki/.codex-plugin/plugin.json'), 'utf-8'));
+    assert.deepEqual(pj, { name: 'llm-wiki', version: '2.0.0', description: 'LLM wiki system', skills: './skills/' });
+
+    // skill body: local ref preserved, external flattened, CLAUDE.md → AGENTS.md
+    const ingest = await fs.readFile(path.join(repo, 'codex/plugins/llm-wiki/skills/ingest-finding/SKILL.md'), 'utf-8');
+    assert.match(ingest, /\/llm-wiki:query-wiki/);     // local preserved
+    assert.match(ingest, /\$post-merge/);              // external flattened
+    assert.match(ingest, /AGENTS\.md/);                // literal transform
+    assert.match(ingest, /bridge_source: llm-wiki\/ingest-finding/);
+
+    // wrapped command → skill
+    const wrapped = await fs.readFile(path.join(repo, 'codex/plugins/github-dev/skills/github-dev-post-merge/SKILL.md'), 'utf-8');
+    assert.match(wrapped, /name: github-dev-post-merge/);
+    // local ref to own plugin preserved
+    assert.match(wrapped, /\/github-dev:cr-fix/);
+
+    // AGENTS.md documents the subagent + hooks
+    const wikiAgents = await fs.readFile(path.join(repo, 'codex/plugins/llm-wiki/AGENTS.md'), 'utf-8');
+    assert.match(wikiAgents, /Hooks \(Claude Code only/);
+    const ghAgents = await fs.readFile(path.join(repo, 'codex/plugins/github-dev/AGENTS.md'), 'utf-8');
+    assert.match(ghAgents, /github-dev-worker/);
+
+    // marketplace.json
+    const mp = JSON.parse(await fs.readFile(path.join(repo, '.agents/plugins/marketplace.json'), 'utf-8'));
+    assert.equal(mp.plugins.length, 2);
+    const names = mp.plugins.map(p => p.name).sort();
+    assert.deepEqual(names, ['github-dev', 'llm-wiki']);
+    for (const p of mp.plugins) {
+      assert.equal(p.source.source, 'local');
+      assert.match(p.source.path, /^\.\/codex\/plugins\//);
+    }
+  } finally {
+    await fs.rm(repo, { recursive: true, force: true });
+  }
+});
+
+test('emitPlugins: respects exclude list (no package, not in catalog)', async () => {
+  const repo = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-bridge-emit-'));
+  try {
+    await makePlugin(repo, 'keep', { skills: { s: '---\nname: s\ndescription: d\n---\nx\n' } });
+    await makePlugin(repo, 'drop', { skills: { s: '---\nname: s\ndescription: d\n---\nx\n' } });
+    const config = JSON.parse(JSON.stringify(DEFAULT_CONFIG));
+    config.exclude = ['plugins/drop/**'];
+    const report = await emitPlugins({
+      pluginsDir: path.join(repo, 'plugins'),
+      buildRoot: repo,
+      config,
+      logger: { warn() {}, info() {} },
+    });
+    assert.equal(report.catalogCount, 1);
+    const mp = JSON.parse(await fs.readFile(path.join(repo, '.agents/plugins/marketplace.json'), 'utf-8'));
+    assert.deepEqual(mp.plugins.map(p => p.name), ['keep']);
+    await assert.rejects(() => fs.access(path.join(repo, 'codex/plugins/drop')));
+  } finally {
+    await fs.rm(repo, { recursive: true, force: true });
+  }
+});
+
+test('emitPlugins: prunes orphan plugin package on full rebuild', async () => {
+  const repo = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-bridge-emit-'));
+  try {
+    // pre-existing orphan package dir
+    const orphan = path.join(repo, 'codex/plugins/ghost');
+    await fs.mkdir(orphan, { recursive: true });
+    await fs.writeFile(path.join(orphan, 'marker'), 'x');
+
+    await makePlugin(repo, 'real', { skills: { s: '---\nname: s\ndescription: d\n---\nx\n' } });
+    const config = JSON.parse(JSON.stringify(DEFAULT_CONFIG));
+    const report = await emitPlugins({
+      pluginsDir: path.join(repo, 'plugins'),
+      buildRoot: repo,
+      config,
+      logger: { warn() {}, info() {} },
+    });
+    assert.ok(report.removed.includes('ghost'));
+    await assert.rejects(() => fs.access(orphan));
+  } finally {
+    await fs.rm(repo, { recursive: true, force: true });
+  }
+});
+
+test('emitPlugins: dry-run writes nothing', async () => {
+  const repo = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-bridge-emit-'));
+  try {
+    await makePlugin(repo, 'real', { skills: { s: '---\nname: s\ndescription: d\n---\nx\n' } });
+    const config = JSON.parse(JSON.stringify(DEFAULT_CONFIG));
+    await emitPlugins({
+      pluginsDir: path.join(repo, 'plugins'),
+      buildRoot: repo,
+      config,
+      dryRun: true,
+      logger: { warn() {}, info() {} },
+    });
+    await assert.rejects(() => fs.access(path.join(repo, 'codex')));
+    await assert.rejects(() => fs.access(path.join(repo, '.agents')));
+  } finally {
+    await fs.rm(repo, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

Adds an `--emit plugin` build target to codex-bridge so the whole plugin collection can be installed in Codex via `codex plugin marketplace add owner/repo` and updated with `git pull`, replacing per-file user-mode copies for that workflow. Existing user-mode (`~/.agents/skills/`, `~/.codex/agents/*.toml`) is fully preserved (backward compatible).

This is **PR-1 (core)**. PR-2 (`feat/codex-plugin-build`) commits the generated artifacts and stacks on this branch.

## What's in this PR

- CLI `--emit user|plugin` (default `user`) + config `emitMode` / `pluginBuildRoot`
- transform rule `scope: "external-only"`: in plugin mode preserve plugin-local `/<plugin>:skill` refs, flatten only other-plugin refs to `$skill`
- emit core: `generatePluginJson`, `generateMarketplaceJson`, `buildPluginAgentsDoc`, `emitPlugins`
  - writes `codex/plugins/<plugin>/{.codex-plugin/plugin.json, skills/, AGENTS.md}` + `.agents/plugins/marketplace.json`
  - `source.path` is repo-root relative (`{"source":"local","path":"./codex/plugins/<plugin>"}`)
- commands wrap to `<plugin>-<command>` skills; agents + Claude hooks documented in `AGENTS.md` (Codex `plugin.json` has no `agents` field; Claude hooks are inert under Codex)
- pure repo output — no `$HOME` side effects
- docs: SKILL.md / CLAUDE.md / README; codex-bridge 1.4.0 → 1.5.0

## Verified (Codex CLI 0.134.0)

- marketplace.json layout confirmed empirically: `codex plugin marketplace add <repo>` reads `<repo>/.agents/plugins/marketplace.json`, resolves source paths from repo root
- `--emit plugin --dry-run` plans 20 plugins, user-mode unaffected
- 23 new tests; full suite **145 passing** (was 122)

## Scope notes

- 20 plugins (not 22): `midjourney` excluded via config `exclude`; `core-config` is hooks-only (no invocable skills)
- hooks downgraded to AGENTS.md documentation (Codex hook lifecycle unverified)