### PR TITLE
docs(rules): dual-integration rule — Claude Code ↔ Codex surface sync

### DIFF
--- a/.claude/rules/dual-integration.md
+++ b/.claude/rules/dual-integration.md
@@ -1,0 +1,41 @@
+# Dual-Integration Rules
+
+This marketplace is driven by **both Codex CLI and Claude Code**. Instructions, hooks, and lore that live on only one surface are invisible to half the toolchain. When you edit anything that shapes agent behavior, check the paired surface on the other runtime in the same change.
+
+Since 1.40.0 the two runtimes share one source tree: Codex 0.135 reads `plugins/<name>/` in place via generated `.codex-plugin/plugin.json` manifests (the old `codex-bridge` body-transform mirror was retired). So "keeping the surfaces in sync" is mostly about guidance, hooks, and manifest regeneration — not copying files.
+
+## Role
+
+Keep the Claude Code surface and the Codex surface in sync whenever guidance, hooks, or derived artifacts change — so a rule added for one agent is not silently missing for the other. This rule itself is mirrored into the root `AGENTS.md` (Codex cannot `@import` `.claude/rules/`), making it self-demonstrating.
+
+## Surface Map
+
+| Concern | Claude Code surface | Codex surface |
+|---|---|---|
+| Top-level guidance | `CLAUDE.md`, `.claude/rules/*.md` (`@import`) | `AGENTS.md` (no `@import` — inline or mirror) |
+| Prompt-submit injection | plugin `UserPromptSubmit` hook (`plugin.json` → `hooks/*.sh`) | `~/.codex/hooks.json` `UserPromptSubmit` → same script, `codex` format arg |
+| Skill delivery | `plugins/*/skills` (native) | same `plugins/<name>/` tree in place + generated `.codex-plugin/plugin.json` (via `scripts/sync-codex-manifests.mjs`) |
+| Command / subagent | `plugins/*/{commands,agents}` (native) | not supported by Codex 0.135 — Claude-only, not emitted to manifests |
+| Shared neutral lore | `.llmwiki/` (read by Claude) | `.llmwiki/` (read by Codex — same root, never forked) |
+
+## Do's
+
+- **Edit guidance in pairs.** When you change `CLAUDE.md` behavioral guidance that Codex should also follow, update the matching `AGENTS.md` block (or confirm it is already covered). The reverse holds too.
+- **Mirror cross-cutting `.claude/rules/` rules into `AGENTS.md`.** Codex cannot `@import` `.claude/rules/`, so a rule that both agents must honor needs a concise mirror block in `AGENTS.md` plus a one-line pointer in `CLAUDE.md` `## Modular Rules`.
+- **Pair every hook change.** A new or changed Claude `UserPromptSubmit` / `SessionStart` hook in a `plugin.json` should be checked against the Codex `~/.codex/hooks.json` equivalent. Prefer one shared script with a format arg (plain stdout for Claude, JSON `additionalContext` for Codex) over two divergent copies.
+- **Regenerate Codex manifests after a plugin's skills / `version` / `description` / `category` change.** Run `node scripts/sync-codex-manifests.mjs` (the `--check` drift guard otherwise fails). Codex reads skill bodies in place — no transform — so valid frontmatter still matters; `commands/` and `agents/` are Claude-only and are not emitted. core-config and midjourney are intentionally excluded (see the generator's `EXCLUDED` set).
+- **Keep shared lore in the neutral root.** Cross-agent insight and wiki content live under `.llmwiki/` (never `.claude/`-only), so both runtimes read one copy.
+- **State when a change is intentionally single-surface.** If guidance applies to only one agent (e.g. a Claude-only Plan Mode rule), say so in the change so the asymmetry reads as deliberate, not forgotten.
+
+## Don'ts
+
+- **Never add behavioral guidance to `CLAUDE.md` alone when it should bind both agents.** A Claude-only edit silently exempts every Codex session.
+- **Never wire a Claude hook without considering the Codex counterpart.** Codex hooks require a separate `~/.codex/hooks.json` entry and a `/hooks` trust step — they are not auto-registered by the Claude plugin.
+- **Never hand-edit generated Codex manifests.** `.codex-plugin/plugin.json` and `.agents/plugins/marketplace.json` are `sync-codex-manifests.mjs` output; edit the marketplace source + regenerate, or the `--check` guard flags drift.
+- **Never promote wiki lore to `.claude/rules/`.** Codex never reads `.claude/rules/`. Cross-agent insight graduates to `.llmwiki/insight/` and is surfaced via the shared prompt-injection hook (see `llm-wiki` ingest rules). `.claude/rules/` is reserved for mechanical tool-operation rules (versioning, this file), not lore.
+- **Never fork `.llmwiki/` into per-agent copies.** One neutral root is the point; a `.codex/wiki/` fork defeats it.
+
+## Source of Truth
+
+- This file is the Claude-side SSOT; the `AGENTS.md` "듀얼 통합" block is its Codex mirror — keep them consistent.
+- Related: `plugin-versioning.md` (version bump + manifest regen), the `AGENTS.md` "Codex 통합 (shared-source)" section, and `.llmwiki/wiki/plugin-ops/shared-source-codex-manifests.md` (design rationale for the shared-source model).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,24 @@
 - 파일 탐색과 검색은 우선 `rg`, `rg --files`를 사용하세요.
 - 문서와 매니페스트가 함께 움직이는 저장소이므로 코드 변경뿐 아니라 README, 루트 `CLAUDE.md`, marketplace manifest의 동기화 필요성을 항상 확인하세요.
 
+## 듀얼 통합 (Claude Code ↔ Codex)
+
+이 저장소는 Claude Code 와 Codex CLI 둘 다로 구동된다. 지침/hook/lore 를 한쪽 표면에만 두면 다른 도구체인에는 안 보인다. 동작에 영향을 주는 변경은 짝 표면을 같은 변경에서 점검한다. (Claude 쪽 SSOT: `.claude/rules/dual-integration.md` — Codex 는 `.claude/rules/` 를 `@import` 못 하므로 이 블록이 미러다.)
+
+| 관심사 | Claude Code 표면 | Codex 표면 |
+|---|---|---|
+| 최상위 지침 | `CLAUDE.md`, `.claude/rules/*.md` | `AGENTS.md` (inline / mirror) |
+| 프롬프트 주입 hook | 플러그인 `UserPromptSubmit` (`plugin.json` → `hooks/*.sh`) | `~/.codex/hooks.json` → 같은 스크립트, `codex` 포맷 인자 |
+| skill | `plugins/*/skills` (native) | 같은 `plugins/<name>/` 트리 in-place + generated `.codex-plugin/plugin.json` (아래 "Codex 통합 (shared-source)" 참조) |
+| command / subagent | `plugins/*/{commands,agents}` (native) | Codex 0.135 미지원 (Claude-only — 매니페스트에 미방출) |
+| 공유 중립 lore | `.llmwiki/` (양 에이전트 동일 루트, fork 금지) | `.llmwiki/` |
+
+- 양 에이전트가 따라야 할 behavioral 지침은 `CLAUDE.md` 와 `AGENTS.md` 를 짝으로 수정한다.
+- Claude hook 을 추가/변경하면 Codex `~/.codex/hooks.json` 대응을 점검한다 (Codex hook 은 별도 `/hooks` trust 필요, 자동 등록 안 됨).
+- skill / 버전 / description 을 바꾸면 Codex 매니페스트 재생성(`node scripts/sync-codex-manifests.mjs`)이 필요한지 점검한다 ("Codex 통합 (shared-source)" 섹션 + `plugin-versioning.md`).
+- wiki lore 는 `.claude/rules/` 로 승격하지 않는다 — Codex 가 못 읽는다. cross-agent insight 는 `.llmwiki/insight/` 로 graduate 후 공유 주입 hook 으로 노출한다.
+- `.llmwiki/` 를 per-agent 로 fork 하지 않는다.
+
 ## 저장소 구조
 
 - `CLAUDE.md`: 플러그인 목록과 전체 구조 요약.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,3 +123,4 @@ Produces `.agents/plugins/marketplace.json` + per-plugin `.codex-plugin/plugin.j
 ## Modular Rules
 
 - See @.claude/rules/plugin-versioning.md for plugin version bump contract and cache-refresh workflow.
+- See @.claude/rules/dual-integration.md for keeping the Claude Code and Codex surfaces in sync when editing guidance, hooks, or derived artifacts (mirrored into `AGENTS.md` since Codex cannot `@import` `.claude/rules/`).


### PR DESCRIPTION
## 배경

이 마켓플레이스는 이제 **Claude Code 와 Codex CLI 둘 다**로 구동된다. 지침/hook/lore 를 한쪽 표면에만 두면 다른 도구체인에는 안 보인다. Claude 는 `.claude/rules/`·`CLAUDE.md` 를 읽고, Codex 는 `AGENTS.md`·`~/.codex/` 를 읽는다. 짝 표면을 함께 맞추라고 환기하는 상시 rule 이 없었다.

## 변경 (WS1 — 듀얼 통합 인지 rule)

- **신규 `.claude/rules/dual-integration.md`** (Claude 쪽 SSOT): surface map 표 + Do's/Don'ts. 지침 편집 시 짝 표면 점검 — `CLAUDE.md`↔`AGENTS.md`, Claude hooks↔Codex hooks, `.claude/`↔`.codex/`·`~/.agents/`, codex-bridge sync 커버, 공유 `.llmwiki/` 루트.
- **`AGENTS.md`**: 간결 한글 미러 블록 (Codex 는 `.claude/rules/` 를 `@import` 못 함). rule 자체가 두 곳에 살아있어 self-demonstrating.
- **`CLAUDE.md`**: `## Modular Rules` 에 포인터 한 줄.

## 범위

- 레포의 기계적 `.claude/rules/*.md` (versioning, codex-bridge-sync, 이 신규 파일) 는 도구 운영 rule 이지 wiki lore 가 아니므로 유지. 이 PR 은 그 분리를 명문화한다 (wiki lore → `.llmwiki/insight/`, Codex 가 못 읽는 `.claude/rules/` 아님).
- 플러그인 코드/매니페스트 변경 없음 → 버전 범프 없음.

이 PR 은 2-PR 계획의 PR-A (소규모 독립). PR-B 는 llm-wiki insight 층 + core-config 훅 주입.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * 듀얼 통합 규칙 세트(.claude/rules/dual-integration.md) 추가
  * Claude Code ↔ Codex 간 지침·훅·파생 아티팩트 동기화 및 SSOT/미러링 운영 절차 문서화
  * AGENTS.md에 듀얼 통합 운영 섹션 추가 및 CLAUDE.md에 참조 항목 등록
  * 위키·hook·매니페스트 재생성 등 운영 체크리스트 포함
<!-- end of auto-generated comment: release notes by coderabbit.ai -->