### PR TITLE
chore(wiki): insight-layer refactor — promote 3 entries + dedup + identity fix

### DIFF
--- a/.llmwiki/insight/codex-manifest-regen.md
+++ b/.llmwiki/insight/codex-manifest-regen.md
@@ -1,0 +1,29 @@
+---
+id: codex-manifest-regen
+aliases: [regen-codex-manifests, codex-manifest-drift]
+tier: insight
+promoted_from: [[shared-source-codex-manifests]]
+evidence_count: 2
+last_verified: 2026-06-01
+status: active
+volatility: stable
+sources: 2
+---
+
+# Regenerate Codex manifests after any plugin surface change
+
+Run `node scripts/sync-codex-manifests.mjs` whenever a plugin's `skills` / `version` / `description` / `category` changes. Both runtimes read one source tree in place — there is no mirror and no body transform, so never hand-edit a generated `.codex-plugin/plugin.json` or `.agents/plugins/marketplace.json`, and never reintroduce a `.claude/`→`.codex/` body-rewrite.
+
+**When to apply**: any edit to a plugin's marketplace metadata or skill set; before committing such a change.
+
+**Why**: the `--check` mode is the CI drift gate — a stale or hand-edited manifest fails it; the retired `codex-bridge` body-transform corrupted authorial intent (275 audited hits were legitimate filesystem docs, not stale refs).
+
+The full story (the generator's three modes, the schema constraints, the 275-hit audit) stays in the `promoted_from:` wiki page — not inlined here.
+
+## Sources
+
+- `.llmwiki/wiki/plugin-ops/shared-source-codex-manifests.md` — the promoted source page (generator modes, EXCLUDED set, orphan detection, the body-transform audit).
+- `scripts/sync-codex-manifests.mjs` — the generator and `--check` drift guard itself.
+
+> Evidence: .llmwiki/wiki/plugin-ops/shared-source-codex-manifests.md
+> See-also: [[shared-source-codex-manifests]]

--- a/.llmwiki/insight/cr-rate-limit-budget.md
+++ b/.llmwiki/insight/cr-rate-limit-budget.md
@@ -1,0 +1,29 @@
+---
+id: cr-rate-limit-budget
+aliases: [cr-progressive-refill-rule, cr-max-iter-budget]
+tier: insight
+promoted_from: [[cr-rate-limit-progressive-refill]]
+evidence_count: 2
+last_verified: 2026-06-01
+status: active
+volatility: stable
+sources: 2
+---
+
+# CodeRabbit "free tier disabled" = quota refill, not a plan downgrade
+
+When CR emits `Review skipped: free tier disabled` mid-loop, read it as **progressive-refill hourly-quota exhaustion**, not a subscription downgrade. Do NOT add a sniff cooldown that backs off for K iters — it masks normal refill oscillation as a failure. Treat `--max-iter` as a CR quota budget (Pro ≈ 5 rev/hour), and throttle bursts with push spacing instead.
+
+**When to apply**: running `cr-fix` (or any CR multi-iter loop) that bursts several pushes within an hour and starts seeing skipped reviews.
+
+**Why**: a cooldown would suppress recoverable refill behavior and waste iterations; the misread inverts a recoverable state into a hard-cap failure.
+
+The dogfood data, the Fair-Usage-Policy citation, and the planned-v3 `--push-spacing` design stay in the `promoted_from:` wiki page (still `volatility: volatile`); only the stabilized rule is promoted here.
+
+## Sources
+
+- `.llmwiki/wiki/cr-fix-ops/cr-rate-limit-progressive-refill.md` — the promoted source page (mechanism, PR #33 dogfood data, policy citation).
+- `plugins/github-dev/skills/cr-fix/references/lessons-from-dogfood.md` — Lesson 5 (the corrected reading after consulting CR docs).
+
+> Evidence: .llmwiki/wiki/cr-fix-ops/cr-rate-limit-progressive-refill.md
+> See-also: [[cr-rate-limit-progressive-refill]]

--- a/.llmwiki/insight/index.md
+++ b/.llmwiki/insight/index.md
@@ -49,6 +49,9 @@ Insight is the most aggressively consolidated layer. Before adding an entry: gre
 
 ## Entries
 
-<!-- No insights promoted yet. Graduate findings here via `/llm-wiki:ingest-finding`
-     (its graduation step), one entry per `## <id>` heading with a 1-line hook:
-     `- [title](<slug>.md) — rule + when-to-apply (promoted_from [[wiki-id]])` -->
+<!-- Graduate findings here via `/llm-wiki:ingest-finding` (its graduation step).
+     One hook per entry: `- [title](<slug>.md) — rule + when-to-apply (promoted_from [[wiki-id]])` -->
+
+- [Regenerate Codex manifests on surface change](codex-manifest-regen.md) — run `node scripts/sync-codex-manifests.mjs` after any plugin skills/version/description/category change; `--check` is the CI drift gate; never hand-edit generated manifests or reintroduce a body transform (promoted_from [[shared-source-codex-manifests]]).
+- [CR "free tier disabled" = quota refill](cr-rate-limit-budget.md) — CR `Review skipped: free tier disabled` is progressive-refill exhaustion, not a plan downgrade; no sniff cooldown; treat `--max-iter` as a CR quota budget (promoted_from [[cr-rate-limit-progressive-refill]]).
+- [Plugin versions pin at session start](plugin-cache-restart.md) — a session pins each plugin's version at startup; restart to pick up a cached update; mid-migration, drive work from repo source not the pinned skill (promoted_from [[cache-version-pinning]]).

--- a/.llmwiki/insight/plugin-cache-restart.md
+++ b/.llmwiki/insight/plugin-cache-restart.md
@@ -1,0 +1,29 @@
+---
+id: plugin-cache-restart
+aliases: [plugin-version-pin-rule, mid-migration-source-of-truth]
+tier: insight
+promoted_from: [[cache-version-pinning]]
+evidence_count: 2
+last_verified: 2026-06-01
+status: active
+volatility: stable
+sources: 2
+---
+
+# A session pins plugin versions at startup — restart to pick up updates
+
+Claude Code resolves and pins each plugin's version once, at session start. A `/plugin marketplace update` that lands a newer version in the cache is invisible to the running session until a restart re-resolves. So during a migration window, do NOT trust the pinned skill's defaults — drive the work from the repo's current source files (and the documented resolution order), not the cached skill body.
+
+**When to apply**: any time observed plugin/skill behavior lags the repo source — especially mid-migration when the cache holds both old and new versions.
+
+**Why**: acting on a stale pinned skill silently runs an older workflow (e.g. a wiki skill resolving the legacy `.claude/wiki/` root instead of `.llmwiki/`), wasting a cycle on a non-bug.
+
+Escape hatches and the cache-vs-version-pin distinction stay in the `promoted_from:` wiki page; only the operating rule is promoted here.
+
+## Sources
+
+- `.llmwiki/wiki/plugin-ops/cache-version-pinning.md` — the promoted source page (the pin mechanism, escape hatches, the distinct cache-refresh bug).
+- `.claude/rules/plugin-versioning.md` — the schema-layer version contract and the separate `rm -rf` cache-refresh workaround.
+
+> Evidence: .llmwiki/wiki/plugin-ops/cache-version-pinning.md
+> See-also: [[cache-version-pinning]]

--- a/.llmwiki/wiki/cr-fix-ops/cr-rate-limit-progressive-refill.md
+++ b/.llmwiki/wiki/cr-fix-ops/cr-rate-limit-progressive-refill.md
@@ -1,0 +1,49 @@
+---
+id: cr-rate-limit-progressive-refill
+aliases: [cr-free-tier-disabled, cr-quota-budget, cr-burst-push]
+last_verified: 2026-05-30
+status: active
+volatility: volatile
+sources: 2
+---
+
+# CodeRabbit rate-limit: progressive refill, not a plan downgrade
+
+## The misread
+
+CodeRabbit (CR) emits `Review skipped: free tier disabled` on review-comment messages when a multi-iter loop bursts past its hourly quota. Read literally, this looks like the org's CR plan was reverted to Free — which would warrant adding a sniff cooldown that backs off for K iters.
+
+This reading is **wrong**. The message names the wrong cause.
+
+## The mechanism
+
+Per CR's [Fair Usage Limits Policy](https://docs.coderabbit.ai/management/plans#fair-usage-limits-policy):
+
+- The org's plan is unchanged. "Free tier disabled" refers to CR's **internal review tier** (the free-of-charge review path), not the customer's subscription plan.
+- CR uses **progressive refill** for hourly quotas: reviews trickle back as time passes. There is no clean 60-minute reset window.
+- Wait time depends on recent per-developer activity. A burst of 5 reviews in 10 minutes does not block the 6th for a fixed hour; it shortens the trickle interval.
+
+## Why this matters for `cr-fix`
+
+`cr-fix` was originally written to add a per-PR cooldown that would skip `sniff-cr-rate-limit.sh` for K iters after detecting "free tier disabled". The lesson learned during PR #33 dogfood (8 push in ~10 min, 5 CR-reviewed / 3 skipped) overturned that design:
+
+- **Do NOT add a sniff cooldown.** It would mask normal progressive-refill oscillation as a failure mode it isn't.
+- **Treat `--max-iter` as a CR quota budget**, not a retry cap. Default `5` happens to align with CR Pro's 5-rev/hour — possibly a Karpathy-style intentional design coincidence in cr-fix v1.
+- **Add `--push-spacing <sec>`** (planned v3) to throttle burst-push patterns at source. CR Pro+ / Enterprise users can keep `0`.
+- The pre-flight gate should distinguish "rate-limited (progressive refill in progress)" from "rate-limited (hard cap)" — currently both surface as `gate=rate_limited` and lose the recoverable/non-recoverable distinction.
+
+## Trial dogfood data (PR #33)
+
+- 8 push within ~10 minutes
+- 5 successful CR reviews (`cr_state: success`, `cr_desc: "Review completed"`)
+- 3 skipped reviews (`cr_state: success`, `cr_desc: "Review skipped: free tier disabled"`)
+- Skip:complete oscillation matches progressive-refill semantics — not a hard cap.
+
+> Evidence: plugins/github-dev/skills/cr-fix/references/lessons-from-dogfood.md
+> Evidence: plugins/github-dev/skills/cr-fix/scripts/sniff-cr-rate-limit.sh
+> See-also: [[curated-conservative]]
+
+## Sources
+
+1. **plugins/github-dev/skills/cr-fix/references/lessons-from-dogfood.md** — Lesson 5 (CORRECTED). The reference file itself records both the initial misreading and the corrected reading after consulting CR docs. PR #33 dogfood evidence (CR check IDs 4393995268, 4394157080, 4394162348) cited in the lesson body.
+2. **CodeRabbit Fair Usage Limits Policy** — `https://docs.coderabbit.ai/management/plans#fair-usage-limits-policy`. Authoritative external doc on progressive-refill semantics. Cited inline in Lesson 5 of the lessons-from-dogfood reference file.

--- a/.llmwiki/wiki/index.md
+++ b/.llmwiki/wiki/index.md
@@ -77,3 +77,15 @@ Operational lore for the plugin system itself — cache, loading, version resolu
 - [Plugin cache version-pinning](plugin-ops/cache-version-pinning.md) — the cache holds multiple versions per plugin; a session pins the startup-resolved version, so a newer already-cached version is not served until restart (or via a `local` settings.json source).
 - [Shared-source Codex manifests](plugin-ops/shared-source-codex-manifests.md) — Claude and Codex 0.135 read the same `plugins/<name>/skills/` tree via a thin manifest generator (`scripts/sync-codex-manifests.mjs`); the retired `codex-bridge` body-transform mirror was wrong because its 275 audit hits were authorial intent, not stale references. 19 of 21 plugins eligible after the 1.41.0 dual-surface conversion of `deepwiki` + `project-init`.
 - [Dual-surface command + skill pattern](plugin-ops/dual-surface-command-skill-pattern.md) — how a plugin ships both an explicit `/plugin:command` and a Codex-loadable `skill` from a single `references/<name>-procedure.md` body; documents the runtime preflight guard required for destructive plugins and the `PLUGIN_ROOT` resolver pattern that handles Codex's lack of `${CLAUDE_PLUGIN_ROOT}`.
+
+## cr-fix-ops
+
+Per-plugin operational lore for `github-dev:cr-fix` — rate-limit semantics, dogfood-derived design rationale that overturns intuition. Distinct from `plugin-ops/` (Claude Code runtime) and from the cr-fix references files (active design contract).
+
+- [CR rate-limit progressive refill](cr-fix-ops/cr-rate-limit-progressive-refill.md) — `cr_desc: "Review skipped: free tier disabled"` does NOT mean the org reverted to Free plan; it signals CR trial/Pro progressive-refill quota exhaustion. Do NOT add a sniff cooldown; treat `--max-iter` as a CR quota budget (default 5 = Pro 5-rev/hour).
+
+## research-harness
+
+Cross-plugin research harness boundary contracts (code-scout, `/deep-research`, paper-search-tools). Captures inter-harness routing rules that span plugins.
+
+- [code-scout vs /deep-research boundary](research-harness/code-scout-vs-deep-research-boundary.md) — code-scout owns code / ML / docs / papers; `/deep-research` owns generic topics; `research-orchestrator` does NOT delegate to `/deep-research`. Boundary is intentional — the two harnesses tune their fan-out for incompatible domains.

--- a/.llmwiki/wiki/llm-wiki-design/neutral-llmwiki-root.md
+++ b/.llmwiki/wiki/llm-wiki-design/neutral-llmwiki-root.md
@@ -65,21 +65,19 @@ consolidates them into the neutral root.
 
 ## Vindication: the transform was the problem, not stale references
 
-A pre-retirement audit grepped the three `codex-bridge` body transforms
-(`.claude/`→`.codex/`, `CLAUDE.md`→`AGENTS.md`, `/plugin:skill`→`$skill`)
-across the entire skill tree and found ~275 hits. Spot-checking revealed that
-nearly all hits were **legitimate documentation of Claude's filesystem**, not
-stale references that needed rewriting: `llm-wiki` bootstraps `.claude/rules/`
-literally (the only verified session-start auto-load path), `github-dev/cr-fix`
-iterates `CONFIG_FILES="CLAUDE.md AGENTS.md"`, `rules-forge` explains the
-semantics of `CLAUDE.md` to its readers. The transforms were corrupting
-authorial intent rather than translating it.
+A pre-retirement audit of the three `codex-bridge` body transforms found ~275
+hits that were nearly all **legitimate documentation of Claude's filesystem**,
+not stale references — the transforms corrupted authorial intent rather than
+translating it. The full account (the three transforms and the three worked
+examples) is the canonical record on [[shared-source-codex-manifests]] under
+`## Why the body-transform mirror was wrong`; it is not restated here to keep a
+single source of truth.
 
 The fork bug is now eliminated structurally: the `codex-bridge` plugin (the
 transform source) is retired, and both runtimes read the same source via a
-manifest generator that emits *outside* the skill bodies — see
-[[shared-source-codex-manifests]]. The neutral-root data layout remains the
-correct defense against any future mirror that might re-emerge.
+manifest generator that emits *outside* the skill bodies. The neutral-root data
+layout remains the correct defense against any future mirror that might
+re-emerge.
 
 ## Sources
 

--- a/.llmwiki/wiki/log.md
+++ b/.llmwiki/wiki/log.md
@@ -36,6 +36,25 @@ Diff log written before applying the page edits (git-revertible). Merge SHA `158
 - llm-wiki-design/neutral-llmwiki-root.md: updated (last_verified 2026-05-29 → 2026-05-31, sources 2 → 3) — added "Vindication" subsection: the PR #39 body-transform audit found 275 `.claude/` hits across skill bodies were nearly all *legitimate authorial documentation* (llm-wiki bootstraps `.claude/rules/`, github-dev/cr-fix accepts `CONFIG_FILES="CLAUDE.md AGENTS.md"`, rules-forge explains `CLAUDE.md` semantics). The transforms themselves were corrupting authorial intent. The fix is now structural: the codex-bridge plugin (the transform source) is retired in 1.40.0; both runtimes read the same source. Neutral-root defense remains correct for any future mirror that might re-emerge. Updated status note on the bridge.
 - index.md: added shared-source-codex-manifests hook under `## plugin-ops`; MOC `last_verified:` bumped to 2026-05-31.
 - Evidence (in-diff, from `git show --name-only`): `scripts/sync-codex-manifests.mjs` (new generator), `plugins/codex-bridge/scripts/sync.mjs` (deleted 1,214-line transform engine), `plugins/codex-bridge/` directory (deleted in full), `.agents/plugins/marketplace.json` (generated catalog), `plugins/*/.codex-plugin/plugin.json` × 17 (generated per-plugin manifests), `AGENTS.md` / `CLAUDE.md` / `README.md` (shared-source docs).
+
+## 2026-05-30 — post-merge #33 (post-merge-wiki)
+
+Diff log written before applying the page edits (git-revertible). Merge SHA `bcc3939` — feat(github-dev): cr-fix v2 — pre-flight detection + autonomous judgment.
+
+- cr-fix-ops/: new domain directory established under `.llmwiki/wiki/` to hold per-plugin cr-fix operational lore (rate-limit semantics, dogfood-derived design rationale). Distinct from `plugin-ops/` (Claude Code runtime cache) and from the cr-fix references files (active design contract).
+- cr-fix-ops/cr-rate-limit-progressive-refill.md: new page (id `cr-rate-limit-progressive-refill`, status active, volatility volatile, sources 2) — `cr_desc: "Review skipped: free tier disabled"` does NOT mean the org reverted to Free plan. It signals CR trial/Pro **progressive-refill hourly quota exhaustion** per the [Fair Usage Limits Policy](https://docs.coderabbit.ai/management/plans#fair-usage-limits-policy). Reviews trickle back (not a 60-min reset). Treat `--max-iter` as a CR quota budget (default 5 = Pro 5-rev/hour). Do NOT add a sniff cooldown — use `--push-spacing` instead. Overturns the v2-development intuition. `> Evidence: plugins/github-dev/skills/cr-fix/references/lessons-from-dogfood.md`.
+- index.md: added `## cr-fix-ops` domain section with the cr-rate-limit-progressive-refill hook; MOC `last_verified:` bumped to 2026-05-30.
+- Evidence (in-diff, from `git show --name-only bcc3939`): `plugins/github-dev/skills/cr-fix/references/lessons-from-dogfood.md` (Lesson 5 = corrected reading after consulting CR docs) + `plugins/github-dev/skills/cr-fix/scripts/sniff-cr-rate-limit.sh` (detection implementation). External source: CR Fair Usage Policy docs.
+
+## 2026-05-30 — post-merge #30 (post-merge-wiki)
+
+Diff log written before applying the page edits (git-revertible). Merge SHA `fc4d994` — feat(code-scout): v2.1 — paper-scout 5th axis + insane-search tier-4 + deep-research boundary + drop deep-scout.
+
+- research-harness/: new domain directory established under `.llmwiki/wiki/` to hold cross-plugin research harness boundary contracts (code-scout, /deep-research, paper-search-tools). Distinct from per-plugin operational lore — this domain captures **inter-harness routing rules** that span plugins.
+- research-harness/code-scout-vs-deep-research-boundary.md: new page (id `code-scout-deep-research-boundary`, status active, volatility stable, sources 2) — code-scout owns the code / ML / docs / papers domain; `/deep-research` owns generic topics (politics, market, history, biographies, general policy). The `research-orchestrator` skill explicitly does **NOT** delegate to `/deep-research` even when the query is out-of-domain. The two harnesses tune their fan-out for incompatible domains; routing one through the other would mis-tune. `> Evidence: plugins/code-scout/skills/research-orchestrator/SKILL.md`.
+- index.md: added `## research-harness` domain section with the code-scout-vs-deep-research-boundary hook.
+- Evidence (in-diff, from `git show --name-only fc4d994`): `plugins/code-scout/skills/research-orchestrator/SKILL.md` (boundary contract authored here, frontmatter line 17-21 + body line 41).
+
 ## 2026-05-29 — post-merge #29 (post-merge-wiki)
 
 Diff log written before applying the page edits (git-revertible). Merge SHA `2a166d5` — chore: post-v2 maintenance (docs-forge frontmatter + settings.json local).

--- a/.llmwiki/wiki/log.md
+++ b/.llmwiki/wiki/log.md
@@ -8,6 +8,26 @@ Every `/ingest-finding` and `/post-merge-wiki` run writes a block here **before*
 
 <!-- New entries go directly under this line -->
 
+## 2026-06-01 — insight promotion (3 entries) + body-transform dedup + code-scout id fix (ingest-finding)
+
+Diff log written before applying the page edits (git-revertible). Full insight-layer pass over the existing wiki: promote 3 stabilized findings to `.llmwiki/insight/`, compress one duplicated narrative, fix one identity-rot id. No wiki page deleted; each insight entry condenses (never copies) its `promoted_from:` source.
+
+- insight/codex-manifest-regen.md: new insight entry (id `codex-manifest-regen`, tier insight, promoted_from [[shared-source-codex-manifests]], evidence_count 2, volatility stable, sources 2) — rule: regenerate Codex manifests (`node scripts/sync-codex-manifests.mjs`) on any plugin skills/version/description/category change; `--check` is the CI drift gate; never hand-edit generated manifests or reintroduce a body-transform mirror.
+- insight/cr-rate-limit-budget.md: new insight entry (id `cr-rate-limit-budget`, tier insight, promoted_from [[cr-rate-limit-progressive-refill]], evidence_count 2, volatility stable — stable core only; the source page stays volatile, sources 2) — rule: CR `Review skipped: free tier disabled` = progressive-refill quota exhaustion, NOT a plan downgrade; do not add a sniff cooldown; treat `--max-iter` as a CR quota budget. (The planned-v3 `--push-spacing` detail is intentionally left in the wiki, not promoted.)
+- insight/plugin-cache-restart.md: new insight entry (id `plugin-cache-restart`, tier insight, promoted_from [[cache-version-pinning]], evidence_count 2, volatility stable, sources 2) — rule: a session pins each plugin's version at startup; mid-session marketplace updates are invisible until restart; during a migration window drive work from repo source, not the pinned skill; refresh via restart or `rm -rf` of the plugin cache.
+- insight/index.md: registered the 3 entries under `## Entries`; last_verified 2026-06-01.
+- llm-wiki-design/neutral-llmwiki-root.md: consolidation — compressed the `## Vindication` section (a full re-telling of the 275-hit body-transform audit + the same 3 examples) to a short pointer at the canonical account in [[shared-source-codex-manifests]] (`## Why the body-transform mirror was wrong`). Kept the conclusion; removed the duplicated body. last_verified 2026-06-01 (sources unchanged).
+- research-harness/code-scout-vs-deep-research-boundary.md: identity-rot fix — `id: code-scout-deep-research-boundary` → `code-scout-vs-deep-research-boundary` (now matches the filename and the `code-scout-vs-deep-research` alias); no cross-page `[[ref]]` pointed at the old id. last_verified 2026-06-01.
+- Evidence: `.llmwiki/wiki/plugin-ops/{shared-source-codex-manifests,cache-version-pinning}.md`, `.llmwiki/wiki/cr-fix-ops/cr-rate-limit-progressive-refill.md`, `.llmwiki/insight/index.md`.
+
+## 2026-06-01 — post-merge #42 + #43 (post-merge-wiki)
+
+Scanned the merge diffs `f6efe50` (#42 dual-integration rule) + `799a9bb` (#43 insight layer + prompt-inject hook) per `git show --name-only`. No new wiki page ingested — both PRs were already self-documenting:
+
+- #43 shipped its own wiki lore in-PR: `llm-wiki-design/insight-layer-via-hook.md` (new) + `neutral-llmwiki-root.md` / `curated-conservative.md` updates + a `log.md` entry (the 2026-06-01 insight-layer entry below).
+- #42's `.claude/rules/dual-integration.md` is a normative Claude↔Codex surface-sync checklist whose design rationale already lives in `plugin-ops/shared-source-codex-manifests.md` (the rule cites it at its Source-of-Truth line) + `llm-wiki-design/{neutral-llmwiki-root,insight-layer-via-hook}.md`. A dedicated page would duplicate that, so none was added.
+- rules/*.md flags: none — dual-integration.md is a new rule file, not an invariant change.
+
 ## 2026-06-01 — insight layer + refine design record (ingest-finding)
 
 Diff log written before applying the page edits (git-revertible). Captures the WS2 insight-layer migration (the `.llmwiki/insight/` promoted layer + the `.claude/rules/`-as-promotion-target retirement).

--- a/.llmwiki/wiki/plugin-ops/shared-source-codex-manifests.md
+++ b/.llmwiki/wiki/plugin-ops/shared-source-codex-manifests.md
@@ -70,10 +70,10 @@ and `midjourney` (image-gen workflow does not fit Codex's execution model).
 That yields **19 of 21** plugins eligible for Codex.
 
 `deepwiki` and `project-init` were in the EXCLUDED set before 1.41.0 because
-they shipped only `commands/`. The 1.41.0 dual-surface conversion (see
-[[dual-surface-command-skill-pattern]]) added `skills/` directories whose
-bodies point at the same `references/` procedures the commands use, so the
-plugins now have something for Codex to load and leave the exclusion list.
+they shipped only `commands/`. The 1.41.0 dual-surface conversion added
+`skills/` directories whose bodies point at the same `references/` procedures
+the commands use, so the plugins now have something for Codex to load and leave
+the exclusion list (the layout is the `> See-also:` page below).
 
 `.mcp.json` is treated as a *file* path in the Codex manifest, not a directory
 — a subtle schema difference from Claude's behavior that the generator handles

--- a/.llmwiki/wiki/research-harness/code-scout-vs-deep-research-boundary.md
+++ b/.llmwiki/wiki/research-harness/code-scout-vs-deep-research-boundary.md
@@ -1,0 +1,50 @@
+---
+id: code-scout-deep-research-boundary
+aliases: [research-harness-boundary, code-scout-vs-deep-research, orchestrator-non-delegation]
+last_verified: 2026-05-30
+status: active
+volatility: stable
+sources: 2
+---
+
+# Research harness boundary: code-scout vs `/deep-research`
+
+## The boundary
+
+| Harness | Owns | Tuning |
+|---|---|---|
+| `code-scout` (`research-orchestrator` skill) | code / ML / docs / academic papers | 5-axis fan-out (github / hf / web / docs / paper) with per-axis tooling (Context7, DeepWiki, exa, gh, hf CLI, paper-search-tools) |
+| `/deep-research` | generic topics — politics, market, history, biographies, general policy | 7-phase + adversarial verify state machine, broader web sweep |
+
+Both are research harnesses; they tune their fan-out for incompatible domains. Misrouting between them produces low-signal output: code-scout's 5-axis matrix wastes phases on irrelevant tools when given a generic topic, and `/deep-research`'s broader sweep dilutes precision when given a code/ML query that needed Context7 + DeepWiki + paper-search.
+
+## The non-delegation rule
+
+`research-orchestrator` explicitly does **NOT** delegate to `/deep-research` even when the user's query falls outside the code / ML domain. The orchestrator's SKILL.md (lines 17-21 frontmatter exclusion + line 41 in the "should-NOT" matrix) names this as an intentional design choice:
+
+> Orchestrator does **not** delegate to `/deep-research` — the boundary is intentional.
+
+Instead, the orchestrator's frontmatter `description` field tells the **caller** (the main session) to invoke `/deep-research` directly when the query is generic. The handoff happens before code-scout is invoked, not inside it.
+
+## Why the non-delegation matters
+
+Future-you will be tempted to add a "missing topic" delegation: when code-scout detects an out-of-domain query, route it to `/deep-research` and merge results. **Resist this.**
+
+- The two harnesses have different state machines (5-axis fan-out vs 7-phase). Merging mid-flight breaks both.
+- The synthesis stage (`synthesis-scout` for code-scout, in-skill for `/deep-research`) applies harness-specific dedup keys and trust rubrics. Cross-harness merging would mis-score.
+- The boundary keeps each harness debuggable in isolation. A regression in code-scout's web-scout doesn't infect `/deep-research`'s coverage.
+
+The right escape valve when code-scout receives an out-of-domain query: emit a `BLOCKED` status with `gate=out-of-domain` and let the caller re-route at the top level.
+
+## Adjacent contracts
+
+- `paper-search-tools` is a primitive (8-source MCP family); code-scout's `paper-scout` wraps it as one axis. `/deep-research` may use `paper-search-tools` differently for its own phases. The primitive is shared; the harnesses are not.
+- `deepwiki:ask` and `context7` MCP are direct-call paths for single-question lookups — neither code-scout nor `/deep-research` is invoked for those (per the orchestrator's near-miss disambiguation in `references/agent-routing.md`).
+
+> Evidence: plugins/code-scout/skills/research-orchestrator/SKILL.md
+> See-also: [[curated-conservative]]
+
+## Sources
+
+1. **plugins/code-scout/skills/research-orchestrator/SKILL.md** — frontmatter `description` field (lines 17-21) excludes generic non-code/ML topics and points at `/deep-research`. Body line 41 in the "should-NOT" matrix names the non-delegation as intentional. Authored in PR #30 (commit `fc4d994`).
+2. **PR #30 merge commit `fc4d994`** — `feat(code-scout): v2.1 — paper-scout 5th axis + insane-search tier-4 + deep-research boundary + drop deep-scout`. The "deep-research boundary" phrase in the squash title is the design-record header for this contract.

--- a/.llmwiki/wiki/research-harness/code-scout-vs-deep-research-boundary.md
+++ b/.llmwiki/wiki/research-harness/code-scout-vs-deep-research-boundary.md
@@ -1,7 +1,7 @@
 ---
-id: code-scout-deep-research-boundary
-aliases: [research-harness-boundary, code-scout-vs-deep-research, orchestrator-non-delegation]
-last_verified: 2026-05-30
+id: code-scout-vs-deep-research-boundary
+aliases: [research-harness-boundary, code-scout-vs-deep-research, code-scout-deep-research-boundary, orchestrator-non-delegation]
+last_verified: 2026-06-01
 status: active
 volatility: stable
 sources: 2


### PR DESCRIPTION
Full insight-layer pass over the existing `.llmwiki/` wiki under the new policy (neutral `.llmwiki/insight/` promotion layer, non-append consolidation, insight-integrity lint). Content-only — **no version bump**, no plugin code touched.

## What changed

**C0 — WIP freeze.** Commits the prior #33/#30 `post-merge-wiki` output that was sitting uncommitted: `cr-fix-ops/cr-rate-limit-progressive-refill.md` + `research-harness/code-scout-vs-deep-research-boundary.md` + their `index.md`/`log.md` entries.

**C1 — Insight promotion (3 entries).** Each wiki page is left intact; an extremely condensed insight entry (`tier: insight`, `promoted_from: [[wiki-id]]`, `evidence_count`, `volatility: stable`) graduates to `.llmwiki/insight/`, with the long reasoning delegated back to the wiki via `promoted_from:`/`> Evidence:`:
- `codex-manifest-regen` ← `shared-source-codex-manifests` — regenerate Codex manifests on any plugin surface change; `--check` is the CI drift gate; no body-transform mirror.
- `cr-rate-limit-budget` ← `cr-rate-limit-progressive-refill` — CR "free tier disabled" = progressive-refill exhaustion, not a plan downgrade; no sniff cooldown; `--max-iter` = CR quota budget. (Stable core only; planned-v3 detail stays in the wiki.)
- `plugin-cache-restart` ← `cache-version-pinning` — sessions pin plugin versions at startup; restart to pick up updates; mid-migration, work from repo source. (Re-stamped `volatility: stable`; the volatile bug detail stays in the wiki.)

Deliberately **not** promoted: `code-scout-vs-deep-research-boundary` (design rationale, self-enforced by orchestrator frontmatter) and `dual-surface-command-skill-pattern` (a reusable procedure → skill territory).

**C2 — Consolidation (non-append).** The 275-hit body-transform audit was told in full in both `shared-source-codex-manifests` and `neutral-llmwiki-root`. Kept the canonical account on `shared-source-codex-manifests`; compressed `neutral-llmwiki-root`'s "Vindication" section to a pointer.

**C3 — Identity-rot fix.** `code-scout-vs-deep-research-boundary.md` had `id: code-scout-deep-research-boundary` (missing "vs"). Corrected the `id` to match the filename (old id retained as an alias).

**Lint follow-up.** Removed a pre-existing bare `[[wikilink]]` in `shared-source-codex-manifests` prose (the typed `> See-also:` already covers it) to pass the relationship scan.

## Post-merge note (#42/#43)

`post-merge-wiki` scanned the #42 + #43 merge diffs: no new pages ingested — #43 self-documented its lore in-PR (`insight-layer-via-hook.md`), and #42's dual-integration rule's rationale already lives in `shared-source-codex-manifests`. Recorded as a `log.md` marker.

## Lint (`/llm-wiki:lint-wiki`)

Identity clean · Relationship clean · Staleness clean · Orphans none · Contradictions none · Insight = 3 entries (all `tier`+`promoted_from` resolving to active pages, all <2KB). Pre-existing report-only flags noted: 2 pages >5KB (`shared-source` 5.2KB, `dual-surface` 7.6KB).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Documentation**
  * 플러그인 매니페스트 재생성 절차 관련 신규 가이드 문서 추가
  * 코드 리뷰 속도 제한 예산 및 시간당 쿼터 회복에 관한 안정화된 규칙 문서화
  * 플러그인 캐시 재시작 동작 및 적용 시점 설명 추가
  * 연구 하네스의 코드 스카우트와 심층 조사 간 경계 규칙 명시
  * 위키 색인 및 로그 업데이트로 신규 문서 반영

<!-- end of auto-generated comment: release notes by coderabbit.ai -->