### PR TITLE
feat: skills installer TUI (hermes/codex, zero-dep npx skills wrapper)

### DIFF
--- a/.claude/spec/2026-06-24-skills-installer-tui.md
+++ b/.claude/spec/2026-06-24-skills-installer-tui.md
@@ -1,0 +1,76 @@
+# Feature Specification: Skills Installer TUI (hermes / codex)
+
+## Overview
+
+이 repo(`my-claude-plugins`)의 SKILL.md들을 골라 **Hermes Agent**와 **Codex**에 설치하는 in-repo 터미널(TUI) 도구. `npx skills`(vercel-labs/skills) CLI를 **래핑**한다. 자체 exporter는 만들지 않는다.
+
+> 상태: spec 취합(plan 전). 구현 미착수.
+
+## Decisions made (인터뷰 + 조사 확정)
+
+| 결정 | 값 |
+|---|---|
+| 구현 방식 | **WRAP** — `npx skills` 래핑. TUI = picker + `npx skills add` spawn (자체 exporter X) |
+| 대상 런타임 | **Hermes Agent**(`-a hermes-agent`) + **Codex**(`-a codex`). hermes = Nous Research Hermes Agent CLI 확정(~90%) |
+| 용도 | **내 로컬 dev 도구** — repo 체크아웃 상태에서 로컬 `plugins/` 트리로부터 설치. in-repo `.mjs` 스크립트 |
+| 선택 단위 | **플러그인 그룹 트리(양쪽)** — 플러그인 줄 체크 = 그 안 skill 전부, 펼쳐 개별 skill 토글 |
+| 스택 | Node ESM(>=18) + `@clack/prompts`(group multiselect) + `yaml` |
+
+## Scope facts (조사 근거)
+
+- **우리 표면**: 25 플러그인 / 47 SKILL.md / 설치 대상 **24개**(`core-config`=skill 0개 제외). frontmatter 계약 = `name`(필)·`description`(필, ≤1024)·`version`·`allowed-tools`(옵). 분포: github-dev 8, llm-wiki 5, ml-toolkit·docs-forge 4, e2e-harness·code-scout 3, paper-search·deepwiki 2, 나머지 16개 각 1.
+- **commands/agents = Claude 전용**(hermes/codex 미이식): code-scout(A), council·deepwiki·docs-forge·paper-search-tools·project-init(C). skill만 설치된다.
+- **npx skills**(vercel-labs/skills, npm `skills`): `add`/`remove`/`update`(alias `upgrade`)/`experimental_sync`/`use`. `.claude-plugin/marketplace.json`/`plugin.json`을 읽음. 기본 symlink + copy fallback. 75+ 타겟.
+- **충돌**: 무조건 덮어쓰기(백업·사용자수정 보호 없음). **삭제**: `remove` 멀티에이전트 청소 + ref-count canonical. **버전**: lockfile 2개(전역 tree-SHA + 프로젝트 content-hash SHA-256, 후자는 VCS 커밋 권장) 해시 드리프트 감지, 기록된 ref에서 always-latest(커밋 SHA 핀 없음).
+- **hermes profile**: profile = 격리된 `HERMES_HOME`. skill이 **profile별로 분리** — default=`~/.hermes/skills`, named=`~/.hermes/profiles/<name>/skills`. **npx skills는 profile 미인식** → `HERMES_HOME` env를 직접 export해야만 특정 profile로 설치됨. codex엔 profile 개념 없음(단일 `~/.codex/skills`).
+
+## Requirements
+
+### Must Have (P0)
+- [ ] 로컬 `plugins/*/skills/*/SKILL.md` 스캔 + `.claude-plugin/marketplace.json` 읽어 **플러그인 그룹 트리** 구성(skill 0개 플러그인은 비활성/회색).
+- [ ] `@clack/prompts` group multiselect: 플러그인 단위 / 개별 skill 단위 양쪽 선택.
+- [ ] 타겟 다중 선택(`hermes-agent`, `codex`) + scope 선택(global `~/` vs project `./`).
+- [ ] **hermes profile 선택기**: `~/.hermes/profiles/*` 스캔 + default; 선택 profile로 `HERMES_HOME` export 후 `npx skills` spawn.
+- [ ] 선택 결과를 `npx skills add <local-skill-path> -a <agents> [-g] -y`로 실행(충돌·삭제·버전 처리는 CLI 상속).
+
+### Should Have (P1)
+- [ ] 실행 전 미리보기: 설치될 (skill x 타겟 x scope/profile) 매트릭스와 대상 경로를 보여주고 확정.
+- [ ] 설치 후 요약(어디에 무엇이 깔렸는지) + lockfile 위치 안내.
+- [ ] pre-flight 검증: `description` ≤1024 + frontmatter 유효성(기존 `scripts/sync-codex-manifests.mjs` 규칙 재사용)으로 깨진 skill 사전 차단.
+
+### Nice to Have (P2)
+- [ ] `remove`/`update`를 TUI에서 노출(`npx skills remove/update` 래핑) — v1은 설치 위주.
+- [ ] 프리셋 빠른 선택(예: Codex-eligible 22).
+- [ ] 배포 가능 구조로 분리(나중에 자체 npx 패키지화). v1은 로컬 우선.
+
+## Technical Constraints
+- Node >=18 ESM, repo의 `.mjs` 툴체인과 일관(@clack/prompts, yaml).
+- npx skills는 profile 미인식 → **HERMES_HOME env 브리지는 우리 래퍼 책임**.
+- commands/agents/hooks/MCP는 hermes/codex 미이식 — **skill만** 설치(트리에서 비-skill 컴포넌트는 제외/회색).
+- 설치 메커니즘(symlink vs copy)·충돌·remove·update·lockfile은 모두 `npx skills`에 위임(재구현 금지).
+
+## Edge Cases
+| 시나리오 | 기대 동작 |
+|---|---|
+| skill 0개 플러그인 선택 시도(core-config) | 트리에서 비활성, 선택 불가 |
+| 같은 이름 skill이 이미 설치됨 | npx skills 기본 덮어쓰기에 위임(우리 추가 보호 없음 — Out of Scope) |
+| hermes 미설치(`~/.hermes` 없음) | profile 선택기 비활성 + 안내; codex만 진행 가능 |
+| named profile 선택 | `HERMES_HOME=~/.hermes/profiles/<p>` export 후 `-g` 설치 |
+| 로컬 경로 add가 marketplace 메타 미인식 | skill 디렉토리를 직접 지정해 add (Open Question 참조) |
+
+## Out of Scope (v1)
+- 자체 exporter(frontmatter 파싱+검증+복사 직접 구현) — WRAP로 대체.
+- 커밋 SHA 핀/재현성 — npx skills의 가변 ref 동작 그대로 수용.
+- update 시 사용자 수정본 보호 — npx skills 덮어쓰기 그대로 수용.
+- 비-skill·Claude 전용 컴포넌트(commands/agents/hooks) 설치, core-config/midjourney/codex-image류.
+- codex profile(개념 없음).
+
+## Open Questions
+- **설치 소스 메커니즘**: `npx skills add ./plugins/<name>/skills/<skill>`(로컬 경로) 방식이 우리 marketplace 메타를 인식하는지 실측 필요. 미인식이면 skill 디렉토리 직접 지정으로 우회.
+- **검증 패리티(P1) 실제 포함 여부**: 우리 skill은 이미 Codex `--check` 통과 → pre-flight 검증의 한계효용이 낮을 수 있음.
+- **remove/update(P2) 노출**: 설치-only v1으로 끊을지, 처음부터 3-mode로 갈지.
+
+## Sources
+- vercel-labs/skills: `src/agents.ts`(hermes-agent 타겟/HERMES_HOME), `installer.ts`(충돌·symlink), `remove.ts`, `update.ts`, `skill-lock.ts`, `local-lock.ts`, `cli.ts`
+- NousResearch/hermes-agent: `hermes_cli/profiles.py`(per-profile skills), `main.py`(`-p` → HERMES_HOME)
+- 로컬: `scripts/sync-codex-manifests.mjs`, `.claude-plugin/marketplace.json`

--- a/scripts/install-skills.mjs
+++ b/scripts/install-skills.mjs
@@ -21,6 +21,9 @@ import { createInterface } from 'node:readline';
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const MARKETPLACE = join(ROOT, '.claude-plugin', 'marketplace.json');
 const PLUGINS_DIR = join(ROOT, 'plugins');
+// hermes home — honor an existing HERMES_HOME (npx skills reads it too) so a
+// relocated install isn't wrongly reported as "not installed".
+const HERMES_BASE = process.env.HERMES_HOME?.trim() || join(homedir(), '.hermes');
 
 // --- tiny fs helpers (same shape as scripts/sync-codex-manifests.mjs) ---
 function readJSON(path) { return JSON.parse(readFileSync(path, 'utf8')); }
@@ -172,13 +175,13 @@ function ask(question) {
   return new Promise((res) => rl.question(question, (a) => { rl.close(); res(a.trim()); }));
 }
 
-// hermes profiles live under ~/.hermes/profiles/<name>; "default" = ~/.hermes/skills.
+// hermes profiles live under <HERMES_BASE>/profiles/<name>; "default" = <HERMES_BASE>/skills.
 function hermesProfiles() {
-  const dir = join(homedir(), '.hermes', 'profiles');
+  const dir = join(HERMES_BASE, 'profiles');
   if (!isDir(dir)) return [];
   return readdirSync(dir).filter((n) => isDir(join(dir, n))).sort();
 }
-const hermesInstalled = () => isDir(join(homedir(), '.hermes'));
+const hermesInstalled = () => isDir(HERMES_BASE);
 
 // One `npx skills add` spawn per (agent, profile). Selection passed as repeated
 // `-s <name>` flags (comma is NOT a valid separator for this CLI).
@@ -189,7 +192,7 @@ function installFor(agent, skills, globalScope, profile) {
   args.push('-y');
   const env = { ...process.env };
   if (agent === 'hermes-agent' && profile && profile !== 'default') {
-    env.HERMES_HOME = join(homedir(), '.hermes', 'profiles', profile);
+    env.HERMES_HOME = join(HERMES_BASE, 'profiles', profile);
   }
   const label = agent === 'hermes-agent' && profile ? `${agent} [${profile}]` : agent;
   out(`\n→ installing ${skills.length} skill(s) to ${label}${globalScope ? ' (global)' : ' (project)'}\n`);

--- a/scripts/install-skills.mjs
+++ b/scripts/install-skills.mjs
@@ -203,6 +203,7 @@ async function interactive() {
     process.exit(1);
   }
   const groups = discover();
+  if (groups.length === 0) { console.log('no discoverable skills found — nothing to do.'); return; }
   const skills = await selectSkills(groups);
   if (skills === null) { console.log('cancelled.'); return; }
   if (skills.length === 0) { console.log('no skills selected — nothing to do.'); return; }

--- a/scripts/install-skills.mjs
+++ b/scripts/install-skills.mjs
@@ -1,0 +1,274 @@
+#!/usr/bin/env node
+// Skills installer TUI — pick this marketplace's skills and install them to
+// Hermes Agent / Codex by wrapping `npx skills` (vercel-labs/skills).
+//
+// Zero-dep: Node builtins only. Run directly:
+//   node scripts/install-skills.mjs            interactive install
+//   node scripts/install-skills.mjs --selftest pure-logic self-check (no TTY/network)
+//
+// We add exactly two things over `npx skills`: (1) a plugin-grouped selector,
+// (2) hermes profile targeting via a HERMES_HOME env bridge (npx skills has no
+// profile concept). Conflicts / symlink / copy / remove / update / lockfile are
+// all inherited from `npx skills` — not reimplemented here.
+
+import { readFileSync, statSync, readdirSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { homedir } from 'node:os';
+import { spawnSync } from 'node:child_process';
+import { createInterface } from 'node:readline';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const MARKETPLACE = join(ROOT, '.claude-plugin', 'marketplace.json');
+const PLUGINS_DIR = join(ROOT, 'plugins');
+
+// --- tiny fs helpers (same shape as scripts/sync-codex-manifests.mjs) ---
+function readJSON(path) { return JSON.parse(readFileSync(path, 'utf8')); }
+function isDir(path) { try { return statSync(path).isDirectory(); } catch { return false; } }
+function isFile(path) { try { return statSync(path).isFile(); } catch { return false; } }
+
+// Minimal frontmatter reader — pulls `name` + a one-line display `description`.
+// (sync-codex-manifests' extractor returns description only; we also need name.)
+// For block scalars (`|` / `>`) we take the first continuation line for display.
+function parseFrontmatter(md) {
+  const out = {};
+  md = md.replace(/\r\n?/g, '\n'); // tolerate CRLF/CR (e.g. cv-explorer/SKILL.md)
+  if (!md.startsWith('---')) return out;
+  const end = md.indexOf('\n---', 3);
+  if (end === -1) return out;
+  const lines = md.slice(3, end).split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    const m = lines[i].match(/^(name|description):\s*(.*)$/);
+    if (!m) continue;
+    let val = m[2];
+    if (/^[|>][+-]?\d*\s*$/.test(val)) { // block scalar → first non-empty indented line
+      val = '';
+      for (let j = i + 1; j < lines.length; j++) {
+        if (lines[j].trim() === '') continue;
+        if (/^\S/.test(lines[j])) break; // dedent ends the block
+        val = lines[j].trim();
+        break;
+      }
+    } else {
+      val = val.trim().replace(/^["']|["']$/g, '');
+    }
+    out[m[1]] = val;
+  }
+  return out;
+}
+
+// Read marketplace.json plugins[], scan plugins/<name>/skills/*/SKILL.md, and
+// group by plugin. Plugins with 0 skills (e.g. core-config) drop out naturally.
+function discover() {
+  const groups = [];
+  for (const entry of readJSON(MARKETPLACE).plugins) {
+    const skillsDir = join(PLUGINS_DIR, entry.name, 'skills');
+    if (!isDir(skillsDir)) continue;
+    const skills = [];
+    for (const dir of readdirSync(skillsDir).sort()) {
+      const md = join(skillsDir, dir, 'SKILL.md');
+      if (!isFile(md)) continue;
+      const fm = parseFrontmatter(readFileSync(md, 'utf8'));
+      if (!fm.name) continue; // a skill with no name can't be -s targeted
+      skills.push({ id: fm.name, name: fm.name, desc: fm.description || '', path: md });
+    }
+    if (skills.length) groups.push({ plugin: entry.name, skills });
+  }
+  return groups;
+}
+
+// --- ANSI / terminal ---
+const ESC = '\x1b[';
+const out = (s) => process.stdout.write(s);
+const truncate = (s, n) => (s.length > n ? s.slice(0, n - 1) + '…' : s);
+
+// Raw-mode grouped checkbox selector. Returns a flat list of selected skill
+// names (frontmatter `name`), or null on cancel.
+function selectSkills(groups) {
+  return new Promise((resolveSel) => {
+    // rows: interleaved plugin headers + indented skills
+    const rows = [];
+    groups.forEach((g, gi) => {
+      rows.push({ kind: 'plugin', gi });
+      g.skills.forEach((_, si) => rows.push({ kind: 'skill', gi, si }));
+    });
+    const sel = groups.map((g) => g.skills.map(() => false));
+    let cursor = 0;
+    let lastLines = 0;
+
+    const groupState = (gi) => {
+      const flags = sel[gi];
+      const on = flags.filter(Boolean).length;
+      return on === 0 ? ' ' : on === flags.length ? 'x' : '~';
+    };
+    const toggleGroup = (gi) => {
+      const all = sel[gi].every(Boolean);
+      sel[gi] = sel[gi].map(() => !all);
+    };
+
+    const render = () => {
+      const lines = [];
+      lines.push('Select skills — ↑/↓ move · space toggle · a toggle plugin · enter confirm · q cancel');
+      lines.push('');
+      rows.forEach((row, i) => {
+        const here = i === cursor ? '>' : ' ';
+        if (row.kind === 'plugin') {
+          const g = groups[row.gi];
+          lines.push(`${here} [${groupState(row.gi)}] ${g.plugin} (${g.skills.length})`);
+        } else {
+          const sk = groups[row.gi].skills[row.si];
+          const box = sel[row.gi][row.si] ? 'x' : ' ';
+          lines.push(`${here}     [${box}] ${sk.name}  ${ESC}2m${truncate(sk.desc, 60)}${ESC}0m`);
+        }
+      });
+      const total = sel.flat().filter(Boolean).length;
+      lines.push('');
+      lines.push(`${total} skill(s) selected`);
+      if (lastLines) out(`${ESC}${lastLines}A`);
+      out(`\r${ESC}J`);
+      out(lines.join('\n'));
+      lastLines = lines.length - 1;
+    };
+
+    const stdin = process.stdin;
+    const cleanup = () => {
+      stdin.setRawMode(false);
+      stdin.pause();
+      stdin.removeListener('data', onKey);
+      out(`\n${ESC}?25h`); // show cursor
+    };
+    const onKey = (key) => {
+      if (key === '\x03' || key === 'q') { cleanup(); resolveSel(null); return; } // Ctrl-C / q
+      if (key === '\x1b[A' || key === 'k') cursor = (cursor - 1 + rows.length) % rows.length;
+      else if (key === '\x1b[B' || key === 'j') cursor = (cursor + 1) % rows.length;
+      else if (key === ' ') {
+        const row = rows[cursor];
+        if (row.kind === 'plugin') toggleGroup(row.gi);
+        else sel[row.gi][row.si] = !sel[row.gi][row.si];
+      } else if (key === 'a') {
+        toggleGroup(rows[cursor].gi);
+      } else if (key === '\r' || key === '\n') {
+        cleanup();
+        const picked = [];
+        groups.forEach((g, gi) => g.skills.forEach((sk, si) => { if (sel[gi][si]) picked.push(sk.name); }));
+        resolveSel(picked);
+        return;
+      }
+      render();
+    };
+
+    out(`${ESC}?25l`); // hide cursor
+    stdin.setRawMode(true);
+    stdin.resume();
+    stdin.setEncoding('utf8');
+    stdin.on('data', onKey);
+    render();
+  });
+}
+
+// --- line-mode prompts (after the raw-mode selector exits) ---
+function ask(question) {
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  return new Promise((res) => rl.question(question, (a) => { rl.close(); res(a.trim()); }));
+}
+
+// hermes profiles live under ~/.hermes/profiles/<name>; "default" = ~/.hermes/skills.
+function hermesProfiles() {
+  const dir = join(homedir(), '.hermes', 'profiles');
+  if (!isDir(dir)) return [];
+  return readdirSync(dir).filter((n) => isDir(join(dir, n))).sort();
+}
+const hermesInstalled = () => isDir(join(homedir(), '.hermes'));
+
+// One `npx skills add` spawn per (agent, profile). Selection passed as repeated
+// `-s <name>` flags (comma is NOT a valid separator for this CLI).
+function installFor(agent, skills, globalScope, profile) {
+  const args = ['--yes', 'skills', 'add', ROOT, '-a', agent];
+  for (const s of skills) args.push('-s', s);
+  if (globalScope) args.push('-g');
+  args.push('-y');
+  const env = { ...process.env };
+  if (agent === 'hermes-agent' && profile && profile !== 'default') {
+    env.HERMES_HOME = join(homedir(), '.hermes', 'profiles', profile);
+  }
+  const label = agent === 'hermes-agent' && profile ? `${agent} [${profile}]` : agent;
+  out(`\n→ installing ${skills.length} skill(s) to ${label}${globalScope ? ' (global)' : ' (project)'}\n`);
+  const r = spawnSync('npx', args, { stdio: 'inherit', env });
+  return { agent: label, ok: r.status === 0, code: r.status };
+}
+
+async function interactive() {
+  if (!process.stdin.isTTY) {
+    console.error('install-skills: interactive mode needs a TTY. Run in a terminal.');
+    process.exit(1);
+  }
+  const groups = discover();
+  const skills = await selectSkills(groups);
+  if (skills === null) { console.log('cancelled.'); return; }
+  if (skills.length === 0) { console.log('no skills selected — nothing to do.'); return; }
+
+  // targets
+  const hermesOk = hermesInstalled();
+  let targets = [];
+  while (targets.length === 0) {
+    const def = hermesOk ? '1,2' : '1';
+    const a = (await ask(`\nTargets — [1] codex  [2] hermes-agent${hermesOk ? '' : ' (not installed — unavailable)'}\nchoose (e.g. 1,2) [${def}]: `)) || def;
+    const set = new Set(a.split(',').map((x) => x.trim()));
+    if (set.has('1')) targets.push('codex');
+    if (set.has('2') && hermesOk) targets.push('hermes-agent');
+    if (set.has('2') && !hermesOk) console.log('  hermes-agent skipped: ~/.hermes not found.');
+  }
+
+  // scope
+  const sc = (await ask('\nScope — [1] global (~/)  [2] project (./)  [1]: ')) || '1';
+  const globalScope = sc.trim() !== '2';
+
+  // hermes profile (only if hermes targeted)
+  let profile = 'default';
+  if (targets.includes('hermes-agent')) {
+    const profiles = hermesProfiles();
+    if (profiles.length) {
+      const list = ['default', ...profiles];
+      const menu = list.map((p, i) => `[${i + 1}] ${p}`).join('  ');
+      const p = (await ask(`\nHermes profile — ${menu}  [1]: `)) || '1';
+      const idx = Math.max(1, Math.min(list.length, parseInt(p, 10) || 1)) - 1;
+      profile = list[idx];
+    }
+  }
+
+  // spawn
+  const results = [];
+  for (const agent of targets) {
+    results.push(installFor(agent, skills, globalScope, agent === 'hermes-agent' ? profile : null));
+  }
+
+  // summary
+  out('\n=== summary ===\n');
+  for (const r of results) out(`  ${r.ok ? 'OK  ' : 'FAIL'} ${r.agent}${r.ok ? '' : ` (exit ${r.code})`}\n`);
+  out(`  ${skills.length} skill(s): ${skills.join(', ')}\n`);
+  out(`  lockfile: global → ~/.agents/skills-lock.json · project → ./skills-lock.json (managed by npx skills)\n`);
+  if (results.some((r) => !r.ok)) process.exitCode = 1;
+}
+
+// --- pure-logic self-check (no TTY, no network) ---
+function selftest() {
+  const groups = discover();
+  const totalSkills = groups.reduce((n, g) => n + g.skills.length, 0);
+  const plugins = groups.map((g) => g.plugin);
+  const assert = (cond, msg) => { if (!cond) { console.error('FAIL:', msg); process.exit(1); } };
+
+  assert(groups.length === 24, `expected 24 skill-bearing plugins, got ${groups.length}`);
+  assert(totalSkills === 47, `expected 47 skills total, got ${totalSkills}`);
+  assert(!plugins.includes('core-config'), 'core-config (0 skills) should be excluded');
+  assert(new Set(groups.flatMap((g) => g.skills.map((s) => s.id))).size === 47, 'skill names must be globally unique for -s targeting');
+
+  const gh = groups.find((g) => g.plugin === 'github-dev');
+  assert(gh && gh.skills.length === 8, 'github-dev should have 8 skills');
+  const cr = gh.skills.find((s) => s.name === 'cr-fix');
+  assert(cr && cr.desc.length > 0, 'cr-fix must parse both name and description');
+
+  console.log(`selftest OK — ${groups.length} plugins, ${totalSkills} skills, name+desc parsed.`);
+}
+
+if (process.argv.includes('--selftest')) selftest();
+else interactive();


### PR DESCRIPTION
Closes #78.

## What

`scripts/install-skills.mjs` — a zero-dep (Node builtins only) interactive TUI to pick this marketplace's skills (47 SKILL.md / 24 skill-bearing plugins) and install them to **Hermes Agent** and **Codex** by wrapping `npx skills` (vercel-labs/skills). No custom exporter.

Our two added values over the raw CLI:
1. **Plugin-grouped selector** — raw-mode checkbox tree (plugin header toggles all children; tri-state `[x]/[~]/[ ]`).
2. **Hermes profile targeting** — `HERMES_HOME` env bridge, since `npx skills` has no profile concept.

Everything else (conflict / symlink / copy / remove / update / lockfile) is inherited from `npx skills`.

## How it spawns (locked by Task 0 reconnaissance)

- Source = repo root `.` → `npx skills` reads `marketplace.json`, discovers all 47 skills by plugin.
- Selection = **repeated `-s <name>`** flags (comma is not a valid separator — `-s a,b` → "No matching skills found").
- **One spawn per (agent, profile)**: `npx skills add . -a <agent> -s <names...> [-g] -y`, with `HERMES_HOME` injected only for non-default hermes profiles.
- All 47 skill `name`s are globally unique, so `-s <name>` is unambiguous against source `.`.

## Verification

- `node --check scripts/install-skills.mjs` — OK
- `node scripts/install-skills.mjs --selftest` — `selftest OK — 24 plugins, 47 skills, name+desc parsed.` (caught + fixed a CRLF frontmatter edge case in `cv-explorer/SKILL.md`)
- `node scripts/sync-codex-manifests.mjs --check` — `up to date (23 manifests)` (unchanged; script is outside `plugins/`)
- Non-TTY guard — exits cleanly with a message
- **pty-driven e2e** (sandbox `HOME`, real `~/.agents` untouched): select `commit-and-push` → codex → global → `npx skills add` installed it to `<sandbox>/.agents/skills/commit-and-push/SKILL.md`, summary `OK codex`

## Scope (v1 = P0 install only)

Out of scope, deferred: remove/update/preview/frontmatter-validation (P1/P2), commit-SHA pinning, non-skill components, codex profiles, npx packaging. `~/.hermes` absent → profile selector degrades to codex-only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 로컬 `plugins/` 및 `.claude-plugin/marketplace.json` 기반으로 스킬을 스캔해 플러그인 그룹 단위로 선택하고, Codex 및/또는 Hermes Agent에 대해 TUI 설치를 실행합니다(필요 시 Hermes 프로필 선택 및 해당 프로필 경로로 설치).
  * 설치 후 에이전트별 결과를 요약하고, 실패가 있으면 작업을 실패로 종료합니다.
* **Documentation**
  * “Skills Installer TUI” 스펙 문서가 추가되어 동작 규칙과 제약을 확인할 수 있습니다.
* **Tests**
  * `--selftest` 모드로 TTY/네트워크 없이 스캔 및 메타 파싱 검증을 수행합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->