### PR TITLE
feat: add brightdata-guide plugin (21 to 22)

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -41,6 +41,18 @@
       "category": "research"
     },
     {
+      "name": "brightdata-guide",
+      "source": {
+        "source": "local",
+        "path": "./plugins/brightdata-guide"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "research"
+    },
+    {
       "name": "deepwiki",
       "source": {
         "source": "local",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,8 +4,8 @@
     "name": "YoungjaeDev"
   },
   "metadata": {
-    "description": "Personal Claude Code plugin collection with 21 specialized plugins. Codex 0.135 + Hermes Agent native — generated `.agents/plugins/marketplace.json` + per-plugin `.codex-plugin/plugin.json` (`scripts/sync-codex-manifests.mjs`) and Hermes `plugin.yaml` + `__init__.py` adapters (`scripts/sync-hermes-manifests.mjs`).",
-    "version": "1.75.0"
+    "description": "Personal Claude Code plugin collection with 22 specialized plugins. Codex 0.135 + Hermes Agent native — generated `.agents/plugins/marketplace.json` + per-plugin `.codex-plugin/plugin.json` (`scripts/sync-codex-manifests.mjs`) and Hermes `plugin.yaml` + `__init__.py` adapters (`scripts/sync-hermes-manifests.mjs`).",
+    "version": "1.76.0"
   },
   "plugins": [
     {
@@ -34,6 +34,13 @@
       "source": "./plugins/code-scout",
       "description": "Multi-axis code & ML research harness. 5-axis scout team (github/hf/web/docs/paper) + synthesis-scout + research-orchestrator skill + exa-web-search skill. exa MCP first, WebSearch fallback, firecrawl tier-3, insane-search tier-4 (WAF/blocked URLs). paper-scout wraps paper-search-tools 8-source family. /deep-research is the sibling for non-code/ML topics (code-scout does not delegate).",
       "version": "2.1.1",
+      "category": "research"
+    },
+    {
+      "name": "brightdata-guide",
+      "source": "./plugins/brightdata-guide",
+      "description": "Bright Data web data access via MCP tools + CLI — scraping (Web Unlocker), SERP, 40+ structured web_data_* extractors, browser automation. Guide skill; operator sets BRIGHTDATA_API_KEY, delegate subagents fall back to the bdata CLI.",
+      "version": "1.0.0",
       "category": "research"
     },
     {

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -21,7 +21,8 @@
       "./plugins/anti-slop-design",
       "./plugins/tally-form",
       "./plugins/ppt-yeong-style",
-      "./plugins/codex-image"
+      "./plugins/codex-image",
+      "./plugins/brightdata-guide"
     ]
   }
 }

--- a/.claude/spec/2026-07-02-brightdata-guide-port.md
+++ b/.claude/spec/2026-07-02-brightdata-guide-port.md
@@ -11,7 +11,7 @@ Cross-ref: `.claude/spec/2026-07-01-plugin-feedback-round.md` (P1 brightdata sec
 
 ## Source (verified 2026-07-02)
 `dandacompany/dante-skills/brightdata-guide` (MIT). Pure guide skill, **no scripts**:
-```
+```text
 brightdata-guide/
   SKILL.md                    # 326 lines; frontmatter name/description/license
   references/cli-commands.md   # 118 lines
@@ -35,7 +35,7 @@ edits, no curl-to-bash, no `npm -g`.
 - [ ] `.claude-plugin/marketplace.json` — add entry `{ name, source: "./plugins/brightdata-guide", description, version: "1.0.0", category: "research" }`; bump `metadata.version` **1.75.0 → 1.76.0** (re-check vs `origin/main` right before merge — ppt PRs have been landing concurrently; concurrent-branch trap).
 - [ ] `.claude/settings.json` `plugins.local` — add `"./plugins/brightdata-guide"` (21 → 22 entries).
 - [ ] `scripts/sync-hermes-manifests.mjs` — add `'brightdata-guide'` to `HERMES_ELIGIBLE` (6 → 7). Only code edit required.
-- [ ] Re-run both generators: `node scripts/sync-codex-manifests.mjs` (auto-adds `.codex-plugin/` + catalog entry) + `node scripts/sync-hermes-manifests.mjs` (adds `plugin.yaml` + `__init__.py`).
+- [ ] Re-run both generators: `node scripts/sync-codex-manifests.mjs` (auto-adds `.codex-plugin/plugin.json` + the `.agents/plugins/marketplace.json` catalog entry) + `node scripts/sync-hermes-manifests.mjs` (adds `plugin.yaml` + `__init__.py`). All three of `.claude-plugin/marketplace.json`, `.agents/plugins/marketplace.json`, `.claude/settings.json` stay in sync.
 
 ### Should Have (P1) — count/doc sync (per plugin-versioning.md)
 - [ ] `CLAUDE.md`: `## Plugins (21)` → `(22)`; add a row under "Research & Search" table; add `brightdata-guide/` to the structure tree; Codex-integration `19 eligible` → `20`; Hermes-integration `6 plugins this round` → `7` (append `brightdata-guide`).
@@ -49,7 +49,7 @@ not the description — the body already carries it. Drop the long `USE FOR:` en
 372 chars) + condense the `IMPORTANT:` delegate/CLI paragraph (p2, 498 chars).
 
 Proposed trimmed description (≈730 chars, under cap — refine at implementation):
-```
+```text
 Bright Data web data access for any AI agent (Hermes, Codex, generic clients) via TWO
 paths: (1) the Bright Data MCP tools, and (2) the Bright Data CLI (bdata / brightdata)
 from the terminal. Prefer Bright Data over the agent's built-in web fetch / web search

--- a/.claude/spec/2026-07-02-brightdata-guide-port.md
+++ b/.claude/spec/2026-07-02-brightdata-guide-port.md
@@ -1,0 +1,107 @@
+# Feature Specification: brightdata-guide plugin port (PR2)
+
+## Overview
+Port the `brightdata-guide` skill (a Hermes-native web-data guide by Dante Labs)
+into this marketplace as a new plugin usable across Claude Code + Codex + Hermes.
+Part of the 2026-07-01 plugin-feedback round (umbrella issue #85, PR2). Base is the
+post-PR#86 state: **21 plugins**, `metadata.version` 1.75.0, Codex-eligible 19,
+Hermes-eligible 6.
+
+Cross-ref: `.claude/spec/2026-07-01-plugin-feedback-round.md` (P1 brightdata section).
+
+## Source (verified 2026-07-02)
+`dandacompany/dante-skills/brightdata-guide` (MIT). Pure guide skill, **no scripts**:
+```
+brightdata-guide/
+  SKILL.md                    # 326 lines; frontmatter name/description/license
+  references/cli-commands.md   # 118 lines
+  references/mcp-setup.md      # 141 lines
+  references/mcp-tools.md      # 161 lines
+```
+What it does: guides an agent to Bright Data for web-data work via TWO interchangeable
+paths hitting the same platform + 5,000 free req/mo quota — **MCP tools** (`search_engine`
+SERP, `scrape_as_markdown`/`scrape_batch` Web Unlocker, `scrape_as_html`, `extract`,
+40+ `web_data_*` structured extractors, `scraping_browser_*`) and the **CLI** (`bdata`/
+`brightdata`) as the fallback for `delegate_task` subagents that inherit the terminal
+but not the parent's MCP toolset. Security posture: agent-agnostic, no host-settings
+edits, no curl-to-bash, no `npm -g`.
+
+## Requirements
+
+### Must Have (P0)
+- [ ] `plugins/brightdata-guide/.claude-plugin/plugin.json` — `{ name: "brightdata-guide", version: "1.0.0", description: "<short>", license: "MIT" }` (version must equal the marketplace entry).
+- [ ] `plugins/brightdata-guide/skills/brightdata-guide/SKILL.md` — copy source body; **trim `description` from 1153 → ≤1024 chars** (BLOCKING — see below); add the runtime tool-compat note.
+- [ ] Copy `references/{cli-commands,mcp-setup,mcp-tools}.md` verbatim.
+- [ ] `.claude-plugin/marketplace.json` — add entry `{ name, source: "./plugins/brightdata-guide", description, version: "1.0.0", category: "research" }`; bump `metadata.version` **1.75.0 → 1.76.0** (re-check vs `origin/main` right before merge — ppt PRs have been landing concurrently; concurrent-branch trap).
+- [ ] `.claude/settings.json` `plugins.local` — add `"./plugins/brightdata-guide"` (21 → 22 entries).
+- [ ] `scripts/sync-hermes-manifests.mjs` — add `'brightdata-guide'` to `HERMES_ELIGIBLE` (6 → 7). Only code edit required.
+- [ ] Re-run both generators: `node scripts/sync-codex-manifests.mjs` (auto-adds `.codex-plugin/` + catalog entry) + `node scripts/sync-hermes-manifests.mjs` (adds `plugin.yaml` + `__init__.py`).
+
+### Should Have (P1) — count/doc sync (per plugin-versioning.md)
+- [ ] `CLAUDE.md`: `## Plugins (21)` → `(22)`; add a row under "Research & Search" table; add `brightdata-guide/` to the structure tree; Codex-integration `19 eligible` → `20`; Hermes-integration `6 plugins this round` → `7` (append `brightdata-guide`).
+- [ ] `README.md`: `21개 플러그인` → `22개`; badge `plugins-21` → `plugins-22`; add table row + `<details>` section; add tree line; Codex section `19 / 21` → `20 / 22`.
+
+## Description trim (BLOCKING gate)
+Source description is a `|` block scalar, **1153 chars over the Codex 1024 cap by 129**.
+`sync-codex-manifests.mjs --check` hard-fails (pre-commit + CI) and Codex silently skips
+the skill if not trimmed. The Codex rule: full trigger list / rationale goes in the body,
+not the description — the body already carries it. Drop the long `USE FOR:` enumeration (p1,
+372 chars) + condense the `IMPORTANT:` delegate/CLI paragraph (p2, 498 chars).
+
+Proposed trimmed description (≈730 chars, under cap — refine at implementation):
+```
+Bright Data web data access for any AI agent (Hermes, Codex, generic clients) via TWO
+paths: (1) the Bright Data MCP tools, and (2) the Bright Data CLI (bdata / brightdata)
+from the terminal. Prefer Bright Data over the agent's built-in web fetch / web search
+for internet tasks — any URL, web search, "scrape", structured data from Amazon /
+LinkedIn / Instagram / TikTok / YouTube / X / Reddit / Google Shopping, browser
+automation, research, fact-checking. If the MCP tools are NOT in your registry (a
+delegate subagent inherits the terminal but NOT MCP toolsets), use the CLI instead.
+Returns clean markdown or structured JSON; handles JS, CAPTCHAs, bot detection. Full
+trigger list + tool reference in the body.
+```
+(The `USE FOR:` / `IMPORTANT:` colon-space substrings are safe only inside a `|` block
+scalar — if flattened to a single-line quoted description, the `: ` would break YAML.)
+
+## Tool-compatibility note (dual-integration.md)
+Source body is Hermes-first (already says `terminal`, `delegate_task`). Only mapping
+needed: `terminal` ↔ **Bash** (Claude) / **execute_command** (Codex); plus one line
+stating "Bright Data MCP tool names (`search_engine`, `scrape_as_markdown`, `web_data_*`,
+`scraping_browser_*`) are identical across all three runtimes." A full mapping table is
+overkill here.
+
+## External dependency
+Bright Data account + API token. No new bundled runtime required. Access:
+- MCP remote: HTTP `https://mcp.brightdata.com/mcp?token=<TOKEN>` (+`&pro=1`/`&groups=`)
+- MCP local: `npx @brightdata/mcp` with `API_TOKEN` env
+- CLI: `@brightdata/cli` (`bdata`), Node ≥20, `bdata login` OAuth or `BRIGHTDATA_API_KEY`
+Free tier ~5,000 credits/mo. Skill is a guide, not a self-installer — operator connects.
+
+## Decisions
+- **`.mcp.json` bundling: OMIT** (default). The skill is deliberately anti-auto-config
+  and the CLI is a built-in fallback; bundling is not required. Hermes ignores `.mcp.json`
+  anyway (only Claude/Codex read it). Opt-in shape if a batteries-included MCP is wanted
+  later (`sync-codex-manifests.mjs` auto-wires a present `.mcp.json`):
+  ```json
+  { "mcpServers": { "brightdata": { "command": "npx", "args": ["-y", "@brightdata/mcp"], "env": { "API_TOKEN": "${BRIGHTDATA_API_KEY}" } } } }
+  ```
+- **Category: `research`** (groups with code-scout / deepwiki / paper-search-tools).
+- **HERMES_ELIGIBLE: YES** (source is already a Hermes skill).
+
+## Verification
+- `node scripts/sync-codex-manifests.mjs --check` passes (esp. the 1024-char description guard).
+- `node scripts/sync-hermes-manifests.mjs --check` passes (new adapter present, no orphans).
+- `.githooks/pre-commit` passes.
+- `ls plugins/ | wc -l` = 22 = settings.local entries = marketplace entries.
+- Codex-eligible = 22 − 2 (core-config, codex-image) = 20 → CLAUDE.md/README match.
+- Hermes-eligible = 7 → `plugin.yaml` + `__init__.py` generated for brightdata-guide.
+- `git grep -n brightdata-guide` shows it wired in all count/manifest/settings homes.
+
+## Out of Scope
+- Bundling a live `.mcp.json` (opt-in only; see Decisions).
+- Any Bright Data credential provisioning / CLI install (operator's job — the skill guides, does not install).
+- Reworking the source body beyond the description trim + tool-compat note (copy verbatim).
+
+## Open Questions
+- Confirm `.mcp.json` omit vs include (default: omit).
+- `metadata.version` target 1.76.0 assumes main stays at 1.75.0 — re-verify vs `origin/main` at merge time.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,7 +70,7 @@
 ## Hermes 통합 (shared-source)
 
 - Hermes Agent 도 **동일한** `plugins/<name>/` 트리를 직접 읽습니다. 어댑터(`plugin.yaml` + `__init__.py`)는 `scripts/sync-hermes-manifests.mjs` 가 `.claude-plugin/marketplace.json` 으로부터 생성합니다 — `plugins/<name>/plugin.yaml` / `__init__.py` 를 손으로 편집하지 마세요.
-- 대상은 생성기의 `HERMES_ELIGIBLE` allowlist (Codex `EXCLUDED` denylist 의 대칭). 현재 6개: `github-dev`, `interview`, `anti-slop-design`, `tcrei-prompt`, `ppt-yeong-style`, `ml-toolkit`. 커버리지 확장은 allowlist 에 이름 추가.
+- 대상은 생성기의 `HERMES_ELIGIBLE` allowlist (Codex `EXCLUDED` denylist 의 대칭). 현재 7개: `github-dev`, `interview`, `anti-slop-design`, `tcrei-prompt`, `ppt-yeong-style`, `ml-toolkit`, `brightdata-guide`. 커버리지 확장은 allowlist 에 이름 추가.
 - Hermes-eligible 플러그인의 `version` / `description` 을 바꾸면 `node scripts/sync-hermes-manifests.mjs` 를 실행해 어댑터를 재생성하세요. `plugin.yaml` 의 `version` 은 marketplace 파생이므로 `--check` 가 drift + orphan 어댑터를 잡습니다 (수동 동기화 불필요 — 생성으로 해소).
 - `__init__.py` 는 `skills/*/SKILL.md` 를 `<plugin>:<skill>` 으로 등록하는 제네릭 엔트리포인트입니다 (플러그인별 로직 없음, `import yaml`=PyYAML 가정).
 - 공유 skill 본문은 3런타임 포터블이어야 합니다. Claude/Codex 는 도구명이 동일하므로, 본문에 Claude/Codex 도구 용어를 Hermes 도구로 매핑하는 호환 표(`Bash`→`terminal`, `Read`→`read_file`, `Edit`→`patch`, `AskUserQuestion`→`clarify`, `Task`→`delegate_task`, `Skill`→`skill_view`, 이미지 생성→`image_generate`, `NotebookEdit`→Hermes Jupyter Live Kernel / `write_file`·`patch` 등)를 둡니다. 새 skill 추가/도구 사용 변경 시 이 표를 점검하세요.
@@ -90,7 +90,7 @@ node scripts/sync-hermes-manifests.mjs --check
 
 ```bash
 codex plugin marketplace add ~/.claude/plugins/marketplaces/my-claude-plugins
-codex plugin list --marketplace my-claude-plugins   # 19 entries
+codex plugin list --marketplace my-claude-plugins   # 20 entries
 codex plugin marketplace remove my-claude-plugins   # 검증 후 정리
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 Plugin-based configuration for Claude Code with multi-agent orchestration. The same plugin tree is loaded by Codex 0.135 via `scripts/sync-codex-manifests.mjs` and by Hermes Agent via `scripts/sync-hermes-manifests.mjs` — one source, three runtimes.
 
-## Plugins (21)
+## Plugins (22)
 
 ### Core
 | Plugin | Description |
@@ -25,6 +25,7 @@ Plugin-based configuration for Claude Code with multi-agent orchestration. The s
 | `code-scout` | Multi-axis research harness — 5-axis scout team (github/hf/web/docs/paper) + synthesis-scout + research-orchestrator skill. exa MCP + WebSearch + firecrawl tier-3 + insane-search tier-4 for WAF/blocked URLs. paper-scout wraps paper-search-tools 8-source family. /deep-research is the sibling for non-code/ML topics. |
 | `deepwiki` | AI-powered GitHub repo documentation |
 | `paper-search-tools` | Academic paper search (arXiv, PubMed, Semantic Scholar, etc.) |
+| `brightdata-guide` | Bright Data web data access via MCP tools + CLI — scraping (Web Unlocker), SERP, structured web_data_* extractors, browser automation. Operator sets BRIGHTDATA_API_KEY; delegate subagents fall back to the bdata CLI |
 
 ### AI Models
 | Plugin | Description |
@@ -90,6 +91,7 @@ Plugin-based configuration for Claude Code with multi-agent orchestration. The s
 │   ├── code-scout/         # Resource discovery
 │   ├── deepwiki/           # Repo docs
 │   ├── paper-search-tools/ # Academic papers
+│   ├── brightdata-guide/   # Bright Data web-data guide (MCP + CLI)
 │   ├── notebook/           # Jupyter
 │   ├── ml-toolkit/         # ML tools
 │   ├── translator/         # Translation
@@ -122,7 +124,7 @@ node scripts/sync-codex-manifests.mjs           # write manifests
 node scripts/sync-codex-manifests.mjs --check   # CI drift guard
 ```
 
-Produces `.agents/plugins/marketplace.json` + per-plugin `.codex-plugin/plugin.json` for 19 eligible plugins. Codex 0.135 manifest top-level only supports `skills` / `hooks` / `mcpServers` / `apps` — `commands` and `agents` are not emitted. Excluded: `core-config` (Claude-only hooks; no Codex hook surface for the same patterns), `codex-image` (Claude->Codex bridge; syncing it into Codex would be circular). Skill bodies are read in place — no mirror, no transform. `--check` also detects orphan manifests left behind when a plugin is removed.
+Produces `.agents/plugins/marketplace.json` + per-plugin `.codex-plugin/plugin.json` for 20 eligible plugins. Codex 0.135 manifest top-level only supports `skills` / `hooks` / `mcpServers` / `apps` — `commands` and `agents` are not emitted. Excluded: `core-config` (Claude-only hooks; no Codex hook surface for the same patterns), `codex-image` (Claude->Codex bridge; syncing it into Codex would be circular). Skill bodies are read in place — no mirror, no transform. `--check` also detects orphan manifests left behind when a plugin is removed.
 
 ## Hermes integration
 
@@ -133,7 +135,7 @@ node scripts/sync-hermes-manifests.mjs           # write adapters
 node scripts/sync-hermes-manifests.mjs --check   # CI drift guard (also in validate-codex.yml + .githooks/pre-commit)
 ```
 
-Adapter fields derive from `marketplace.json` (`plugin.yaml` name/version/description; `__init__.py` a generic skill-registration entrypoint, no per-plugin logic). Coverage is an allowlist — `HERMES_ELIGIBLE` (6 plugins this round: `github-dev`, `interview`, `anti-slop-design`, `tcrei-prompt`, `ppt-yeong-style`, `ml-toolkit`); add a name to extend. `--check` flags adapter drift + orphan adapters. Shared skill bodies carry a Hermes tool-compatibility table (Claude/Codex tool terms → Hermes tools). Skill-level install (no adapter needed) is also available via `node scripts/install-skills.mjs` (wraps `npx skills`).
+Adapter fields derive from `marketplace.json` (`plugin.yaml` name/version/description; `__init__.py` a generic skill-registration entrypoint, no per-plugin logic). Coverage is an allowlist — `HERMES_ELIGIBLE` (7 plugins this round: `github-dev`, `interview`, `anti-slop-design`, `tcrei-prompt`, `ppt-yeong-style`, `ml-toolkit`, `brightdata-guide`); add a name to extend. `--check` flags adapter drift + orphan adapters. Shared skill bodies carry a Hermes tool-compatibility table (Claude/Codex tool terms → Hermes tools). Skill-level install (no adapter needed) is also available via `node scripts/install-skills.mjs` (wraps `npx skills`).
 
 ## Modular Rules
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
 
 # my-claude-plugins
 
-Claude Code를 위한 21개 플러그인 모음 - GitHub 워크플로우부터 AI 이미지 생성까지. Codex 0.135 와 Hermes Agent 도 동일한 소스 트리를 네이티브로 로드합니다 (shared source).
+Claude Code를 위한 22개 플러그인 모음 - GitHub 워크플로우부터 AI 이미지 생성까지. Codex 0.135 와 Hermes Agent 도 동일한 소스 트리를 네이티브로 로드합니다 (shared source).
 
-[![Plugins](https://img.shields.io/badge/plugins-21-blue.svg)](https://github.com/YoungjaeDev/my-claude-plugins)
+[![Plugins](https://img.shields.io/badge/plugins-22-blue.svg)](https://github.com/YoungjaeDev/my-claude-plugins)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-compatible-purple.svg)](https://docs.anthropic.com/claude-code)
 
@@ -89,6 +89,7 @@ rm -rf ~/.claude/plugins/cache/my-claude-plugins/
 | **Research** | `code-scout` | 다축 리서치 하네스 — 5-axis scout 팀 (github/hf/web/docs/paper) + synthesis-scout + research-orchestrator skill. exa MCP + WebSearch + firecrawl(tier-3) + insane-search(tier-4, WAF/blocked). paper-scout 가 paper-search-tools 8-source 래핑. 비-code/ML 토픽은 sibling `/deep-research` 직접 호출 (orchestrator 가 위임하지 않음) |
 | | `deepwiki` | GitHub 레포 AI 문서화 |
 | | `paper-search-tools` | arXiv, PubMed 등 8개 플랫폼 논문 검색 |
+| | `brightdata-guide` | Bright Data 웹 데이터 (MCP 툴 + CLI) — 스크래핑(Web Unlocker), SERP, 구조화 web_data_* 추출, 브라우저 자동화. operator 가 BRIGHTDATA_API_KEY 설정 |
 | **AI Models** | `codex-image` | Claude->Codex 이미지 생성 브리지 (ChatGPT OAuth, OpenAI API key 불필요) |
 | **Dev Tools** | `notebook` | Jupyter 노트북 안전 편집 |
 | | `ml-toolkit` | ML/멀티모달 개발 원칙, GPU 병렬 처리, Gradio CV 앱 |
@@ -270,6 +271,20 @@ WORKSPACE=$(mktemp -d "$PARENT/run.XXXXXX")
 **Platforms:** arXiv, PubMed, bioRxiv, medRxiv, Google Scholar, IACR, Semantic Scholar, CrossRef
 
 **MCP Tools (23):** `search_arxiv`, `download_arxiv`, `read_arxiv_paper` 등
+
+</details>
+
+<details>
+<summary><strong>brightdata-guide</strong> - Bright Data 웹 데이터 접근 (MCP + CLI)</summary>
+
+Bright Data 플랫폼으로 웹 데이터 작업을 수행하는 가이드 스킬. 두 경로가 같은 플랫폼 + 무료 5,000 req/월 을 공유합니다.
+
+- **MCP 툴**: `search_engine` (SERP), `scrape_as_markdown`/`scrape_batch` (Web Unlocker — JS/CAPTCHA/봇 탐지 우회), `extract` (AI 구조화 JSON), 40+ `web_data_*` 구조화 추출기 (Amazon/LinkedIn/Instagram/TikTok/YouTube/X/Reddit 등), `scraping_browser_*` 브라우저 자동화
+- **CLI (`bdata`/`brightdata`)**: MCP 툴을 못 받는 `delegate_task` 서브에이전트용 fallback (터미널은 상속하지만 부모의 MCP 툴셋은 상속 안 함)
+
+**Runtime:** Claude / Codex / Hermes 공용 (MCP 툴명 동일; `terminal` ↔ Bash / execute_command)
+
+**Requirements:** Bright Data 계정 + `BRIGHTDATA_API_KEY` (또는 `bdata login`). 스킬은 guide 라 설치/키 하드코딩 안 함 — operator 가 out-of-band 로 연결.
 
 </details>
 
@@ -619,7 +634,7 @@ codex plugin marketplace add ~/.claude/plugins/marketplaces/my-claude-plugins
 codex plugin add llm-wiki@my-claude-plugins
 ```
 
-Codex 에서 제외되는 플러그인: `core-config` (Claude-only hooks — Codex 에 대응 surface 없음), `codex-image` (Claude->Codex 브리지 — Codex 로 sync 하면 순환). 즉 19 / 21 플러그인이 양쪽에서 skill 단위로 동작. `deepwiki` 와 `project-init` 은 1.41.0 부터 dual-surface (command + skill) 로 양쪽 런타임에서 사용 가능.
+Codex 에서 제외되는 플러그인: `core-config` (Claude-only hooks — Codex 에 대응 surface 없음), `codex-image` (Claude->Codex 브리지 — Codex 로 sync 하면 순환). 즉 20 / 22 플러그인이 양쪽에서 skill 단위로 동작. `deepwiki` 와 `project-init` 은 1.41.0 부터 dual-surface (command + skill) 로 양쪽 런타임에서 사용 가능.
 
 Codex 0.135 manifest top-level은 `skills` / `hooks` / `mcpServers` / `apps` 만 지원하므로, command-bearing 플러그인(`paper-search-tools`, `docs-forge` 등)도 Codex 측에는 skill만 노출됩니다 — Claude 측 commands 는 그대로 동작합니다. `github-dev` 는 모든 워크플로가 skill 로 전환돼 command surface 가 없으므로 Claude·Codex 양쪽에서 동일하게 동작합니다.
 
@@ -648,7 +663,7 @@ hermes plugins install YoungjaeDev/my-claude-plugins/plugins/github-dev --enable
 hermes gateway restart  # 메시징 게이트웨이 사용 시
 ```
 
-어댑터 필드는 marketplace 엔트리에서 파생되고(`plugin.yaml` name/version/description, `__init__.py` 는 SKILL.md 를 `<plugin>:<skill>` 로 등록하는 제네릭 엔트리포인트 — 플러그인별 로직 없음), 대상은 `HERMES_ELIGIBLE` allowlist (이번 라운드 6개: `github-dev`, `interview`, `anti-slop-design`, `tcrei-prompt`, `ppt-yeong-style`, `ml-toolkit`) 입니다. allowlist 에 이름을 추가하면 커버리지가 확장됩니다. `--check` 가 어댑터 drift + orphan 어댑터를 잡습니다. 공유 skill 본문은 Claude/Codex 도구 용어를 Hermes 도구로 매핑하는 호환 표를 포함합니다.
+어댑터 필드는 marketplace 엔트리에서 파생되고(`plugin.yaml` name/version/description, `__init__.py` 는 SKILL.md 를 `<plugin>:<skill>` 로 등록하는 제네릭 엔트리포인트 — 플러그인별 로직 없음), 대상은 `HERMES_ELIGIBLE` allowlist (이번 라운드 7개: `github-dev`, `interview`, `anti-slop-design`, `tcrei-prompt`, `ppt-yeong-style`, `ml-toolkit`, `brightdata-guide`) 입니다. allowlist 에 이름을 추가하면 커버리지가 확장됩니다. `--check` 가 어댑터 drift + orphan 어댑터를 잡습니다. 공유 skill 본문은 Claude/Codex 도구 용어를 Hermes 도구로 매핑하는 호환 표를 포함합니다.
 
 플러그인 스킬은 opt-in 이라 enable 후 `skill_view("<plugin>:<skill>")` 로 명시 로드합니다 (`--enable` 후 새 Hermes 세션 시작).
 
@@ -690,6 +705,7 @@ node scripts/install-skills.mjs
 │   ├── code-scout/            # 리소스 탐색
 │   ├── deepwiki/              # 레포 문서화
 │   ├── paper-search-tools/    # 논문 검색
+│   ├── brightdata-guide/      # Bright Data 웹데이터 guide (MCP + CLI)
 │   ├── notebook/              # Jupyter 편집
 │   ├── ml-toolkit/            # ML 개발
 │   ├── translator/            # 번역

--- a/plugins/brightdata-guide/.claude-plugin/plugin.json
+++ b/plugins/brightdata-guide/.claude-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "brightdata-guide",
+  "version": "1.0.0",
+  "description": "Bright Data web data access (MCP tools + CLI) for scraping, SERP, structured extractors, and browser automation.",
+  "license": "MIT"
+}

--- a/plugins/brightdata-guide/.codex-plugin/plugin.json
+++ b/plugins/brightdata-guide/.codex-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "brightdata-guide",
+  "version": "1.0.0",
+  "description": "Bright Data web data access via MCP tools + CLI — scraping (Web Unlocker), SERP, 40+ structured web_data_* extractors, browser automation. Guide skill; operator sets BRIGHTDATA_API_KEY, delegate subagents fall back to the bdata CLI.",
+  "author": {
+    "name": "YoungjaeDev"
+  },
+  "license": "MIT",
+  "skills": "./skills/"
+}

--- a/plugins/brightdata-guide/__init__.py
+++ b/plugins/brightdata-guide/__init__.py
@@ -1,0 +1,54 @@
+"""Hermes Agent adapter for the brightdata-guide plugin.
+
+The upstream plugin already ships skills for Claude Code and Codex. Hermes loads
+plugin-provided skills through a small Python entrypoint, so this module simply
+registers the existing SKILL.md files under the ``brightdata-guide:<skill>`` namespace.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+def _frontmatter_from_skill(skill_md: Path) -> dict[str, Any]:
+    """Decode the YAML frontmatter from a SKILL.md file."""
+    text = skill_md.read_text(encoding="utf-8", errors="replace")
+    if not text.startswith("---"):
+        return {}
+    try:
+        _, frontmatter, _ = text.split("---", 2)
+    except ValueError:
+        return {}
+    try:
+        data = yaml.safe_load(frontmatter) or {}
+    except yaml.YAMLError:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _description_from_skill(skill_md: Path) -> str:
+    """Extract the decoded frontmatter description from a SKILL.md file."""
+    description = _frontmatter_from_skill(skill_md).get("description", "")
+    if description is None:
+        return ""
+    if isinstance(description, str):
+        return description.strip()
+    return str(description).strip()
+
+
+def register(ctx) -> None:
+    """Register brightdata-guide skills with Hermes.
+
+    Hermes automatically qualifies these as ``brightdata-guide:<name>`` based on the
+    plugin manifest name, matching the existing Claude/Codex command namespace.
+    """
+    skills_root = Path(__file__).resolve().parent / "skills"
+    for skill_md in sorted(skills_root.glob("*/SKILL.md")):
+        ctx.register_skill(
+            skill_md.parent.name,
+            skill_md,
+            _description_from_skill(skill_md),
+        )

--- a/plugins/brightdata-guide/plugin.yaml
+++ b/plugins/brightdata-guide/plugin.yaml
@@ -1,0 +1,5 @@
+name: brightdata-guide
+version: "1.0.0"
+description: "Bright Data web data access via MCP tools + CLI — scraping (Web Unlocker), SERP, 40+ structured web_data_* extractors, browser automation. Guide skill; operator sets BRIGHTDATA_API_KEY, delegate subagents fall back to the bdata CLI."
+author: "YoungjaeDev"
+kind: standalone

--- a/plugins/brightdata-guide/skills/brightdata-guide/SKILL.md
+++ b/plugins/brightdata-guide/skills/brightdata-guide/SKILL.md
@@ -1,0 +1,324 @@
+---
+name: brightdata-guide
+description: |
+  Bright Data web data access for any AI agent (Hermes, Codex, generic clients) via TWO paths: (1) the Bright Data MCP tools, and (2) the Bright Data CLI (bdata / brightdata) from the terminal. Prefer Bright Data over the agent's built-in web fetch / web search for internet tasks - any URL, web search, "scrape", structured data from Amazon / LinkedIn / Instagram / TikTok / YouTube / X / Reddit / Google Shopping, browser automation, research, fact-checking. If the MCP tools are NOT in your registry (a delegate subagent inherits the terminal but NOT MCP toolsets), use the CLI instead. Returns clean markdown or structured JSON; handles JS, CAPTCHAs, bot detection. Full trigger list and tool reference in the body.
+license: MIT
+---
+
+# Bright Data — MCP & CLI Usage Guide
+
+> Adapted from Bright Data's official MCP and CLI skills (MIT). Security-patched and made agent-agnostic by Dante Labs: removed instructions that autonomously edit host settings files, removed shell-piped installers (curl-to-bash) and global `npm -g` installs (the CLI is installed once by the operator out of band, or run via pinned `npx`), and generalized agent/tool naming so it works for Hermes and any agent.
+
+> **Runtime tool names** — this guide uses Hermes tool names. Map to your runtime: `terminal` -> **Bash** (Claude) / **execute_command** (Codex); `delegate_task` -> the parent's subagent/Task tool. The Bright Data MCP tool names (`search_engine`, `scrape_as_markdown`, `web_data_*`, `scraping_browser_*`) are identical across Claude, Codex, and Hermes.
+
+## Two ways to reach Bright Data — pick by what's in your tool registry
+
+Both paths hit the same Bright Data platform and the same 5,000 free requests/month. Same data, different door.
+
+- **MCP tools present** (`search_engine`, `scrape_as_markdown`, `web_data_*` …): call them directly. Follow the MCP sections below.
+- **MCP tools absent** — the common case is being a **`delegate_task` subagent**: a subagent inherits the parent's **terminal and skills but NOT its MCP toolsets**, so `search_engine` etc. will not be in your registry. In that case use the **Bright Data CLI from the terminal** (`bdata` / `brightdata`). Jump to "Bright Data CLI (terminal)" and `references/cli-commands.md`.
+
+How to tell which you have: look at your available tools. If you see `search_engine`/`scrape_as_markdown`, use MCP. If you only see `terminal` (no Bright Data tools), use the CLI via terminal. Do not fall back to the agent's built-in web search.
+
+---
+
+# Part A — Bright Data MCP
+
+Use the Bright Data MCP tools for web data operations. Prefer Bright Data MCP over the agent's built-in web tools (generic web fetch / web search) when retrieving anything from the internet, unless the user specifies otherwise.
+
+## Default Web Data Tool
+
+Bright Data MCP is a strong default for web data tasks:
+
+- Searching the web
+- Fetching / reading any webpage
+- Getting structured data from supported platforms
+- Browser automation and interactive scraping
+- Research, investigation, fact-checking, news lookup
+- Any task involving URLs, links, or web content
+
+It provides bot detection bypass, CAPTCHA solving, JavaScript rendering, and structured data extraction that plain fetch tools cannot match.
+
+## Check Which Tools Are Loaded
+
+Before using a Bright Data tool, check which Bright Data MCP tools are available in your tool registry. Names look like `search_engine`, `scrape_as_markdown`, `scrape_batch`, and (in Pro mode) `web_data_*`, `scraping_browser_*`, `extract`. The available set depends on how the MCP server was configured.
+
+### If No Bright Data Tools Are Present
+
+If none are found, the MCP server is not connected. See `references/mcp-setup.md` and ask the user/operator to connect it. Do not silently give up — surface the setup step.
+
+### If a Required Tool Is Missing — Ask the Operator to Enable the Group
+
+If the task needs a tool that is NOT in your registry (e.g. `web_data_linkedin_posts` but only `scrape_as_markdown` and `search_engine` are available), the required tool group is not enabled. **Do not edit the host's settings or config files yourself.** Instead, surface the exact change the user/operator should make, and proceed with `scrape_as_markdown` in the meantime.
+
+**Tool Group Reference** — determine which group contains the tool you need:
+
+| Group               | Platforms/Tools                                                          |
+| ------------------- | ------------------------------------------------------------------------ |
+| `social`            | LinkedIn, Instagram, Facebook, TikTok, YouTube, X/Twitter, Reddit        |
+| `ecommerce`         | Amazon, Walmart, eBay, Best Buy, Etsy, Home Depot, Zara, Google Shopping |
+| `business`          | Crunchbase, ZoomInfo, Google Maps, Zillow                                |
+| `finance`           | Yahoo Finance                                                            |
+| `research`          | Reuters, GitHub                                                          |
+| `app_stores`        | Google Play, Apple App Store                                             |
+| `travel`            | Booking.com                                                              |
+| `browser`           | Browser automation (`scraping_browser_*` tools)                          |
+| `advanced_scraping` | `scrape_as_html`, `extract`, batch tools, `session_stats`                |
+
+**How a group gets enabled (tell the user — do not change files yourself):**
+
+- Remote MCP server (URL-based): append `&groups=<group_name>` to the Bright Data MCP URL (comma-separate multiple groups), or `&pro=1` to enable all Pro tools.
+- Local MCP server (stdio): add `GROUPS=<group_name>` (or `PRO_MODE=true`) to the server's environment variables.
+
+Examples of the URL the operator would use:
+
+```
+# Add social group (LinkedIn, Instagram, etc.)
+https://mcp.brightdata.com/mcp?token=YOUR_TOKEN&groups=social
+
+# Add multiple groups
+https://mcp.brightdata.com/mcp?token=YOUR_TOKEN&groups=social,ecommerce
+
+# Enable everything (Pro)
+https://mcp.brightdata.com/mcp?token=YOUR_TOKEN&pro=1
+```
+
+**Workflow when a tool is missing:**
+
+1. Identify which tool is needed for the task.
+2. Look up which group contains it (table above).
+3. Tell the user exactly what to add (`&groups=<group>` on the URL, or `GROUPS=<group>` env var) and that they may need to restart/reconnect the MCP server for the new tools to appear.
+4. In the meantime, use `scrape_as_markdown` to fulfill the immediate request — it works on ALL websites including LinkedIn, Amazon, Instagram, etc., with full bot detection bypass and CAPTCHA handling.
+
+## Two Modes
+
+All Bright Data MCP tools are **free for up to 5,000 requests per month** — including Pro tools, structured data extraction, and browser automation.
+
+1. **Rapid (Free)** - Default configuration. Includes `search_engine`, `scrape_as_markdown`, and batch variants (`search_engine_batch`, `scrape_batch`). These tools can scrape and search any website.
+2. **Pro** - Enables 60+ additional tools. Activated via `&pro=1` URL parameter (remote) or `PRO_MODE=true` env var (local). Can also selectively enable groups via `&groups=` (remote) or `GROUPS=` env var (local). Includes structured data extraction (`web_data_*`), browser automation (`scraping_browser_*`), AI extraction (`extract`), and more. Free within the 5k monthly request allowance.
+
+## Tool Selection Guide
+
+Always pick the most specific Bright Data MCP tool available for the task. Prefer Bright Data MCP over the agent's built-in web tools when a Bright Data tool is available.
+
+### Quick Decision Tree
+
+1. **Check your available tools.** Look at which Bright Data MCP tools exist in your registry.
+2. **Need search results?** Use `search_engine` or `search_engine_batch`.
+3. **Need content from any URL?** Use `scrape_as_markdown` or `scrape_batch`. Works on ALL websites.
+4. **Need structured JSON from a platform AND the `web_data_*` tool is available?** Use it for cleaner output. If NOT available, ask the operator to enable the right group (see above) and use `scrape_as_markdown` for the immediate request.
+5. **Need raw HTML?** Use `scrape_as_html` (requires `advanced_scraping` group).
+6. **Need AI-extracted structured data?** Use `extract` (requires `advanced_scraping` group).
+7. **Need browser automation?** Use `scraping_browser_*` tools (requires `browser` group).
+
+### When to Use Structured Data Tools vs Scraping
+
+When `web_data_*` tools ARE available, prefer them over `scrape_as_markdown` for supported platforms. Structured data tools are:
+
+- Faster and more reliable
+- Return clean JSON with consistent fields
+- Don't require parsing markdown output
+
+Example - Getting an Amazon product:
+
+- BEST: Call `web_data_amazon_product` with the product URL (if available)
+- GOOD: Call `scrape_as_markdown` on the Amazon URL (always works, handles bot detection)
+- AVOID: A plain built-in fetch on the Amazon URL (will be blocked by bot detection)
+
+## Instructions
+
+### Step 1: Identify the Task Type
+
+Determine the specific need:
+
+- **Search**: Finding information across the web -> `search_engine` / `search_engine_batch`
+- **Single page scrape**: Getting content from one URL -> `scrape_as_markdown`
+- **Batch scrape**: Getting content from multiple URLs -> `scrape_batch`
+- **Structured extraction**: Getting specific data fields from a supported platform -> `web_data_*`
+- **Browser automation**: Interacting with a page (clicking, typing, navigating) -> `scraping_browser_*`
+
+### Step 2: Select the Right Tool
+
+Consult `references/mcp-tools.md` for the complete tool reference organized by category.
+
+**For searches:**
+
+- `search_engine` - Single query. Supports Google, Bing, Yandex. Returns JSON for Google, Markdown for others. Use `cursor` parameter for pagination.
+- `search_engine_batch` - Up to 10 queries in parallel.
+
+**For page content:**
+
+- `scrape_as_markdown` - Best for reading page content. Handles bot protection and CAPTCHA automatically.
+- `scrape_batch` - Up to 10 URLs in one request.
+- `scrape_as_html` - When you need the raw HTML (Pro).
+- `extract` - When you need structured JSON from any page using AI extraction (Pro). Accepts optional custom extraction prompt.
+
+**For platform-specific data (Pro):**
+Use the matching `web_data_*` tool. Key ones:
+
+- Amazon: `web_data_amazon_product`, `web_data_amazon_product_reviews`, `web_data_amazon_product_search`
+- LinkedIn: `web_data_linkedin_person_profile`, `web_data_linkedin_company_profile`, `web_data_linkedin_job_listings`, `web_data_linkedin_posts`, `web_data_linkedin_people_search`
+- Instagram: `web_data_instagram_profiles`, `web_data_instagram_posts`, `web_data_instagram_reels`, `web_data_instagram_comments`
+- TikTok: `web_data_tiktok_profiles`, `web_data_tiktok_posts`, `web_data_tiktok_shop`, `web_data_tiktok_comments`
+- YouTube: `web_data_youtube_videos`, `web_data_youtube_profiles`, `web_data_youtube_comments`
+- Facebook: `web_data_facebook_posts`, `web_data_facebook_marketplace_listings`, `web_data_facebook_company_reviews`, `web_data_facebook_events`
+- X (Twitter): `web_data_x_posts`
+- Reddit: `web_data_reddit_posts`
+- Business: `web_data_crunchbase_company`, `web_data_zoominfo_company_profile`, `web_data_google_maps_reviews`, `web_data_zillow_properties_listing`
+- Finance: `web_data_yahoo_finance_business`
+- E-Commerce: `web_data_walmart_product`, `web_data_ebay_product`, `web_data_google_shopping`, `web_data_bestbuy_products`, `web_data_etsy_products`, `web_data_homedepot_products`, `web_data_zara_products`
+- Apps: `web_data_google_play_store`, `web_data_apple_app_store`
+- Other: `web_data_reuter_news`, `web_data_github_repository_file`, `web_data_booking_hotel_listings`
+
+**For browser automation (Pro):**
+Use `scraping_browser_*` tools in sequence:
+
+1. `scraping_browser_navigate` - Open a URL
+2. `scraping_browser_snapshot` - Get ARIA snapshot with interactive element refs
+3. `scraping_browser_click_ref` / `scraping_browser_type_ref` - Interact with elements
+4. `scraping_browser_screenshot` - Capture visual state
+5. `scraping_browser_get_text` / `scraping_browser_get_html` - Extract content
+
+### Step 3: Execute and Validate
+
+After calling a tool:
+
+1. Check that the response contains the expected data
+2. If the response is empty or contains an error, check the URL format matches what the tool expects
+3. For `web_data_*` tools, ensure the URL matches the required pattern (e.g., Amazon URLs must contain `/dp/`)
+
+### Step 4: Handle Errors
+
+**Tool not found / not available:**
+This is the most common issue. The tool exists but hasn't been loaded because the required group is not enabled. Instead of giving up:
+
+1. Identify which group the tool belongs to (see the Tool Group Reference table above).
+2. Tell the user exactly what to enable (`&groups=<group_name>` on the MCP URL, or `GROUPS=<group_name>` env var) and that a restart/reconnect may be needed. Do not edit their settings files yourself.
+3. Use `scrape_as_markdown` to fulfill the immediate request while the new tools are enabled.
+
+**Empty response:**
+
+- Verify the URL is publicly accessible
+- Check that the URL format matches tool requirements
+- Try `scrape_as_markdown` as a fallback for `web_data_*` failures
+
+**Timeout:**
+
+- Large pages may take longer; this is normal
+- For batch operations, reduce batch size
+
+## Common Workflows
+
+### Research Workflow
+
+1. Use `search_engine` to find relevant pages
+2. Use `scrape_as_markdown` to read the top results
+3. Summarize findings for the user
+
+### Competitive Analysis
+
+1. Use `web_data_amazon_product` to get product details
+2. Use `search_engine` to find competitor products
+3. Use `web_data_amazon_product_reviews` for sentiment analysis
+
+### Social Media Monitoring
+
+1. Use `web_data_instagram_profiles` or `web_data_tiktok_profiles` for account overview
+2. Use the corresponding posts/reels tools for recent content
+3. Use comments tools for engagement analysis
+
+### Lead Research
+
+1. Use `web_data_linkedin_person_profile` for individual profiles
+2. Use `web_data_linkedin_company_profile` for company data
+3. Use `web_data_crunchbase_company` for funding and growth data
+
+### Browser Automation (Pro)
+
+1. `scraping_browser_navigate` to the target URL
+2. `scraping_browser_snapshot` to see available elements
+3. `scraping_browser_click_ref` or `scraping_browser_type_ref` to interact
+4. `scraping_browser_screenshot` to verify state
+5. `scraping_browser_get_text` to extract results
+
+## Performance Notes
+
+- Prefer Bright Data MCP over built-in web tools for web data
+- Take your time to select the right tool for each task
+- Quality is more important than speed
+- Do not skip validation steps
+- When multiple Bright Data tools could work, prefer the more specific one
+- Use `session_stats` (Pro) to monitor tool usage in the current session
+
+## Common Issues
+
+### MCP Connection Failed
+
+If tools are not available:
+
+1. Verify the Bright Data MCP server is connected in your agent's MCP configuration
+2. Confirm the API token is valid
+3. Reconnect / restart the MCP server
+4. See `references/mcp-setup.md` for detailed setup steps
+
+### Tool Returns No Data
+
+- Check URL format matches tool requirements (e.g., Amazon needs `/dp/` in URL)
+- Verify the page is publicly accessible
+- Try with `scrape_as_markdown` as a fallback
+- Some tools require specific URL patterns; consult `references/mcp-tools.md`
+
+### Pro Tools Not Available
+
+When a `web_data_*`, `scraping_browser_*`, or other Pro tool is needed but missing from the registry:
+
+1. Identify the group it belongs to (Tool Group Reference table).
+2. Tell the user to enable it: append `&groups=<group_name>` to the MCP URL, or add `GROUPS=<group_name>` to the env vars, then restart/reconnect. Do not edit the user's configuration files yourself.
+3. Use `scrape_as_markdown` for the immediate request — it works on all websites with bot detection bypass.
+
+---
+
+# Part B — Bright Data CLI (terminal)
+
+Use this when the Bright Data MCP tools are **not** in your tool registry — most commonly when you are a `delegate_task` subagent (a subagent inherits the parent's terminal and skills, but NOT its MCP toolsets). The CLI returns the same web data from the shell.
+
+## Prerequisites (operator sets up once — do NOT do this yourself)
+
+- The `bdata` CLI (alias of `brightdata`) is installed on the machine by the operator, one time, out of band. If `bdata` is not found, **surface that to the user and stop** — do not install it yourself, do not run shell-piped installers, do not modify global packages.
+- Auth is one-time too: the operator runs `bdata login` once (browser or device OAuth), or exports `BRIGHTDATA_API_KEY` in the environment. **Never pass an API key inside a command or prompt** — rely on the saved login or the env var. Saved credentials live under the user's config dir.
+- No-install option the operator may choose: a version-pinned `npx --yes --package @brightdata/cli@<version> brightdata <command>`. Treat `bdata` below as either the installed binary or that npx form.
+
+## Core commands
+
+| Need                     | Command                                                                                                                       |
+| ------------------------ | ----------------------------------------------------------------------------------------------------------------------------- |
+| Web search (SERP)        | `bdata search "<query>" --type <web/news/shopping> --country <cc> --json`                                                     |
+| Read a page              | `bdata scrape <url> -f markdown` (also `html` / `screenshot` / `json`)                                                        |
+| Structured platform data | `bdata pipelines <type> "<url>"` (40+ types: `google_shopping`, `amazon_product`, `linkedin_*`, `instagram_*`, `youtube_*` …) |
+| Account balance          | `bdata budget`                                                                                                                |
+| Proxy zones              | `bdata zones`                                                                                                                 |
+
+Google `search` returns structured JSON (organic, shopping, ads, related). `pipelines` runs an async collection job and returns clean JSON. Both honor the 5,000 free requests/month.
+
+## Examples — collecting prices (the delegate use case)
+
+```bash
+# Shopping SERP for a Korean query, structured JSON
+bdata search "유니클로 남성 자켓 가격" --type shopping --country kr --json
+
+# Structured Google Shopping extraction from a results URL
+bdata pipelines google_shopping "https://www.google.com/search?tbm=shop&q=men+jacket"
+
+# Read a product or listing page as markdown
+bdata scrape "https://www.musinsa.com/products/123" -f markdown
+```
+
+Parse prices from the JSON or markdown output. Keep brand, item, price, currency, source URL, and the observation date.
+
+## Decision: MCP vs CLI
+
+1. Are `search_engine` / `scrape_as_markdown` in your tools? → use **MCP** (Part A).
+2. Only `terminal` available, no Bright Data tools? → use the **CLI** above.
+3. `bdata` not installed or not logged in? → tell the user; do not auto-install and do not hardcode keys.
+
+Full command, flag, and pipeline-type reference: `references/cli-commands.md`.

--- a/plugins/brightdata-guide/skills/brightdata-guide/references/cli-commands.md
+++ b/plugins/brightdata-guide/skills/brightdata-guide/references/cli-commands.md
@@ -1,0 +1,118 @@
+# Bright Data CLI — Command Reference (security-patched)
+
+**Package:** `@brightdata/cli` · **Commands:** `brightdata` / `bdata` (shorthand) · **Requires:** Node.js >= 20
+
+> Patched by Dante Labs: the official reference shipped shell-piped and global-install commands. Those are removed here. **The agent must not install the CLI.** Installation and login are one-time operator tasks done out of band.
+
+## Setup (operator, one-time — not the agent)
+
+- The operator installs the `@brightdata/cli` package (pin a specific version) on the machine, or the operator chooses the no-install path: `npx --yes --package @brightdata/cli@<version> brightdata <command>`.
+- The operator authenticates once with `bdata login` (browser or `--device` for headless), or exports `BRIGHTDATA_API_KEY` in the environment. Credentials are saved under the user's config directory.
+- The agent assumes `bdata` is on PATH and already authenticated. If it is not, surface that to the user and stop — do not install or hardcode keys.
+
+## Global options
+
+| Flag                  | Description                                                                                     |
+| --------------------- | ----------------------------------------------------------------------------------------------- |
+| `-k, --api-key <key>` | Override API key for one request (avoid in shared/subagent contexts; prefer saved login or env) |
+| `--timing`            | Show request timing                                                                             |
+| `-v, --version`       | Show CLI version                                                                                |
+
+## `bdata login` / `bdata logout`
+
+Authenticate (one-time, operator). Browser OAuth by default.
+
+| Flag                     | Description                               |
+| ------------------------ | ----------------------------------------- |
+| `-d, --device`           | Device flow for SSH/headless environments |
+| `-c, --customer-id <id>` | Account ID (optional)                     |
+
+```bash
+bdata login            # browser OAuth (operator)
+bdata login --device   # headless/SSH (operator)
+bdata logout           # clear stored credentials
+```
+
+On login the CLI validates the key, saves credentials, and auto-creates required zones (`cli_unlocker`, `cli_browser`).
+
+## `bdata scrape <url>` — Web Unlocker
+
+Fetch any URL (handles CAPTCHA, JS rendering, anti-bot).
+
+| Flag                  | Description                                        |
+| --------------------- | -------------------------------------------------- |
+| `-f, --format <fmt>`  | `markdown` (default), `html`, `screenshot`, `json` |
+| `--country <code>`    | Geo-target (e.g. `kr`, `us`, `jp`)                 |
+| `--zone <name>`       | Web Unlocker zone                                  |
+| `--mobile`            | Mobile user agent                                  |
+| `--async`             | Submit async, return snapshot ID                   |
+| `-o, --output <path>` | Write to file                                      |
+
+```bash
+bdata scrape https://example.com
+bdata scrape https://www.musinsa.com/products/123 -f markdown
+bdata scrape https://shop.example.com -f json --country kr -o out.json
+```
+
+## `bdata search <query>` — SERP
+
+Search Google/Bing/Yandex. Google returns structured JSON (organic, ads, People Also Ask, related).
+
+| Flag                  | Description                                   |
+| --------------------- | --------------------------------------------- |
+| `--engine <name>`     | `google` (default), `bing`, `yandex`          |
+| `--country <code>`    | Localized results (e.g. `kr`)                 |
+| `--language <code>`   | Language (e.g. `ko`, `en`)                    |
+| `--type <type>`       | `web` (default), `news`, `images`, `shopping` |
+| `--page <n>`          | Page, 0-indexed                               |
+| `--json` / `--pretty` | JSON output                                   |
+| `-o, --output <path>` | Write to file                                 |
+
+```bash
+bdata search "유니클로 남성 자켓 가격" --type shopping --country kr --json
+bdata search "men jacket price" --type shopping --country kr --json --pretty
+bdata search "open source scraping" --json | jq -r '.organic[].link'
+```
+
+## `bdata pipelines <type> [params...]` — structured extraction (40+ platforms)
+
+Triggers an async collection job, polls, returns structured results.
+
+| Flag                  | Description                                |
+| --------------------- | ------------------------------------------ |
+| `--format <fmt>`      | `json` (default), `csv`, `ndjson`, `jsonl` |
+| `--timeout <seconds>` | Poll timeout (default 600)                 |
+| `--json` / `--pretty` | JSON output                                |
+| `-o, --output <path>` | Write to file                              |
+
+```bash
+bdata pipelines list                                   # all types
+bdata pipelines google_shopping "https://www.google.com/search?tbm=shop&q=men+jacket"
+bdata pipelines amazon_product "https://www.amazon.com/dp/B09V3KXJPB" --format csv -o p.csv
+bdata pipelines amazon_product_search "laptop" "https://www.amazon.com"
+```
+
+### Common pipeline types
+
+| Group        | Types                                                                                                                                                                                                                                                        |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| E-commerce   | `google_shopping`, `amazon_product`, `amazon_product_reviews`, `amazon_product_search` (`<keyword> <domain>`), `walmart_product`, `ebay_product`, `bestbuy_products`, `etsy_products`, `homedepot_products`, `zara_products`                                 |
+| Professional | `linkedin_person_profile`, `linkedin_company_profile`, `linkedin_job_listings`, `linkedin_posts`, `linkedin_people_search` (`<url> <first> <last>`), `crunchbase_company`, `zoominfo_company_profile`                                                        |
+| Social       | `instagram_profiles`/`_posts`/`_reels`/`_comments`, `facebook_posts`/`_marketplace_listings`/`_company_reviews`/`_events`, `tiktok_profiles`/`_posts`/`_shop`/`_comments`, `x_posts`, `youtube_profiles`/`_videos`/`_comments` (`<url> [n]`), `reddit_posts` |
+
+Most types take just `<url>`; the exceptions are noted in parentheses. Run `bdata pipelines list` for the live, complete set.
+
+## `bdata status <job-id>` / `zones` / `budget` / `config`
+
+```bash
+bdata status s_abc123 --wait --pretty   # poll an async job
+bdata zones                             # list proxy zones
+bdata budget                            # account balance (free tier: 5,000 req/month)
+bdata config get default_zone_unlocker  # view/set CLI config
+```
+
+> Free tier: ~5,000 credits/month shared across Unlocker/SERP/Web Scraper, reset on the 1st, no rollover. A near-zero balance on a free account is expected, not an error.
+
+## Output parsing (for price collection)
+
+`search --type shopping --json` and `pipelines google_shopping` return JSON with product titles and prices. `scrape -f markdown` returns readable text. Extract: brand, item, price (number), currency, source URL, observation date — one row per item, drop rows with no verifiable price.

--- a/plugins/brightdata-guide/skills/brightdata-guide/references/mcp-setup.md
+++ b/plugins/brightdata-guide/skills/brightdata-guide/references/mcp-setup.md
@@ -1,0 +1,141 @@
+# Bright Data MCP Server Setup
+
+> Agent-agnostic setup. Works for Hermes, Codex, and any MCP-capable client. Configure the MCP server through your agent's own MCP configuration UI/CLI — this guide describes the values to use, it does not edit your settings files for you.
+
+## Prerequisites
+
+1. A Bright Data account - sign up at [brightdata.com](https://brightdata.com)
+2. An API token from the [Bright Data Dashboard](https://brightdata.com/cp)
+
+## Remote MCP Server (Recommended)
+
+The remote MCP server requires no local installation. Connect directly via URL.
+
+### Base URL
+
+```
+https://mcp.brightdata.com/mcp?token=<YOUR_BRIGHTDATA_API_TOKEN>
+```
+
+### Optional Parameters
+
+| Parameter | Values        | Description                                                          |
+| --------- | ------------- | -------------------------------------------------------------------- |
+| `pro`     | `1`           | Enable all 60+ Pro tools (browser automation, structured extraction) |
+| `groups`  | Group name(s) | Enable specific tool groups without full Pro mode                    |
+| `tools`   | Tool name(s)  | Enable only specific individual tools                                |
+
+### URL Examples
+
+**Rapid (Free) mode** - search and scrape only:
+
+```
+https://mcp.brightdata.com/mcp?token=YOUR_TOKEN
+```
+
+**Full Pro mode** - all 60+ tools:
+
+```
+https://mcp.brightdata.com/mcp?token=YOUR_TOKEN&pro=1
+```
+
+**Specific groups** - e.g., social media + e-commerce:
+
+```
+https://mcp.brightdata.com/mcp?token=YOUR_TOKEN&groups=social,ecommerce
+```
+
+**Specific tools** - e.g., only Amazon product and search:
+
+```
+https://mcp.brightdata.com/mcp?token=YOUR_TOKEN&tools=web_data_amazon_product,search_engine
+```
+
+### Connecting (any MCP client)
+
+Add the URL above as a remote (HTTP) MCP server in your agent's MCP configuration. Each agent has its own way to register an MCP server:
+
+- **Hermes**: `hermes mcp add brightdata --url "https://mcp.brightdata.com/mcp?token=YOUR_TOKEN"` (or add it through the Hermes dashboard MCP tab). The connection is stored in the active profile's `config.yaml` under `mcp_servers`.
+- **Generic MCP client**: register a server entry with the `url` field pointing at the URL above.
+
+Verify the connection reports a healthy/connected status and that the Bright Data tools appear in the tool list.
+
+## Local MCP Server (stdio)
+
+For users who prefer running the MCP server locally via `npx` (no global install needed).
+
+### Run via npx
+
+```bash
+API_TOKEN=your_token PRO_MODE=true npx @brightdata/mcp
+```
+
+> Uses `npx` so the package is fetched on demand — no global (`-g`) install required.
+
+### Environment Variables
+
+| Variable    | Required | Description                       |
+| ----------- | -------- | --------------------------------- |
+| `API_TOKEN` | Yes      | Your Bright Data API token        |
+| `PRO_MODE`  | No       | Set to `true` to enable Pro tools |
+| `GROUPS`    | No       | Comma-separated group names       |
+
+### Connecting (any MCP client)
+
+Register a stdio MCP server whose command is `npx` with args `@brightdata/mcp`, passing the variables above as environment variables. Example for Hermes:
+
+```bash
+hermes mcp add brightdata --command npx --args @brightdata/mcp \
+  --env API_TOKEN=your_token WEB_UNLOCKER_ZONE=your_zone npm_config_yes=true
+```
+
+(The credential variable is named `API_TOKEN`. `npm_config_yes=true` auto-approves the npx package fetch.)
+
+## Choosing Your Mode
+
+All modes are **free for up to 5,000 requests per month** — including Pro tools.
+
+### Rapid (Free) - Default
+
+- `search_engine` and `scrape_as_markdown` available (plus batch variants)
+- Best for: everyday browsing, reading web pages, search queries
+
+### Pro Mode (`pro=1` / `PRO_MODE=true`)
+
+- All 60+ tools enabled
+- Structured data from Amazon, LinkedIn, Instagram, TikTok, YouTube, etc.
+- Browser automation tools
+- Best for: data extraction, social media analysis, e-commerce monitoring, automation
+
+### Groups (Selective Pro)
+
+Enable only the tool groups you need:
+
+- `ecommerce` - Amazon, Walmart, eBay, Best Buy, etc.
+- `social` - LinkedIn, Instagram, Facebook, TikTok, YouTube, X, Reddit
+- `business` - Crunchbase, ZoomInfo, Google Maps, Zillow
+- `finance` - Yahoo Finance
+- `research` - Reuters, GitHub
+- `app_stores` - Google Play, Apple App Store
+- `travel` - Booking.com
+- `browser` - Full browser automation
+- `advanced_scraping` - HTML scraping, AI extraction, batch operations
+
+## Verifying Your Setup
+
+After connecting, test with a simple tool call:
+
+1. Ask your agent: "Use the Bright Data MCP to search for 'test query'"
+2. This should call `search_engine` and return results
+3. If it works, your MCP connection is active
+
+If it fails:
+
+- Check your API token is valid and not expired
+- Verify the MCP URL is correctly formatted
+- Check network connectivity to mcp.brightdata.com
+- Reconnect the MCP server in your agent's configuration
+
+## Documentation
+
+Full documentation index: https://docs.brightdata.com/llms.txt

--- a/plugins/brightdata-guide/skills/brightdata-guide/references/mcp-tools.md
+++ b/plugins/brightdata-guide/skills/brightdata-guide/references/mcp-tools.md
@@ -1,0 +1,161 @@
+# Bright Data MCP Tools Reference
+
+Complete reference for all Bright Data MCP server tools, organized by mode and category.
+
+## Rapid (Free) Tools
+
+Available by default, no special configuration needed.
+
+### search_engine
+
+Scrape search results from Google, Bing, or Yandex. Returns SERP results in JSON for Google and Markdown for Bing/Yandex. Supports pagination with the `cursor` parameter.
+
+### scrape_as_markdown
+
+Scrape a single webpage with advanced extraction and return Markdown. Uses Bright Data's unlocker to handle bot protection and CAPTCHA.
+
+### search_engine_batch
+
+Run up to 10 search queries in parallel. Returns JSON for Google results and Markdown for Bing/Yandex. Requires `advanced_scraping` group or Pro mode.
+
+### scrape_batch
+
+Scrape up to 10 webpages in one request and return an array of URL/content pairs in Markdown format. Requires `advanced_scraping` group or Pro mode.
+
+---
+
+## Pro Tools by Group
+
+### Advanced Scraping Group (`advanced_scraping`)
+
+| Tool                  | Description                                                                                                        |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| `scrape_as_html`      | Scrape a webpage and return raw HTML. Handles bot detection and CAPTCHA.                                           |
+| `extract`             | Scrape a webpage as Markdown, then convert to structured JSON using AI. Accepts optional custom extraction prompt. |
+| `session_stats`       | Report how many times each tool has been called during the current MCP session.                                    |
+| `search_engine_batch` | Run up to 10 search queries in parallel.                                                                           |
+| `scrape_batch`        | Scrape up to 10 webpages in one request.                                                                           |
+
+### E-Commerce Group (`ecommerce`)
+
+| Tool                              | URL Requirement                      | Description                                                         |
+| --------------------------------- | ------------------------------------ | ------------------------------------------------------------------- |
+| `web_data_amazon_product`         | Must contain `/dp/`                  | Structured Amazon product data (title, price, rating, images, etc.) |
+| `web_data_amazon_product_reviews` | Must contain `/dp/`                  | Structured Amazon review data                                       |
+| `web_data_amazon_product_search`  | Requires keyword + Amazon domain URL | Structured search results (first page only)                         |
+| `web_data_walmart_product`        | Must contain `/ip/`                  | Structured Walmart product data                                     |
+| `web_data_walmart_seller`         | Valid Walmart seller URL             | Structured seller data                                              |
+| `web_data_ebay_product`           | Valid eBay product URL               | Structured eBay listing data                                        |
+| `web_data_homedepot_products`     | Valid homedepot.com URL              | Structured Home Depot data                                          |
+| `web_data_zara_products`          | Valid Zara product URL               | Structured Zara data                                                |
+| `web_data_etsy_products`          | Valid Etsy product URL               | Structured Etsy data                                                |
+| `web_data_bestbuy_products`       | Valid Best Buy product URL           | Structured Best Buy data                                            |
+| `web_data_google_shopping`        | Valid Google Shopping URL            | Structured Google Shopping data                                     |
+
+### Social Media Group (`social`)
+
+| Tool                                     | URL Requirement                                                  | Description                                  |
+| ---------------------------------------- | ---------------------------------------------------------------- | -------------------------------------------- |
+| `web_data_linkedin_person_profile`       | Valid LinkedIn profile URL                                       | Profile data (experience, skills, education) |
+| `web_data_linkedin_company_profile`      | Valid LinkedIn company URL                                       | Company profile data                         |
+| `web_data_linkedin_job_listings`         | Valid LinkedIn jobs URL                                          | Job listing details                          |
+| `web_data_linkedin_posts`                | Valid LinkedIn post URL                                          | Post content and engagement                  |
+| `web_data_linkedin_people_search`        | LinkedIn people search URL                                       | People search results                        |
+| `web_data_instagram_profiles`            | Valid Instagram profile URL                                      | Bio, followers, following                    |
+| `web_data_instagram_posts`               | Valid Instagram post URL                                         | Post details, likes, captions                |
+| `web_data_instagram_reels`               | Valid Instagram reel URL                                         | Reel data and metrics                        |
+| `web_data_instagram_comments`            | Valid Instagram URL                                              | Post comments                                |
+| `web_data_facebook_posts`                | Valid Facebook post URL                                          | Post content and reactions                   |
+| `web_data_facebook_marketplace_listings` | Valid Marketplace listing URL                                    | Listing details                              |
+| `web_data_facebook_company_reviews`      | Valid Facebook company URL (+ optional review count)             | Company reviews                              |
+| `web_data_facebook_events`               | Valid Facebook event URL                                         | Event details                                |
+| `web_data_tiktok_profiles`               | Valid TikTok profile URL                                         | Creator profile data                         |
+| `web_data_tiktok_posts`                  | Valid TikTok post URL                                            | Video details and metrics                    |
+| `web_data_tiktok_shop`                   | Valid TikTok Shop product URL                                    | Product data                                 |
+| `web_data_tiktok_comments`               | Valid TikTok video URL                                           | Video comments                               |
+| `web_data_x_posts`                       | Valid X (Twitter) post URL                                       | Tweet data                                   |
+| `web_data_youtube_videos`                | Valid YouTube video URL                                          | Video metadata                               |
+| `web_data_youtube_profiles`              | Valid YouTube channel URL                                        | Channel profile data                         |
+| `web_data_youtube_comments`              | Valid YouTube video URL (+ optional num_of_comments, default 10) | Video comments                               |
+| `web_data_reddit_posts`                  | Valid Reddit post URL                                            | Post and comment data                        |
+
+### Business Intelligence Group (`business`)
+
+| Tool                                 | URL Requirement                                          | Description                        |
+| ------------------------------------ | -------------------------------------------------------- | ---------------------------------- |
+| `web_data_crunchbase_company`        | Valid Crunchbase company URL                             | Company funding, employees, rounds |
+| `web_data_zoominfo_company_profile`  | Valid ZoomInfo company URL                               | Company profile data               |
+| `web_data_google_maps_reviews`       | Valid Google Maps URL (+ optional days_limit, default 3) | Business reviews                   |
+| `web_data_zillow_properties_listing` | Valid Zillow listing URL                                 | Property listing data              |
+
+### Finance Group (`finance`)
+
+| Tool                              | URL Requirement                  | Description                    |
+| --------------------------------- | -------------------------------- | ------------------------------ |
+| `web_data_yahoo_finance_business` | Valid Yahoo Finance business URL | Company profile and stock data |
+
+### Research Group (`research`)
+
+| Tool                              | URL Requirement                | Description          |
+| --------------------------------- | ------------------------------ | -------------------- |
+| `web_data_reuter_news`            | Valid Reuters news article URL | Structured news data |
+| `web_data_github_repository_file` | Valid GitHub file URL          | Repository file data |
+
+### App Stores Group (`app_stores`)
+
+| Tool                         | URL Requirement          | Description          |
+| ---------------------------- | ------------------------ | -------------------- |
+| `web_data_google_play_store` | Valid Play Store app URL | App data and reviews |
+| `web_data_apple_app_store`   | Valid App Store app URL  | App data and reviews |
+
+### Travel Group (`travel`)
+
+| Tool                              | URL Requirement               | Description        |
+| --------------------------------- | ----------------------------- | ------------------ |
+| `web_data_booking_hotel_listings` | Valid Booking.com listing URL | Hotel listing data |
+
+### Browser Automation Group (`browser`)
+
+Use these tools in sequence for interactive web automation.
+
+| Tool                                | Description                                                                                    |
+| ----------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `scraping_browser_navigate`         | Open or reuse a session, navigate to URL. Resets tracked network requests.                     |
+| `scraping_browser_go_back`          | Navigate back to the previous page.                                                            |
+| `scraping_browser_go_forward`       | Navigate forward to the next page.                                                             |
+| `scraping_browser_snapshot`         | Capture ARIA snapshot listing interactive elements with refs.                                  |
+| `scraping_browser_click_ref`        | Click an element by its ref from the ARIA snapshot. Requires ref + human-readable description. |
+| `scraping_browser_type_ref`         | Fill an input element by ref. Optionally press Enter after typing.                             |
+| `scraping_browser_screenshot`       | Capture screenshot. Supports optional `full_page` mode.                                        |
+| `scraping_browser_network_requests` | List network requests since page load (method, URL, status).                                   |
+| `scraping_browser_wait_for_ref`     | Wait until an element becomes visible (optional timeout in ms).                                |
+| `scraping_browser_get_text`         | Return the text content of the page body.                                                      |
+| `scraping_browser_get_html`         | Return page HTML. Avoid `full_page` unless head/script tags are needed.                        |
+| `scraping_browser_scroll`           | Scroll to the bottom of the page.                                                              |
+| `scraping_browser_scroll_to_ref`    | Scroll until a specific element (by ARIA ref) is in view.                                      |
+
+#### Browser Automation Best Practices
+
+1. Always start with `scraping_browser_navigate` to open the target URL
+2. Use `scraping_browser_snapshot` to discover interactive elements before clicking/typing
+3. Use refs from the snapshot (not selectors) for all interactions
+4. After interactions, take a new `scraping_browser_snapshot` to see updated state
+5. Use `scraping_browser_screenshot` to visually verify state when debugging
+6. Use `scraping_browser_wait_for_ref` before interacting with elements that load dynamically
+7. Extract final content with `scraping_browser_get_text` or `scraping_browser_get_html`
+
+---
+
+## Available Groups Summary
+
+| Group               | Description                 | Key Tools                                                 |
+| ------------------- | --------------------------- | --------------------------------------------------------- |
+| `ecommerce`         | E-commerce platforms        | Amazon, Walmart, eBay, Best Buy, Etsy, etc.               |
+| `social`            | Social media & professional | LinkedIn, Instagram, Facebook, TikTok, YouTube, X, Reddit |
+| `business`          | Business intelligence       | Crunchbase, ZoomInfo, Google Maps, Zillow                 |
+| `finance`           | Financial data              | Yahoo Finance                                             |
+| `research`          | Research & news             | Reuters, GitHub                                           |
+| `app_stores`        | App stores                  | Google Play, Apple App Store                              |
+| `travel`            | Travel platforms            | Booking.com                                               |
+| `browser`           | Browser automation          | Navigate, click, type, screenshot, extract                |
+| `advanced_scraping` | Advanced extraction         | HTML scraping, AI extraction, batch operations            |

--- a/scripts/sync-hermes-manifests.mjs
+++ b/scripts/sync-hermes-manifests.mjs
@@ -32,6 +32,7 @@ const HERMES_ELIGIBLE = new Set([
   'tcrei-prompt',
   'ppt-yeong-style',
   'ml-toolkit',
+  'brightdata-guide',
 ]);
 
 const AUTHOR = 'YoungjaeDev';


### PR DESCRIPTION
Part of #85 (PR2 brightdata port).

## What
Port the Hermes-native `brightdata-guide` skill (Dante Labs, MIT) as a new plugin usable across Claude Code + Codex + Hermes — a guide (no scripts) for Bright Data web-data access via MCP tools + the `bdata` CLI.

## Files
- `plugins/brightdata-guide/skills/brightdata-guide/{SKILL.md, references/*}` — body + 3 references copied verbatim; SKILL `description` trimmed 1153 to 718 chars (Codex 1024 cap) + a runtime tool-name compat note (`terminal` to Bash/execute_command; Bright Data MCP tool names are runtime-identical).
- `.mcp.json` omitted by design (skill is anti-auto-config; CLI fallback built in; Hermes ignores `.mcp.json`).

## Wiring
- `HERMES_ELIGIBLE` +brightdata-guide (6 to 7); regenerated codex + hermes manifests.
- marketplace `metadata.version` 1.75.0 to 1.76.0; counts synced (Plugins 22, Codex-eligible 20) across CLAUDE.md + README + settings.local.

## Verify
- `node scripts/sync-codex-manifests.mjs --check` + `node scripts/sync-hermes-manifests.mjs --check` pass; description-length guard passes (718 <= 1024).
- `ls plugins/ | wc -l` = 22 = settings.local entries = marketplace entries.
- Token validated out-of-band via MCP initialize (0 credits); key not committed.

Spec: `.claude/spec/2026-07-02-brightdata-guide-port.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 새 플러그인 **brightdata-guide** 추가로 Bright Data 기반 웹 데이터 접근 범위가 확대되었습니다.
  * MCP 도구 우선 사용 및 필요 시 CLI 대체 흐름을 제공하며, 관련 스킬이 함께 배포되었습니다.
  * Hermes/Codex에서 해당 플러그인이 마켓플레이스 대상으로 반영되어 플러그인 수 및 허용 범위 안내가 갱신되었습니다.

* **Documentation**
  * README/CLAUDE 및 플러그인 상세 문서에서 총 플러그인 수(22개)와 설정/사용 범위가 최신화되었습니다.
  * MCP 설정, MCP 도구 레퍼런스, CLI 커맨드 레퍼런스 등 참고 문서가 추가·보강되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->