### PR TITLE
feat(mem0-ops): 플릿 레벨 mem0 진단·정리 플러그인 (0.1.0)

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -255,6 +255,18 @@
         "authentication": "ON_INSTALL"
       },
       "category": "productivity"
+    },
+    {
+      "name": "mem0-ops",
+      "source": {
+        "source": "local",
+        "path": "./plugins/mem0-ops"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "productivity"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,8 +4,8 @@
     "name": "YoungjaeDev"
   },
   "metadata": {
-    "description": "Personal Claude Code plugin collection with 23 specialized plugins. Codex 0.135 + Hermes Agent native — generated `.agents/plugins/marketplace.json` + per-plugin `.codex-plugin/plugin.json` (`scripts/sync-codex-manifests.mjs`) and Hermes `plugin.yaml` + `__init__.py` adapters (`scripts/sync-hermes-manifests.mjs`).",
-    "version": "1.83.0"
+    "description": "Personal Claude Code plugin collection with 24 specialized plugins. Codex 0.135 + Hermes Agent native — generated `.agents/plugins/marketplace.json` + per-plugin `.codex-plugin/plugin.json` (`scripts/sync-codex-manifests.mjs`) and Hermes `plugin.yaml` + `__init__.py` adapters (`scripts/sync-hermes-manifests.mjs`).",
+    "version": "1.84.0"
   },
   "plugins": [
     {
@@ -166,6 +166,13 @@
       "name": "gws-sync",
       "source": "./plugins/gws-sync",
       "description": "로컬 폴더 → Google Drive 단방향 제안형 동기화 (gws CLI 기반, MCP 아님). 매핑 설정 파일(.gws-sync.json)로 로컬↔Drive 폴더 대응을 기억하고, 실행 시 Drive 트리 탐색 → 신규·변경 diff 리포트 → 업로드 위치 AskUserQuestion 승인 → 업로드(기존 파일은 content update로 ID·공유링크 보존). 삭제는 제안만(자동 삭제 금지), Drive→로컬 다운로드 범위 밖. gws 미설치 시 공식 docs 기반 설치 안내 출력 후 중단(자동 설치 안 함). googleworkspace/cli 공식 스킬/레시피 95종 카탈로그(llms.txt)를 references에 동봉 — 상황에 유용한 미설치 스킬을 npx skills add로 제안.",
+      "version": "0.1.0",
+      "category": "productivity"
+    },
+    {
+      "name": "mem0-ops",
+      "source": "./plugins/mem0-ops",
+      "description": "Fleet-level mem0 diagnostics and cleanup — complements the upstream mem0 plugin (which owns per-project quality). fleet-scan reports per-app noise ratio, junk app_id candidates, and app/user_id fragmentation across all apps; doctor checks config posture (MEM0_RERANK env, ~/.mem0/settings.json auto_save precedence trap, project decay flag, hook timeout budget, identity fragmentation); cleanup does backup-then-delete by metadata.type or whole junk app behind a dry-run default and per-app confirmation gate. stdlib-only REST scripts, zero LLM cost for the deterministic parts.",
       "version": "0.1.0",
       "category": "productivity"
     }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -172,7 +172,7 @@
     {
       "name": "mem0-ops",
       "source": "./plugins/mem0-ops",
-      "description": "Fleet-level mem0 diagnostics and cleanup — complements the upstream mem0 plugin (which owns per-project quality). fleet-scan reports per-app noise ratio, junk app_id candidates, and app/user_id fragmentation across all apps; doctor checks config posture (MEM0_RERANK env, ~/.mem0/settings.json auto_save precedence trap, project decay flag, hook timeout budget, identity fragmentation); cleanup does backup-then-delete by metadata.type or whole junk app behind a dry-run default and per-app confirmation gate. stdlib-only REST scripts, zero LLM cost for the deterministic parts.",
+      "description": "Fleet-level mem0 diagnostics and cleanup — complements the upstream mem0 plugin (which owns per-project quality). fleet-scan reports per-app noise ratio, junk app_id candidates, and app/user_id fragmentation across all apps; doctor checks config posture (MEM0_RERANK env, ~/.mem0/settings.json auto_save precedence trap, project decay flag, hook timeout budget, identity fragmentation); cleanup does backup-then-delete by metadata.type or whole junk app behind a dry-run default plus a skill-layer per-app confirmation gate (the script alone gates on --execute only). stdlib-only REST scripts, zero LLM cost for the deterministic parts.",
       "version": "0.1.0",
       "category": "productivity"
     }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -23,7 +23,8 @@
       "./plugins/ppt-yeong-style",
       "./plugins/codex-image",
       "./plugins/brightdata-guide",
-      "./plugins/gws-sync"
+      "./plugins/gws-sync",
+      "./plugins/mem0-ops"
     ]
   }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,7 +90,7 @@ node scripts/sync-hermes-manifests.mjs --check
 
 ```bash
 codex plugin marketplace add ~/.claude/plugins/marketplaces/my-claude-plugins
-codex plugin list --marketplace my-claude-plugins   # 21 entries
+codex plugin list --marketplace my-claude-plugins   # 22 entries
 codex plugin marketplace remove my-claude-plugins   # 검증 후 정리
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 Plugin-based configuration for Claude Code with multi-agent orchestration. The same plugin tree is loaded by Codex 0.135 via `scripts/sync-codex-manifests.mjs` and by Hermes Agent via `scripts/sync-hermes-manifests.mjs` — one source, three runtimes.
 
-## Plugins (23)
+## Plugins (24)
 
 ### Core
 | Plugin | Description |
@@ -76,6 +76,7 @@ Plugin-based configuration for Claude Code with multi-agent orchestration. The s
 ### Memory & Lore
 | Plugin | Description |
 |--------|-------------|
+| `mem0-ops` | 플릿 레벨 mem0 진단·정리 — upstream mem0 플러그인(프로젝트 내부 품질)과 역할 분리. fleet-scan(전 앱 노이즈율·쓰레기 app_id 후보·app/user_id 파편화 리포트) + doctor(rerank env·auto_save 파일 우선순위 함정·decay·훅 timeout·정체성 파편화 점검, 제안만) + cleanup(백업→타입/앱 단위 삭제, dry-run 기본 + 앱별 확인 게이트). stdlib REST 스크립트라 결정론 구간 LLM 비용 0 |
 | `llm-wiki` | Karpathy LLM-Wiki 3-layer (insight + wiki + raw under neutral `.llmwiki/`): 5 skills + 5 hooks (incl. Stop-capture + SessionStart-drain auto-ingest) + bootstrap templates. Post-merge wiki ingest is a mandatory step inside `github-dev:post-merge` (post-merge-wiki absorbed). Promoted cross-agent rules graduate to `.llmwiki/insight/` (surfaced via core-config prompt-inject hook), not `.claude/rules/` |
 
 ### Workflow State
@@ -107,6 +108,7 @@ Plugin-based configuration for Claude Code with multi-agent orchestration. The s
 │   ├── slidev/             # Presentation generator
 │   ├── tcrei-prompt/       # TCREI prompt structuring
 │   ├── llm-wiki/           # LLM-Wiki 3-layer (wiki lore)
+│   ├── mem0-ops/           # Fleet-level mem0 diagnostics/cleanup (fleet-scan/doctor/cleanup)
 │   ├── spec-state/         # spec/issue/PR work-pipeline aggregate
 │   ├── anti-slop-design/   # Anti-AI-slop design guard (web/ppt/dashboard/copy)
 │   ├── ppt-yeong-style/    # yeong-style lecture/proposal deck writing layer (on ppt-master)
@@ -129,7 +131,7 @@ node scripts/sync-codex-manifests.mjs           # write manifests
 node scripts/sync-codex-manifests.mjs --check   # CI drift guard
 ```
 
-Produces `.agents/plugins/marketplace.json` + per-plugin `.codex-plugin/plugin.json` for 21 eligible plugins. Codex 0.135 manifest top-level only supports `skills` / `hooks` / `mcpServers` / `apps` — `commands` and `agents` are not emitted. Excluded: `core-config` (Claude-only hooks; no Codex hook surface for the same patterns), `codex-image` (Claude->Codex bridge; syncing it into Codex would be circular). Skill bodies are read in place — no mirror, no transform. `--check` also detects orphan manifests left behind when a plugin is removed.
+Produces `.agents/plugins/marketplace.json` + per-plugin `.codex-plugin/plugin.json` for 22 eligible plugins. Codex 0.135 manifest top-level only supports `skills` / `hooks` / `mcpServers` / `apps` — `commands` and `agents` are not emitted. Excluded: `core-config` (Claude-only hooks; no Codex hook surface for the same patterns), `codex-image` (Claude->Codex bridge; syncing it into Codex would be circular). Skill bodies are read in place — no mirror, no transform. `--check` also detects orphan manifests left behind when a plugin is removed.
 
 ## Hermes integration
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,7 @@ Plugin-based configuration for Claude Code with multi-agent orchestration. The s
 ### Memory & Lore
 | Plugin | Description |
 |--------|-------------|
-| `mem0-ops` | 플릿 레벨 mem0 진단·정리 — upstream mem0 플러그인(프로젝트 내부 품질)과 역할 분리. fleet-scan(전 앱 노이즈율·쓰레기 app_id 후보·app/user_id 파편화 리포트) + doctor(rerank env·auto_save 파일 우선순위 함정·decay·훅 timeout·정체성 파편화 점검, 제안만) + cleanup(백업→타입/앱 단위 삭제, dry-run 기본 + 앱별 확인 게이트). stdlib REST 스크립트라 결정론 구간 LLM 비용 0 |
+| `mem0-ops` | 플릿 레벨 mem0 진단·정리 — upstream mem0 플러그인(프로젝트 내부 품질)과 역할 분리. fleet-scan(전 앱 노이즈율·쓰레기 app_id 후보·app/user_id 파편화 리포트) + doctor(rerank env·auto_save 파일 우선순위 함정·decay·훅 timeout·정체성 파편화 점검, 제안만) + cleanup(백업→타입/앱 단위 삭제, dry-run 기본 + 스킬 레이어 앱별 확인 게이트). stdlib REST 스크립트라 결정론 구간 LLM 비용 0 |
 | `llm-wiki` | Karpathy LLM-Wiki 3-layer (insight + wiki + raw under neutral `.llmwiki/`): 5 skills + 5 hooks (incl. Stop-capture + SessionStart-drain auto-ingest) + bootstrap templates. Post-merge wiki ingest is a mandatory step inside `github-dev:post-merge` (post-merge-wiki absorbed). Promoted cross-agent rules graduate to `.llmwiki/insight/` (surfaced via core-config prompt-inject hook), not `.claude/rules/` |
 
 ### Workflow State

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
 
 # my-claude-plugins
 
-Claude Code를 위한 23개 플러그인 모음 - GitHub 워크플로우부터 AI 이미지 생성까지. Codex 0.135 와 Hermes Agent 도 동일한 소스 트리를 네이티브로 로드합니다 (shared source).
+Claude Code를 위한 24개 플러그인 모음 - GitHub 워크플로우부터 AI 이미지 생성까지. Codex 0.135 와 Hermes Agent 도 동일한 소스 트리를 네이티브로 로드합니다 (shared source).
 
-[![Plugins](https://img.shields.io/badge/plugins-23-blue.svg)](https://github.com/YoungjaeDev/my-claude-plugins)
+[![Plugins](https://img.shields.io/badge/plugins-24-blue.svg)](https://github.com/YoungjaeDev/my-claude-plugins)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-compatible-purple.svg)](https://docs.anthropic.com/claude-code)
 
@@ -102,6 +102,7 @@ rm -rf ~/.claude/plugins/cache/my-claude-plugins/
 | **Docs** | `docs-forge` | README/CHANGELOG 생성 (CRO 최적화) + 배포 문서 템플릿 + MOC 인덱스 |
 | | `rules-forge` | CLAUDE.md + .claude/rules/ 자동 모드 감지 생성 (write-rules 스킬) |
 | **Memory & Lore** | `llm-wiki` | Karpathy LLM-Wiki 3-layer (insight + wiki + raw; query/ingest/lint/bootstrap/migrate + 5 hooks; post-merge ingest built into `github-dev:post-merge`) |
+| **Memory & Lore** | `mem0-ops` | 플릿 레벨 mem0 진단·정리 — fleet-scan(전 앱 노이즈율·파편화) + doctor(설정 자세 점검) + cleanup(백업→삭제, dry-run 기본). upstream mem0 플러그인(프로젝트 내부 품질)과 역할 분리 |
 | **Workflow State** | `spec-state` | spec / issue / PR work-pipeline aggregate (`state-tracker` skill, `.claude/state/spec.json`) |
 | **Design** | `anti-slop-design` | 웹/SaaS 랜딩, 덱(PPT), 대시보드, 카피 anti-AI-slop 가드. clarify→context→plan→run→audit→revise + 2단계 audit gate; 한국어 카피는 `humanize-korean` 위임. 6개 OSS repo 기반 |
 | | `ppt-yeong-style` | yeong 스타일 강의·제안 덱 작성 규약. `ppt-master` 엔진 위 작성 레이어 — 스킬 3종(메인 작성 규약 + `lecture-deck` 강의 덱 운영 + `deck-review` 리뷰 오케스트레이션) + 리뷰 서브에이전트 4종(audience-fit·story-flow·fact-check·design-qa). md 규약·원칙 15종·밀도 리듬·역할 기반 색·앱 UI 실물 강제·전사 회고 루프·스크린샷 슬롯·리넘버링. 진입점 SKILL.md + references/ + 주입 프롬프트 |
@@ -421,6 +422,24 @@ Google TCREI 구조(Task, Context, References, Evaluate, Iterate)로 프롬프�
 
 </details>
 
+<details>
+<summary><strong>mem0-ops</strong> - 플릿 레벨 mem0 진단·정리</summary>
+
+mem0 Platform store를 app_id **간** 레벨에서 진단·정리합니다. upstream `mem0@mem0-plugins`(health/memory-reviewer/stats/dream — 프로젝트 내부 품질, 200건 캡)와 역할 분리 — 기능 복제 없음. 스크립트는 stdlib + REST 직결(v1 entities/delete, v2 list)이라 upstream 버전 변화와 무관하고, 결정론 구간은 LLM 비용 0.
+
+**Skills:**
+| Skill | Description |
+|-------|-------------|
+| `/mem0-ops:fleet-scan` | 전 앱 스캔 — 앱별 노이즈율, 쓰레기 app_id 후보(`JUNK?`), app/user_id 파편화 쌍(`FRAG`). read-only |
+| `/mem0-ops:doctor` | 설정 자세 점검 — `MEM0_RERANK` env, `~/.mem0/settings.json` `auto_save`(env가 아니라 이 파일이 지배하는 함정), decay, 훅 timeout 예산, 정체성 파편화. 제안만 |
+| `/mem0-ops:cleanup` | 백업→삭제 — 타입 단위(`--type session_summary`) 또는 앱 전체(`--all`). dry-run 기본, `--execute` + 앱별 사용자 확인 필수. 백업은 `~/.mem0/backups/`, 복원은 `infer=False` 재주입 |
+
+**스코프 규칙:** cleanup은 cwd의 프로젝트 app_id가 기본(upstream과 동일한 해석 체인: env → project_map → git slug → basename). basename fallback 스코프는 거부 — 쓰레기 app_id 생성 경로이기 때문. fleet-scan/doctor는 항상 전역.
+
+**전제:** `MEM0_API_KEY` (없으면 안내 후 중단).
+
+</details>
+
 ### Workflow State
 
 <details>
@@ -650,7 +669,7 @@ codex plugin marketplace add ~/.claude/plugins/marketplaces/my-claude-plugins
 codex plugin add llm-wiki@my-claude-plugins
 ```
 
-Codex 에서 제외되는 플러그인: `core-config` (Claude-only hooks — Codex 에 대응 surface 없음), `codex-image` (Claude->Codex 브리지 — Codex 로 sync 하면 순환). 즉 21 / 23 플러그인이 양쪽에서 skill 단위로 동작. `deepwiki` 와 `project-init` 은 1.41.0 부터 dual-surface (command + skill) 로 양쪽 런타임에서 사용 가능.
+Codex 에서 제외되는 플러그인: `core-config` (Claude-only hooks — Codex 에 대응 surface 없음), `codex-image` (Claude->Codex 브리지 — Codex 로 sync 하면 순환). 즉 22 / 24 플러그인이 양쪽에서 skill 단위로 동작. `deepwiki` 와 `project-init` 은 1.41.0 부터 dual-surface (command + skill) 로 양쪽 런타임에서 사용 가능.
 
 Codex 0.135 manifest top-level은 `skills` / `hooks` / `mcpServers` / `apps` 만 지원하므로, command-bearing 플러그인(`paper-search-tools`, `docs-forge` 등)도 Codex 측에는 skill만 노출됩니다 — Claude 측 commands 는 그대로 동작합니다. `github-dev` 는 모든 워크플로가 skill 로 전환돼 command surface 가 없으므로 Claude·Codex 양쪽에서 동일하게 동작합니다.
 
@@ -736,7 +755,8 @@ node scripts/install-skills.mjs
 │   ├── anti-slop-design/      # anti-AI-slop 디자인 가드 (web/ppt/dashboard/copy)
 │   ├── ppt-yeong-style/       # yeong 스타일 덱 작성 레이어 — 스킬 3종(메인/lecture-deck/deck-review) + 리뷰 에이전트 4종
 │   ├── project-init/          # Day-1 프로젝트 부트스트랩 (인터뷰 + .claude/ + AGENTS.md + gh repo)
-│   └── gws-sync/              # 로컬 → Google Drive 단방향 제안형 동기화 (gws CLI 기반)
+│   ├── gws-sync/              # 로컬 → Google Drive 단방향 제안형 동기화 (gws CLI 기반)
+│   └── mem0-ops/              # 플릿 레벨 mem0 진단·정리 (fleet-scan/doctor/cleanup)
 ├── CLAUDE.md
 └── README.md
 ```

--- a/README.md
+++ b/README.md
@@ -432,7 +432,7 @@ mem0 Platform store를 app_id **간** 레벨에서 진단·정리합니다. upst
 |-------|-------------|
 | `/mem0-ops:fleet-scan` | 전 앱 스캔 — 앱별 노이즈율, 쓰레기 app_id 후보(`JUNK?`), app/user_id 파편화 쌍(`FRAG`). read-only |
 | `/mem0-ops:doctor` | 설정 자세 점검 — `MEM0_RERANK` env, `~/.mem0/settings.json` `auto_save`(env가 아니라 이 파일이 지배하는 함정), decay, 훅 timeout 예산, 정체성 파편화. 제안만 |
-| `/mem0-ops:cleanup` | 백업→삭제 — 타입 단위(`--type session_summary`) 또는 앱 전체(`--all`). dry-run 기본, `--execute` + 앱별 사용자 확인 필수. 백업은 `~/.mem0/backups/`, 복원은 `infer=False` 재주입 |
+| `/mem0-ops:cleanup` | 백업→삭제 — 타입 단위(`--type session_summary`) 또는 앱 전체(`--all`). dry-run 기본, `--execute` + 스킬 레이어 앱별 사용자 확인(스크립트 단독은 `--execute`만 게이트). 백업은 `~/.mem0/backups/`(런별 타임스탬프), 복원은 `infer=False` 재주입 |
 
 **스코프 규칙:** cleanup은 cwd의 프로젝트 app_id가 기본(upstream과 동일한 해석 체인: env → project_map → git slug → basename). basename fallback 스코프는 거부 — 쓰레기 app_id 생성 경로이기 때문. fleet-scan/doctor는 항상 전역.
 

--- a/plugins/mem0-ops/.claude-plugin/plugin.json
+++ b/plugins/mem0-ops/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "mem0-ops",
+  "version": "0.1.0",
+  "description": "Fleet-level mem0 diagnostics and cleanup — complements the upstream mem0 plugin (which owns per-project quality). fleet-scan reports per-app noise ratio, junk app_id candidates, and app/user_id fragmentation across all apps; doctor checks config posture (MEM0_RERANK env, ~/.mem0/settings.json auto_save precedence trap, project decay flag, hook timeout budget, identity fragmentation); cleanup does backup-then-delete by metadata.type or whole junk app behind a dry-run default and per-app confirmation gate. stdlib-only REST scripts, zero LLM cost for the deterministic parts.",
+  "skills": [
+    "./skills/fleet-scan",
+    "./skills/doctor",
+    "./skills/cleanup"
+  ]
+}

--- a/plugins/mem0-ops/.claude-plugin/plugin.json
+++ b/plugins/mem0-ops/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "mem0-ops",
   "version": "0.1.0",
-  "description": "Fleet-level mem0 diagnostics and cleanup — complements the upstream mem0 plugin (which owns per-project quality). fleet-scan reports per-app noise ratio, junk app_id candidates, and app/user_id fragmentation across all apps; doctor checks config posture (MEM0_RERANK env, ~/.mem0/settings.json auto_save precedence trap, project decay flag, hook timeout budget, identity fragmentation); cleanup does backup-then-delete by metadata.type or whole junk app behind a dry-run default and per-app confirmation gate. stdlib-only REST scripts, zero LLM cost for the deterministic parts.",
+  "description": "Fleet-level mem0 diagnostics and cleanup — complements the upstream mem0 plugin (which owns per-project quality). fleet-scan reports per-app noise ratio, junk app_id candidates, and app/user_id fragmentation across all apps; doctor checks config posture (MEM0_RERANK env, ~/.mem0/settings.json auto_save precedence trap, project decay flag, hook timeout budget, identity fragmentation); cleanup does backup-then-delete by metadata.type or whole junk app behind a dry-run default plus a skill-layer per-app confirmation gate (the script alone gates on --execute only). stdlib-only REST scripts, zero LLM cost for the deterministic parts.",
   "skills": [
     "./skills/fleet-scan",
     "./skills/doctor",

--- a/plugins/mem0-ops/.codex-plugin/plugin.json
+++ b/plugins/mem0-ops/.codex-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "mem0-ops",
+  "version": "0.1.0",
+  "description": "Fleet-level mem0 diagnostics and cleanup — complements the upstream mem0 plugin (which owns per-project quality). fleet-scan reports per-app noise ratio, junk app_id candidates, and app/user_id fragmentation across all apps; doctor checks config posture (MEM0_RERANK env, ~/.mem0/settings.json auto_save precedence trap, project decay flag, hook timeout budget, identity fragmentation); cleanup does backup-then-delete by metadata.type or whole junk app behind a dry-run default and per-app confirmation gate. stdlib-only REST scripts, zero LLM cost for the deterministic parts.",
+  "author": {
+    "name": "YoungjaeDev"
+  },
+  "license": "MIT",
+  "skills": "./skills/"
+}

--- a/plugins/mem0-ops/.codex-plugin/plugin.json
+++ b/plugins/mem0-ops/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "mem0-ops",
   "version": "0.1.0",
-  "description": "Fleet-level mem0 diagnostics and cleanup — complements the upstream mem0 plugin (which owns per-project quality). fleet-scan reports per-app noise ratio, junk app_id candidates, and app/user_id fragmentation across all apps; doctor checks config posture (MEM0_RERANK env, ~/.mem0/settings.json auto_save precedence trap, project decay flag, hook timeout budget, identity fragmentation); cleanup does backup-then-delete by metadata.type or whole junk app behind a dry-run default and per-app confirmation gate. stdlib-only REST scripts, zero LLM cost for the deterministic parts.",
+  "description": "Fleet-level mem0 diagnostics and cleanup — complements the upstream mem0 plugin (which owns per-project quality). fleet-scan reports per-app noise ratio, junk app_id candidates, and app/user_id fragmentation across all apps; doctor checks config posture (MEM0_RERANK env, ~/.mem0/settings.json auto_save precedence trap, project decay flag, hook timeout budget, identity fragmentation); cleanup does backup-then-delete by metadata.type or whole junk app behind a dry-run default plus a skill-layer per-app confirmation gate (the script alone gates on --execute only). stdlib-only REST scripts, zero LLM cost for the deterministic parts.",
   "author": {
     "name": "YoungjaeDev"
   },

--- a/plugins/mem0-ops/CLAUDE.md
+++ b/plugins/mem0-ops/CLAUDE.md
@@ -1,0 +1,15 @@
+# mem0-ops
+
+플릿 레벨 mem0 진단·정리. upstream `mem0@mem0-plugins`(프로젝트 내부 품질:
+health/memory-reviewer/stats/dream)와 역할 분리 — 이 플러그인은 app_id **간**
+운영만 담당한다. 기능 복제 금지.
+
+| Skill | 역할 |
+|---|---|
+| `fleet-scan` | 전 앱 노이즈율·쓰레기 후보·파편화 리포트 (read-only) |
+| `doctor` | 설정 자세 점검 — rerank env, auto_save 파일 우선순위 함정, decay, 훅 timeout, 정체성 파편화 (제안만) |
+| `cleanup` | 백업→타입/앱 단위 삭제. dry-run 기본, `--execute` + 사용자 확인 필수 |
+
+스크립트는 stdlib + REST 직결(`scripts/_api.py`). upstream 스크립트/venv 의존
+없음. `MEM0_API_KEY` 필수. 근거 스펙:
+`docs/superpowers/specs/2026-07-07-mem0-ops-plugin-design.md`.

--- a/plugins/mem0-ops/CLAUDE.md
+++ b/plugins/mem0-ops/CLAUDE.md
@@ -8,7 +8,7 @@ health/memory-reviewer/stats/dream)와 역할 분리 — 이 플러그인은 app
 |---|---|
 | `fleet-scan` | 전 앱 노이즈율·쓰레기 후보·파편화 리포트 (read-only) |
 | `doctor` | 설정 자세 점검 — rerank env, auto_save 파일 우선순위 함정, decay, 훅 timeout, 정체성 파편화 (제안만) |
-| `cleanup` | 백업→타입/앱 단위 삭제. dry-run 기본, `--execute` + 사용자 확인 필수 |
+| `cleanup` | 백업→타입/앱 단위 삭제. dry-run 기본, `--execute` + 스킬 레이어 사용자 확인(스크립트 단독 실행은 `--execute`만 게이트) |
 
 스크립트는 stdlib + REST 직결(`scripts/_api.py`). upstream 스크립트/venv 의존
 없음. `MEM0_API_KEY` 필수. 근거 스펙:

--- a/plugins/mem0-ops/scripts/_api.py
+++ b/plugins/mem0-ops/scripts/_api.py
@@ -57,6 +57,23 @@ def req_json(url, body=None, method=None, retries=3):
     raise last
 
 
+def entity_filters(app, user):
+    """v2 list filters for one app.
+
+    user '*' broadens to every entity scope (user/agent/run) — a bare
+    user_id wildcard only matches rows where user_id is non-null, silently
+    missing agent/run-scoped memories in the same app.
+    """
+    if user == "*":
+        return {
+            "AND": [
+                {"app_id": app},
+                {"OR": [{"user_id": "*"}, {"agent_id": "*"}, {"run_id": "*"}]},
+            ]
+        }
+    return {"AND": [{"user_id": user}, {"app_id": app}]}
+
+
 def list_memories(filters):
     """Page through POST /v2/memories/ (list-by-filter). Returns all rows."""
     mems, page = [], 1

--- a/plugins/mem0-ops/scripts/_api.py
+++ b/plugins/mem0-ops/scripts/_api.py
@@ -60,26 +60,29 @@ def req_json(url, body=None, method=None, retries=3):
 def entity_filters(app, user):
     """v2 list filters for one app.
 
-    user '*' broadens to every entity scope (user/agent/run) — a bare
-    user_id wildcard only matches rows where user_id is non-null, silently
-    missing agent/run-scoped memories in the same app.
+    user '*' means the whole app: filter by app_id alone. Wildcards on
+    user/agent/run only match rows where that field is non-null, so even an
+    OR of all three misses rows written with app_id only (absent entity
+    fields are null per the mem0 entity-scoped docs) — a bare app_id clause
+    is both simpler and complete. Live-verified 2026-07-07.
     """
     if user == "*":
-        return {
-            "AND": [
-                {"app_id": app},
-                {"OR": [{"user_id": "*"}, {"agent_id": "*"}, {"run_id": "*"}]},
-            ]
-        }
+        return {"AND": [{"app_id": app}]}
     return {"AND": [{"user_id": user}, {"app_id": app}]}
 
 
 def list_memories(filters):
-    """Page through POST /v2/memories/ (list-by-filter). Returns all rows."""
+    """Page through POST /v2/memories/ (list-by-filter). Returns all rows.
+
+    show_expired: the list API hides expired memories by default; this
+    helper is the SSOT for cleanup/backup target selection, so expired
+    rows must be visible or teardown reports complete while leaving data.
+    """
     mems, page = [], 1
     while True:
         d = req_json(
-            f"{BASE}/v2/memories/?page={page}&page_size=100", {"filters": filters}
+            f"{BASE}/v2/memories/?page={page}&page_size=100",
+            {"filters": filters, "show_expired": True},
         )
         res = d.get("results", []) if isinstance(d, dict) else d
         mems.extend(res)

--- a/plugins/mem0-ops/scripts/_api.py
+++ b/plugins/mem0-ops/scripts/_api.py
@@ -39,9 +39,12 @@ def req_json(url, body=None, method=None, retries=3):
                 },
             )
             with urllib.request.urlopen(req, timeout=30) as r:
-                if r.status == 204 or not r.length:
+                if r.status == 204:
                     return {}
-                return json.load(r)
+                raw = r.read()
+                if not raw:
+                    return {}
+                return json.loads(raw)
         except urllib.error.HTTPError as e:
             if e.code == 404 and method == "DELETE":
                 return {}
@@ -69,16 +72,22 @@ def list_memories(filters):
     return mems
 
 
-def list_apps():
-    """All app entity names via GET /v1/entities/."""
-    apps, page = [], 1
+def list_entities():
+    """All entity rows via GET /v1/entities/ (paginated, empty-page guarded)."""
+    rows, page = [], 1
     while True:
         d = req_json(f"{BASE}/v1/entities/?page={page}")
-        apps += [e["name"] for e in d["results"] if e["type"] == "app"]
-        if not d.get("next"):
+        res = d.get("results", [])
+        rows.extend(res)
+        if not d.get("next") or not res:
             break
         page += 1
-    return apps
+    return rows
+
+
+def list_apps():
+    """All app entity names via GET /v1/entities/."""
+    return [e["name"] for e in list_entities() if e["type"] == "app"]
 
 
 def resolve_app_id():

--- a/plugins/mem0-ops/scripts/_api.py
+++ b/plugins/mem0-ops/scripts/_api.py
@@ -1,0 +1,121 @@
+"""Shared REST helpers for mem0-ops scripts. stdlib only.
+
+All mem0-ops scripts talk to the mem0 Platform REST API directly
+(v1 entities/delete, v2 list). No dependency on the upstream mem0
+plugin's scripts or venv.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+
+BASE = "https://api.mem0.ai"
+
+
+def api_key() -> str:
+    k = os.environ.get("MEM0_API_KEY")
+    if not k:
+        sys.exit("MEM0_API_KEY not set. mem0-ops requires a mem0 Platform API key.")
+    return k
+
+
+def req_json(url, body=None, method=None, retries=3):
+    """JSON request with 5xx retry/backoff. DELETE 404 is idempotent-ok."""
+    last = None
+    for i in range(retries):
+        try:
+            data = json.dumps(body).encode() if body is not None else None
+            req = urllib.request.Request(
+                url,
+                data=data,
+                method=method,
+                headers={
+                    "Authorization": f"Token {api_key()}",
+                    "Content-Type": "application/json",
+                },
+            )
+            with urllib.request.urlopen(req, timeout=30) as r:
+                if r.status == 204 or not r.length:
+                    return {}
+                return json.load(r)
+        except urllib.error.HTTPError as e:
+            if e.code == 404 and method == "DELETE":
+                return {}
+            if e.code in (500, 502, 503, 504) and i < retries - 1:
+                time.sleep(2**i)
+                last = e
+                continue
+            raise
+    assert last is not None  # loop always returns or raises on final attempt
+    raise last
+
+
+def list_memories(filters):
+    """Page through POST /v2/memories/ (list-by-filter). Returns all rows."""
+    mems, page = [], 1
+    while True:
+        d = req_json(
+            f"{BASE}/v2/memories/?page={page}&page_size=100", {"filters": filters}
+        )
+        res = d.get("results", []) if isinstance(d, dict) else d
+        mems.extend(res)
+        if not isinstance(d, dict) or not d.get("next") or not res:
+            break
+        page += 1
+    return mems
+
+
+def list_apps():
+    """All app entity names via GET /v1/entities/."""
+    apps, page = [], 1
+    while True:
+        d = req_json(f"{BASE}/v1/entities/?page={page}")
+        apps += [e["name"] for e in d["results"] if e["type"] == "app"]
+        if not d.get("next"):
+            break
+        page += 1
+    return apps
+
+
+def resolve_app_id():
+    """Mirror the upstream mem0 plugin's cwd->app_id resolution chain.
+
+    Order: MEM0_PROJECT_ID env -> ~/.mem0/project_map.json[$PWD]
+    -> git remote slug (owner-repo) -> basename fallback.
+    Returns (app_id, source). source == "basename" callers should warn:
+    unmapped dirs are exactly how junk app_ids get created.
+    """
+    env = os.environ.get("MEM0_PROJECT_ID")
+    if env:
+        return env, "env"
+    cwd = os.getcwd()
+    pmap = os.path.expanduser("~/.mem0/project_map.json")
+    if os.path.isfile(pmap):
+        try:
+            mapped = json.load(open(pmap)).get(cwd)
+            if mapped:
+                return mapped, "map"
+        except (json.JSONDecodeError, OSError):
+            pass
+    try:
+        url = subprocess.run(
+            ["git", "remote", "get-url", "origin"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        ).stdout.strip()
+    except (subprocess.SubprocessError, OSError):
+        url = ""
+    if url:
+        slug = url.removesuffix(".git")
+        for p in ("https://", "http://", "ssh://", "git://", "git@"):
+            slug = slug.removeprefix(p)
+        slug = slug.replace(":", "/")
+        parts = [p for p in slug.split("/") if p]
+        if len(parts) >= 2:
+            return f"{parts[-2]}-{parts[-1]}", "git"
+    return os.path.basename(cwd), "basename"

--- a/plugins/mem0-ops/scripts/audit.py
+++ b/plugins/mem0-ops/scripts/audit.py
@@ -14,7 +14,7 @@ import sys
 from collections import Counter, defaultdict
 from datetime import date, datetime
 
-from _api import list_memories, resolve_app_id
+from _api import entity_filters, list_memories, resolve_app_id
 
 STOP = set(
     "a an the and or of to in on for with is are was were be been this that "
@@ -67,7 +67,7 @@ def main():
                 file=sys.stderr,
             )
 
-    mems = list_memories({"AND": [{"user_id": args.user}, {"app_id": app}]})
+    mems = list_memories(entity_filters(app, args.user))
     if args.dump:
         with open(args.dump, "w") as f:
             json.dump(mems, f, ensure_ascii=False)

--- a/plugins/mem0-ops/scripts/audit.py
+++ b/plugins/mem0-ops/scripts/audit.py
@@ -1,0 +1,175 @@
+"""Single-app mem0 audit: duplicates, exclusions compliance, age buckets.
+
+Read-only. Deterministic heuristics only (Jaccard + regex) — no LLM cost.
+Port of the session-proven ~/.mem0/mem0_audit.py (2026-07-07), APP_ID
+constant replaced by --app / cwd scope resolution.
+ponytail: pairwise O(n^2) dup scan within type groups, fine at ~1k memories.
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+from collections import Counter, defaultdict
+from datetime import date, datetime
+
+from _api import list_memories, resolve_app_id
+
+STOP = set(
+    "a an the and or of to in on for with is are was were be been this that "
+    "it its as by from at not no via into during when what which who how "
+    "user assistant session user's".split()
+)
+WORD = re.compile(r"[a-zA-Z가-힣][a-zA-Z0-9_.가-힣-]+")
+
+# Exclusions-compliance heuristics (mirror the GUI custom-instructions Exclusions)
+E_FILELIST = re.compile(r"files touched|listed the files|file list", re.I)
+E_NARRATION = re.compile(
+    r"\b(this session|in the session|during (this|the) session)\b", re.I
+)
+E_TRANSIENT = re.compile(
+    r"\b([0-9a-f]{7,40}|PR ?#\d+|issue ?#\d+|branch [\w/.-]+|run.id|task.id)\b", re.I
+)
+
+
+def toks(text):
+    return {w.lower() for w in WORD.findall(text)} - STOP
+
+
+def jaccard(a, b):
+    return len(a & b) / len(a | b) if a | b else 0.0
+
+
+def age_days(iso, today):
+    try:
+        d = datetime.fromisoformat(iso.replace("Z", "+00:00")).date()
+        return (today - d).days
+    except (ValueError, AttributeError):
+        return None
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Single-app mem0 audit (read-only)")
+    ap.add_argument("--app", help="app_id (default: resolve from cwd)")
+    ap.add_argument("--user", default=os.environ.get("MEM0_USER_ID", "*"))
+    ap.add_argument("--dump", help="write full memory dump JSON to this path")
+    args = ap.parse_args()
+
+    app = args.app
+    if not app:
+        app, source = resolve_app_id()
+        if source == "basename":
+            print(
+                f"WARNING: unmapped directory resolved to '{app}' (basename "
+                f"fallback) — this is how junk app_ids are born. "
+                f"Run from a project root or pass --app.",
+                file=sys.stderr,
+            )
+
+    mems = list_memories({"AND": [{"user_id": args.user}, {"app_id": app}]})
+    if args.dump:
+        with open(args.dump, "w") as f:
+            json.dump(mems, f, ensure_ascii=False)
+
+    today = date.today()
+    by_type = Counter()
+    by_cat = Counter()
+    by_source = Counter()
+    ages = Counter()
+    untagged = []
+    stale = []
+    excl_filelist, excl_narration, excl_transient_only = [], [], []
+    groups = defaultdict(list)
+    oldest, newest = None, None
+
+    for m in mems:
+        md = m.get("metadata") or {}
+        t = md.get("type") or "(none)"
+        by_type[t] += 1
+        cats = m.get("categories") or []
+        c0 = cats[0] if cats else "(none)"
+        if c0 == "auto_capture":
+            c0 = "uncategorized"
+        by_cat[c0] += 1
+        by_source[md.get("source") or "(none)"] += 1
+        text = m.get("memory") or ""
+        a = age_days(m.get("created_at", ""), today)
+        if a is not None:
+            oldest = max(oldest, a) if oldest is not None else a
+            newest = min(newest, a) if newest is not None else a
+            if a < 7:
+                ages["<7d"] += 1
+            elif a < 30:
+                ages["7-30d"] += 1
+            elif a < 90:
+                ages["30-90d"] += 1
+            else:
+                ages[">90d"] += 1
+        if not md.get("type"):
+            untagged.append(m["id"])
+        if t in ("session_state", "compact_summary") and a is not None and a > 90:
+            stale.append((m["id"], t, a))
+        elif (
+            a is not None
+            and a > 180
+            and m.get("updated_at", "")[:10] == m.get("created_at", "")[:10]
+        ):
+            stale.append((m["id"], t, a))
+        tk = toks(text)
+        if E_FILELIST.search(text):
+            excl_filelist.append((m["id"], t, text[:90]))
+        elif E_NARRATION.search(text):
+            excl_narration.append((m["id"], t, text[:90]))
+        if E_TRANSIENT.search(text) and len(tk) <= 12:
+            excl_transient_only.append((m["id"], t, text[:90]))
+        groups[t].append((m["id"], tk, text))
+
+    dups = []
+    for t, items in groups.items():
+        n = len(items)
+        for i in range(n):
+            for j in range(i + 1, n):
+                s = jaccard(items[i][1], items[j][1])
+                if s > 0.6:
+                    dups.append(
+                        (
+                            round(s, 2),
+                            t,
+                            items[i][0],
+                            items[j][0],
+                            items[i][2][:70],
+                            items[j][2][:70],
+                        )
+                    )
+    dups.sort(reverse=True)
+
+    rep = {
+        "app": app,
+        "total": len(mems),
+        "by_type": by_type.most_common(),
+        "by_category": by_cat.most_common(),
+        "by_source": by_source.most_common(),
+        "age_buckets": dict(ages),
+        "oldest_days": oldest,
+        "newest_days": newest,
+        "duplicate_pairs": len(dups),
+        "dup_top20": dups[:20],
+        "untagged": len(untagged),
+        "untagged_ids": untagged[:10],
+        "stale": len(stale),
+        "stale_sample": stale[:10],
+        "excl_violation_filelist": len(excl_filelist),
+        "excl_filelist_sample": excl_filelist[:8],
+        "excl_violation_narration": len(excl_narration),
+        "excl_narration_sample": excl_narration[:8],
+        "excl_transient_only": len(excl_transient_only),
+        "excl_transient_sample": excl_transient_only[:8],
+    }
+    json.dump(rep, sys.stdout, ensure_ascii=False, indent=1, default=str)
+    print()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/mem0-ops/scripts/cleanup.py
+++ b/plugins/mem0-ops/scripts/cleanup.py
@@ -3,7 +3,9 @@
 Safety contract (spec section 6): mandatory full-app JSON backup to
 ~/.mem0/backups/<app>-<timestamp>.json before any DELETE; 5xx retry in
 _api.req_json; DELETE 404 treated as already-deleted (idempotent).
-Restore: re-add backup rows via add_memory with infer=False.
+Restore: re-add only the rows whose id is in the backup's target_ids via
+add_memory with infer=False — the backup stores the whole app for context,
+but only target_ids were actually deleted.
 """
 
 import argparse
@@ -14,7 +16,7 @@ import sys
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 
-from _api import BASE, list_memories, req_json, resolve_app_id
+from _api import BASE, entity_filters, list_memories, req_json, resolve_app_id
 
 
 def select_targets(mems, mem_type=None, all_types=False):
@@ -25,18 +27,21 @@ def select_targets(mems, mem_type=None, all_types=False):
     return [m["id"] for m in mems if (m.get("metadata") or {}).get("type") == mem_type]
 
 
-def backup(app, mems):
+def backup(app, mems, target_ids):
     bdir = os.path.expanduser("~/.mem0/backups")
     os.makedirs(bdir, exist_ok=True)
     # app is user-controlled (--app / env / project_map) — sanitize the filename
     # component so absolute paths or separators cannot escape the backup dir,
     # and timestamp per run so a same-day second cleanup never overwrites the
-    # only recovery copy of the first.
+    # only recovery copy of the first. target_ids records what was actually
+    # deleted so a partial (--type) restore never re-adds untouched rows.
     safe = re.sub(r"[^A-Za-z0-9._-]", "_", app) or "app"
     stamp = datetime.now().strftime("%Y-%m-%dT%H%M%S")
     path = os.path.join(bdir, f"{safe}-{stamp}.json")
     with open(path, "w") as f:
-        json.dump(mems, f, ensure_ascii=False)
+        json.dump(
+            {"app": app, "target_ids": target_ids, "rows": mems}, f, ensure_ascii=False
+        )
     return path
 
 
@@ -76,8 +81,13 @@ def main():
         user = args.user
     elif args.all:
         user = "*"
+    elif os.environ.get("MEM0_USER_ID"):
+        user = os.environ["MEM0_USER_ID"]
     else:
-        user = os.environ.get("MEM0_USER_ID", "*")
+        sys.exit(
+            "--type needs an explicit scope: pass --user or set "
+            "MEM0_USER_ID (only --all may target every user)."
+        )
     app = args.app
     if not app:
         app, source = resolve_app_id()
@@ -86,7 +96,7 @@ def main():
                 f"refusing to run against basename-fallback scope "
                 f"'{app}' — run from a project root or pass --app."
             )
-    mems = list_memories({"AND": [{"user_id": user}, {"app_id": app}]})
+    mems = list_memories(entity_filters(app, user))
     targets = select_targets(mems, mem_type=args.mem_type, all_types=args.all)
     print(
         f"app={app} user={user} total={len(mems)} targets={len(targets)} "
@@ -102,7 +112,7 @@ def main():
     if not targets:
         print("nothing to delete")
         return 0
-    path = backup(app, mems)
+    path = backup(app, mems, targets)
     print(f"backup: {path}")
     with ThreadPoolExecutor(max_workers=8) as ex:
         results = list(ex.map(delete_one, targets))

--- a/plugins/mem0-ops/scripts/cleanup.py
+++ b/plugins/mem0-ops/scripts/cleanup.py
@@ -1,7 +1,7 @@
 """Backup-then-delete mem0 cleanup. --dry-run is the default; --execute deletes.
 
 Safety contract (spec section 6): mandatory full-app JSON backup to
-~/.mem0/backups/<app>-<YYYY-MM-DD>.json before any DELETE; 5xx retry in
+~/.mem0/backups/<app>-<timestamp>.json before any DELETE; 5xx retry in
 _api.req_json; DELETE 404 treated as already-deleted (idempotent).
 Restore: re-add backup rows via add_memory with infer=False.
 """
@@ -9,9 +9,10 @@ Restore: re-add backup rows via add_memory with infer=False.
 import argparse
 import json
 import os
+import re
 import sys
 from concurrent.futures import ThreadPoolExecutor
-from datetime import date
+from datetime import datetime
 
 from _api import BASE, list_memories, req_json, resolve_app_id
 
@@ -27,7 +28,13 @@ def select_targets(mems, mem_type=None, all_types=False):
 def backup(app, mems):
     bdir = os.path.expanduser("~/.mem0/backups")
     os.makedirs(bdir, exist_ok=True)
-    path = os.path.join(bdir, f"{app}-{date.today().isoformat()}.json")
+    # app is user-controlled (--app / env / project_map) — sanitize the filename
+    # component so absolute paths or separators cannot escape the backup dir,
+    # and timestamp per run so a same-day second cleanup never overwrites the
+    # only recovery copy of the first.
+    safe = re.sub(r"[^A-Za-z0-9._-]", "_", app) or "app"
+    stamp = datetime.now().strftime("%Y-%m-%dT%H%M%S")
+    path = os.path.join(bdir, f"{safe}-{stamp}.json")
     with open(path, "w") as f:
         json.dump(mems, f, ensure_ascii=False)
     return path
@@ -44,7 +51,13 @@ def delete_one(mid):
 def main():
     ap = argparse.ArgumentParser(description="mem0 backup-then-delete cleanup")
     ap.add_argument("--app", help="app_id (default: resolve from cwd)")
-    ap.add_argument("--user", default=os.environ.get("MEM0_USER_ID", "*"))
+    ap.add_argument(
+        "--user",
+        default=None,
+        help="user_id filter (default: MEM0_USER_ID env; "
+        "--all defaults to '*' so whole-app teardown "
+        "never silently inherits one user)",
+    )
     ap.add_argument(
         "--type",
         dest="mem_type",
@@ -59,6 +72,12 @@ def main():
     args = ap.parse_args()
     if not args.mem_type and not args.all:
         sys.exit("pass --type <metadata.type> or --all")
+    if args.user:
+        user = args.user
+    elif args.all:
+        user = "*"
+    else:
+        user = os.environ.get("MEM0_USER_ID", "*")
     app = args.app
     if not app:
         app, source = resolve_app_id()
@@ -67,10 +86,10 @@ def main():
                 f"refusing to run against basename-fallback scope "
                 f"'{app}' — run from a project root or pass --app."
             )
-    mems = list_memories({"AND": [{"user_id": args.user}, {"app_id": app}]})
+    mems = list_memories({"AND": [{"user_id": user}, {"app_id": app}]})
     targets = select_targets(mems, mem_type=args.mem_type, all_types=args.all)
     print(
-        f"app={app} total={len(mems)} targets={len(targets)} "
+        f"app={app} user={user} total={len(mems)} targets={len(targets)} "
         f"selector={'ALL' if args.all else args.mem_type}"
     )
     if not args.execute:

--- a/plugins/mem0-ops/scripts/cleanup.py
+++ b/plugins/mem0-ops/scripts/cleanup.py
@@ -1,0 +1,99 @@
+"""Backup-then-delete mem0 cleanup. --dry-run is the default; --execute deletes.
+
+Safety contract (spec section 6): mandatory full-app JSON backup to
+~/.mem0/backups/<app>-<YYYY-MM-DD>.json before any DELETE; 5xx retry in
+_api.req_json; DELETE 404 treated as already-deleted (idempotent).
+Restore: re-add backup rows via add_memory with infer=False.
+"""
+
+import argparse
+import json
+import os
+import sys
+from concurrent.futures import ThreadPoolExecutor
+from datetime import date
+
+from _api import BASE, list_memories, req_json, resolve_app_id
+
+
+def select_targets(mems, mem_type=None, all_types=False):
+    if all_types:
+        return [m["id"] for m in mems]
+    if not mem_type:
+        return []
+    return [m["id"] for m in mems if (m.get("metadata") or {}).get("type") == mem_type]
+
+
+def backup(app, mems):
+    bdir = os.path.expanduser("~/.mem0/backups")
+    os.makedirs(bdir, exist_ok=True)
+    path = os.path.join(bdir, f"{app}-{date.today().isoformat()}.json")
+    with open(path, "w") as f:
+        json.dump(mems, f, ensure_ascii=False)
+    return path
+
+
+def delete_one(mid):
+    try:
+        req_json(f"{BASE}/v1/memories/{mid}/", method="DELETE")
+        return mid, "ok"
+    except Exception as e:  # 부분 실패 리포트용 — 전체 중단 금지
+        return mid, f"ERR:{e}"
+
+
+def main():
+    ap = argparse.ArgumentParser(description="mem0 backup-then-delete cleanup")
+    ap.add_argument("--app", help="app_id (default: resolve from cwd)")
+    ap.add_argument("--user", default=os.environ.get("MEM0_USER_ID", "*"))
+    ap.add_argument(
+        "--type",
+        dest="mem_type",
+        help="delete only this metadata.type (e.g. session_summary)",
+    )
+    ap.add_argument(
+        "--all", action="store_true", help="delete the whole app (junk app_id teardown)"
+    )
+    ap.add_argument(
+        "--execute", action="store_true", help="actually delete; default is dry-run"
+    )
+    args = ap.parse_args()
+    if not args.mem_type and not args.all:
+        sys.exit("pass --type <metadata.type> or --all")
+    app = args.app
+    if not app:
+        app, source = resolve_app_id()
+        if source == "basename":
+            sys.exit(
+                f"refusing to run against basename-fallback scope "
+                f"'{app}' — run from a project root or pass --app."
+            )
+    mems = list_memories({"AND": [{"user_id": args.user}, {"app_id": app}]})
+    targets = select_targets(mems, mem_type=args.mem_type, all_types=args.all)
+    print(
+        f"app={app} total={len(mems)} targets={len(targets)} "
+        f"selector={'ALL' if args.all else args.mem_type}"
+    )
+    if not args.execute:
+        target_set = set(targets[:5])
+        for m in mems:
+            if m["id"] in target_set:
+                print(f"  sample: [{m['id'][:8]}] {(m.get('memory') or '')[:80]}")
+        print("dry-run (pass --execute to delete)")
+        return 0
+    if not targets:
+        print("nothing to delete")
+        return 0
+    path = backup(app, mems)
+    print(f"backup: {path}")
+    with ThreadPoolExecutor(max_workers=8) as ex:
+        results = list(ex.map(delete_one, targets))
+    ok = sum(1 for _, s in results if s == "ok")
+    errs = [(m, s) for m, s in results if s != "ok"]
+    print(f"deleted ok={ok} failed={len(errs)}")
+    for m, s in errs[:10]:
+        print(f"  FAIL {m} {s}")
+    return 1 if errs else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/mem0-ops/scripts/doctor.py
+++ b/plugins/mem0-ops/scripts/doctor.py
@@ -12,7 +12,7 @@ import os
 import sys
 from collections import Counter
 
-from _api import BASE, req_json
+from _api import BASE, list_entities, req_json
 
 
 def check(label, ok, detail):
@@ -45,8 +45,14 @@ def main():
         decay = req_json(f"{BASE}/api/v1/orgs/projects/?fields=decay")
     except Exception:
         decay = None
-    if isinstance(decay, dict) and "decay" in str(decay):
-        check("decay", True, f"project response: {json.dumps(decay)[:80]}")
+    if isinstance(decay, dict) and "decay" in decay:
+        val = decay.get("decay")
+        check(
+            "decay",
+            bool(val),
+            f"project decay={val}"
+            + ("" if val else " (search-time ranking decay disabled)"),
+        )
     else:
         print(
             "INFO  decay                  could not read via REST "
@@ -71,14 +77,7 @@ def main():
         except (KeyError, IndexError, json.JSONDecodeError, OSError):
             continue
 
-    users, page = Counter(), 1
-    while True:
-        d = req_json(f"{BASE}/v1/entities/?page={page}")
-        for e in d["results"]:
-            users[e["type"]] += 1
-        if not d.get("next"):
-            break
-        page += 1
+    users = Counter(e["type"] for e in list_entities())
     check(
         "identity",
         users.get("user", 0) <= 2,

--- a/plugins/mem0-ops/scripts/doctor.py
+++ b/plugins/mem0-ops/scripts/doctor.py
@@ -1,0 +1,92 @@
+"""mem0 config posture check. Read-only, machine+account level.
+
+Checks (spec section 5): MEM0_RERANK env, ~/.mem0/settings.json auto_save
+(the file, not env, is authoritative — upstream _identity.sh overwrites the
+env from this file on every hook run), project decay flag via REST,
+upstream hook timeout budget, identity fragmentation.
+"""
+
+import glob
+import json
+import os
+import sys
+from collections import Counter
+
+from _api import BASE, req_json
+
+
+def check(label, ok, detail):
+    print(f"{'PASS' if ok else 'WARN'}  {label:<22} {detail}")
+
+
+def main():
+    rerank = os.environ.get("MEM0_RERANK", "")
+    check(
+        "MEM0_RERANK",
+        rerank.strip().lower() in ("0", "false", "no", "off"),
+        f"env={rerank or '(unset -> rerank ON, against mem0 best practice)'}",
+    )
+
+    spath = os.path.expanduser("~/.mem0/settings.json")
+    auto_save = True
+    if os.path.isfile(spath):
+        try:
+            auto_save = json.load(open(spath)).get("auto_save", True)
+        except (json.JSONDecodeError, OSError):
+            pass
+    check(
+        "auto_save",
+        auto_save is False,
+        f"~/.mem0/settings.json auto_save={auto_save} "
+        f"(this file governs; env MEM0_AUTO_SAVE is overwritten per hook)",
+    )
+
+    try:
+        decay = req_json(f"{BASE}/api/v1/orgs/projects/?fields=decay")
+    except Exception:
+        decay = None
+    if isinstance(decay, dict) and "decay" in str(decay):
+        check("decay", True, f"project response: {json.dumps(decay)[:80]}")
+    else:
+        print(
+            "INFO  decay                  could not read via REST "
+            "(verify in GUI or SDK: client.project.get(fields=['decay']))"
+        )
+
+    hooks = glob.glob(
+        os.path.expanduser(
+            "~/.claude/plugins/cache/mem0-plugins/mem0/*/hooks/hooks.json"
+        )
+    )
+    for h in sorted(hooks):
+        try:
+            cfg = json.load(open(h))
+            ups = cfg["hooks"]["UserPromptSubmit"][0]["hooks"][0].get("timeout")
+            check(
+                "hook timeout",
+                (ups or 0) >= 10,
+                f"{h.split('/cache/')[-1]} UserPromptSubmit timeout={ups}s "
+                f"(8s budget overruns on resume-type prompts)",
+            )
+        except (KeyError, IndexError, json.JSONDecodeError, OSError):
+            continue
+
+    users, page = Counter(), 1
+    while True:
+        d = req_json(f"{BASE}/v1/entities/?page={page}")
+        for e in d["results"]:
+            users[e["type"]] += 1
+        if not d.get("next"):
+            break
+        page += 1
+    check(
+        "identity",
+        users.get("user", 0) <= 2,
+        f"entities: {users.get('user', 0)} users, {users.get('app', 0)} apps "
+        f"(>2 users = fragmentation; recall splits across user_ids)",
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/mem0-ops/scripts/fleet_scan.py
+++ b/plugins/mem0-ops/scripts/fleet_scan.py
@@ -1,0 +1,85 @@
+"""Fleet-wide mem0 scan: per-app noise ratio, type mix, fragmentation.
+
+Read-only. Junk heuristic: basename-looking name (no owner- prefix pattern
+match to a sibling), noise >= 90%, zero manually-typed memories.
+Fragmentation: app A whose name is a suffix of app B (owner-prefixed pair).
+"""
+
+import sys
+from collections import Counter
+
+from _api import list_apps, list_memories
+
+MANUAL_TYPES = {
+    "decision",
+    "feedback",
+    "task_learning",
+    "convention",
+    "anti_pattern",
+    "user_preference",
+    "project_profile",
+    "project",
+}
+NOISE_TYPES = {"session_summary", "compact_summary", "session_state"}
+
+
+def scan_app(app):
+    mems = list_memories({"AND": [{"user_id": "*"}, {"app_id": app}]})
+    types = Counter((m.get("metadata") or {}).get("type") or "(none)" for m in mems)
+    users = Counter(m.get("user_id") for m in mems)
+    noise = sum(n for t, n in types.items() if t in NOISE_TYPES)
+    manual = sum(n for t, n in types.items() if t in MANUAL_TYPES)
+    return {
+        "app": app,
+        "total": len(mems),
+        "noise": noise,
+        "manual": manual,
+        "users": users,
+        "types": types,
+    }
+
+
+def fragmentation_pairs(apps):
+    pairs = []
+    for a in apps:
+        for b in apps:
+            if a != b and b.endswith("-" + a):
+                pairs.append((a, b))
+    return pairs
+
+
+def main():
+    apps = list_apps()
+    rows = [scan_app(a) for a in apps]
+    rows.sort(key=lambda r: -r["total"])
+    frag = fragmentation_pairs(apps)
+    frag_names = {a for pair in frag for a in pair}
+    print(f"{'total':>6} {'noise%':>6}  app  [flags]  [user split]")
+    grand = grand_noise = 0
+    for r in rows:
+        if not r["total"]:
+            continue
+        grand += r["total"]
+        grand_noise += r["noise"]
+        pct = 100 * r["noise"] // r["total"]
+        flags = []
+        if pct >= 90 and r["manual"] == 0 and "-" not in r["app"]:
+            flags.append("JUNK?")
+        if r["app"] in frag_names:
+            flags.append("FRAG")
+        u = ",".join(f"{k}:{v}" for k, v in r["users"].most_common())
+        print(f"{r['total']:>6} {pct:>5}%  {r['app']}  [{' '.join(flags)}]  [{u}]")
+    print(
+        f"\nGRAND total={grand} noise={grand_noise} "
+        f"({100 * grand_noise // max(grand, 1)}%) across "
+        f"{sum(1 for r in rows if r['total'])} active apps"
+    )
+    if frag:
+        print("\nFragmentation pairs (report-only; merge is out of scope v1):")
+        for a, b in frag:
+            print(f"  {a}  <->  {b}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/mem0-ops/scripts/fleet_scan.py
+++ b/plugins/mem0-ops/scripts/fleet_scan.py
@@ -8,7 +8,7 @@ Fragmentation: app A whose name is a suffix of app B (owner-prefixed pair).
 import sys
 from collections import Counter
 
-from _api import list_apps, list_memories
+from _api import entity_filters, list_apps, list_memories
 
 MANUAL_TYPES = {
     "decision",
@@ -24,7 +24,7 @@ NOISE_TYPES = {"session_summary", "compact_summary", "session_state"}
 
 
 def scan_app(app):
-    mems = list_memories({"AND": [{"user_id": "*"}, {"app_id": app}]})
+    mems = list_memories(entity_filters(app, "*"))
     types = Counter((m.get("metadata") or {}).get("type") or "(none)" for m in mems)
     users = Counter(m.get("user_id") for m in mems)
     noise = sum(n for t, n in types.items() if t in NOISE_TYPES)

--- a/plugins/mem0-ops/skills/cleanup/SKILL.md
+++ b/plugins/mem0-ops/skills/cleanup/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: cleanup
+description: "Backup-then-delete mem0 noise for one app (default: current project's app_id resolved from cwd like the upstream plugin does) or any app via --app. Dry-run is the default; deletion requires --execute and per-app user confirmation. Full-app teardown (--all) for junk app_ids. Always writes a JSON backup to ~/.mem0/backups/ first; restore = re-add with infer=False. Use for 'mem0 정리', 'session_summary 삭제', junk app teardown after fleet-scan."
+---
+
+# cleanup
+
+## Hermes/Codex note
+
+Script is plain `python3` on all runtimes. The confirmation gate uses
+`AskUserQuestion` on Claude; on Codex/Hermes ask in plain text and wait
+(Hermes: `clarify`).
+
+## Steps
+
+1. Resolve scope: no args = current project (script mirrors upstream chain:
+   `MEM0_PROJECT_ID` env -> `~/.mem0/project_map.json` -> git slug -> basename).
+   The script REFUSES basename-fallback scope; pass `--app` explicitly then.
+2. Dry-run first, always:
+   `python3 ${CLAUDE_PLUGIN_ROOT}/scripts/cleanup.py [--app X] --type session_summary`
+   (or `--all` for a junk app teardown flagged by fleet-scan).
+3. Show the dry-run count + samples to the user, then gate with
+   AskUserQuestion (one question per app: delete N of M? yes/no).
+4. Only after explicit yes: re-run with `--execute`. Report ok/failed counts
+   and the backup path.
+5. Verify: run `python3 ${CLAUDE_PLUGIN_ROOT}/scripts/audit.py --app X` and
+   confirm the deleted type count is now 0.
+6. Restore procedure (if the user regrets): read the backup JSON at
+   `~/.mem0/backups/<app>-<date>.json` and re-add each row via mem0
+   `add_memory` with `infer=False`, same app_id/user_id/metadata.

--- a/plugins/mem0-ops/skills/cleanup/SKILL.md
+++ b/plugins/mem0-ops/skills/cleanup/SKILL.md
@@ -9,22 +9,41 @@ description: "Backup-then-delete mem0 noise for one app (default: current projec
 
 Script is plain `python3` on all runtimes. The confirmation gate uses
 `AskUserQuestion` on Claude; on Codex/Hermes ask in plain text and wait
-(Hermes: `clarify`).
+(Hermes: `clarify`). Codex 0.135 does NOT export `CLAUDE_PLUGIN_ROOT` —
+always resolve `PLUGIN_ROOT` first (block below).
 
 ## Steps
 
-1. Resolve scope: no args = current project (script mirrors upstream chain:
+1. Resolve the plugin root (cross-runtime):
+
+   ```bash
+   PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-}"
+   [ -z "$PLUGIN_ROOT" ] && [ -d plugins/mem0-ops/scripts ] && PLUGIN_ROOT=plugins/mem0-ops
+   if [ -z "$PLUGIN_ROOT" ]; then
+     cache_root="${CODEX_PLUGIN_CACHE:-$HOME/.codex/plugins/cache}"
+     PLUGIN_ROOT=$(ls -1d "$cache_root"/*/mem0-ops/* 2>/dev/null | sort | tail -1)
+   fi
+   [ -d "$PLUGIN_ROOT/scripts" ] || { echo "mem0-ops scripts not found"; exit 1; }
+   ```
+
+   Scope: no args = current project (script mirrors upstream chain:
    `MEM0_PROJECT_ID` env -> `~/.mem0/project_map.json` -> git slug -> basename).
    The script REFUSES basename-fallback scope; pass `--app` explicitly then.
+   `--type` additionally requires a user scope (`--user` or `MEM0_USER_ID`);
+   only `--all` targets every entity scope (user/agent/run) in the app.
 2. Dry-run first, always:
-   `python3 ${CLAUDE_PLUGIN_ROOT}/scripts/cleanup.py [--app X] --type session_summary`
+   `python3 "$PLUGIN_ROOT/scripts/cleanup.py" [--app X] --type session_summary`
    (or `--all` for a junk app teardown flagged by fleet-scan).
 3. Show the dry-run count + samples to the user, then gate with
    AskUserQuestion (one question per app: delete N of M? yes/no).
 4. Only after explicit yes: re-run with `--execute`. Report ok/failed counts
    and the backup path.
-5. Verify: run `python3 ${CLAUDE_PLUGIN_ROOT}/scripts/audit.py --app X` and
+5. Verify: run `python3 "$PLUGIN_ROOT/scripts/audit.py" --app X` and
    confirm the deleted type count is now 0.
 6. Restore procedure (if the user regrets): read the backup JSON at
-   `~/.mem0/backups/<app>-<date>.json` and re-add each row via mem0
-   `add_memory` with `infer=False`, same app_id/user_id/metadata.
+   `~/.mem0/backups/<app>-<timestamp>.json` — it holds `{app, target_ids,
+   rows}` where `rows` is the WHOLE app at backup time and `target_ids`
+   lists what was actually deleted. Re-add ONLY the rows whose id is in
+   `target_ids` via mem0 `add_memory` with `infer=False`, same
+   app_id/user_id/metadata — re-adding all rows would duplicate the
+   untouched ones.

--- a/plugins/mem0-ops/skills/doctor/SKILL.md
+++ b/plugins/mem0-ops/skills/doctor/SKILL.md
@@ -7,12 +7,24 @@ description: "Check mem0 configuration posture on this machine — MEM0_RERANK e
 
 ## Hermes/Codex note
 
-Runs the same on Claude and Codex (script is plain `python3`). On Hermes,
-`Bash` maps to `terminal`.
+Script is plain `python3` on all runtimes. On Hermes, `Bash` maps to
+`terminal`. Codex 0.135 does NOT export `CLAUDE_PLUGIN_ROOT` — always
+resolve `PLUGIN_ROOT` first (block below).
 
 ## Steps
 
-1. Run `python3 ${CLAUDE_PLUGIN_ROOT}/scripts/doctor.py`.
+1. Resolve the plugin root (cross-runtime), then run the check:
+
+   ```bash
+   PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-}"
+   [ -z "$PLUGIN_ROOT" ] && [ -d plugins/mem0-ops/scripts ] && PLUGIN_ROOT=plugins/mem0-ops
+   if [ -z "$PLUGIN_ROOT" ]; then
+     cache_root="${CODEX_PLUGIN_CACHE:-$HOME/.codex/plugins/cache}"
+     PLUGIN_ROOT=$(ls -1d "$cache_root"/*/mem0-ops/* 2>/dev/null | sort | tail -1)
+   fi
+   [ -d "$PLUGIN_ROOT/scripts" ] || { echo "mem0-ops scripts not found"; exit 1; }
+   python3 "$PLUGIN_ROOT/scripts/doctor.py"
+   ```
 2. For each WARN, explain the fix but do NOT apply automatically:
    - MEM0_RERANK unset -> add `"MEM0_RERANK": "off"` to `~/.claude/settings.json` env.
    - auto_save true -> set `"auto_save": false` in `~/.mem0/settings.json`

--- a/plugins/mem0-ops/skills/doctor/SKILL.md
+++ b/plugins/mem0-ops/skills/doctor/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: doctor
+description: "Check mem0 configuration posture on this machine — MEM0_RERANK env (unset means rerank ON, against mem0's own best practice), ~/.mem0/settings.json auto_save (the file overrides env on every hook run — common trap), project decay flag, upstream hook UserPromptSubmit timeout budget, and user_id/app_id identity fragmentation. Read-only; suggests fixes but never applies them. Use for 'mem0 설정 점검', hook timeout complaints, or after installing mem0 on a new machine."
+---
+
+# doctor
+
+## Hermes/Codex note
+
+Runs the same on Claude and Codex (script is plain `python3`). On Hermes,
+`Bash` maps to `terminal`.
+
+## Steps
+
+1. Run `python3 ${CLAUDE_PLUGIN_ROOT}/scripts/doctor.py`.
+2. For each WARN, explain the fix but do NOT apply automatically:
+   - MEM0_RERANK unset -> add `"MEM0_RERANK": "off"` to `~/.claude/settings.json` env.
+   - auto_save true -> set `"auto_save": false` in `~/.mem0/settings.json`
+     (env MEM0_AUTO_SAVE does NOT work — upstream `_identity.sh` overwrites it
+     from this file on every hook run).
+   - hook timeout 8s -> raising it means editing the plugin cache copy, which
+     resets on update; prefer rerank off first, upstream issue second.
+     Multiple cached versions may be listed — only the session-pinned one is live.
+   - identity fragmentation -> consolidate `MEM0_USER_ID` across machines.
+3. decay INFO line: if the REST read failed, tell the user to check the GUI
+   toggle or run `client.project.get(fields=["decay"])` via the mem0 SDK.

--- a/plugins/mem0-ops/skills/fleet-scan/SKILL.md
+++ b/plugins/mem0-ops/skills/fleet-scan/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: fleet-scan
+description: "Scan ALL mem0 app_ids at once — per-app memory count, noise ratio (session_summary and friends), junk app_id candidates (JUNK? flag), and app/user_id fragmentation pairs. Read-only, deterministic script, zero LLM cost. Use when the user asks for a mem0-wide overview, 'which projects are noisy', 'mem0 전체 점검', or before a cleanup round. Per-project quality (duplicates inside one app) belongs to the upstream mem0 plugin's memory-reviewer instead."
+---
+
+# fleet-scan
+
+## Hermes/Codex note
+
+Runs the same on Claude and Codex (script is plain `python3`). On Hermes,
+`Bash` maps to `terminal`.
+
+## Steps
+
+1. Run `python3 ${CLAUDE_PLUGIN_ROOT}/scripts/fleet_scan.py`.
+   - Requires `MEM0_API_KEY`; the script exits with guidance if unset.
+   - Full-fleet scan pages every app — expect ~1-2 minutes on large stores.
+2. Interpret the report for the user:
+   - `JUNK?` flag = basename-style name + noise >= 90% + zero manual types.
+     These are cwd-fallback artifacts; suggest `cleanup --app <name> --all`.
+   - `FRAG` pairs = same project split across two app_ids (recall is split).
+     Merge is out of scope v1 — report only.
+   - High noise% on a real project = suggest
+     `cleanup --app <name> --type session_summary`.
+3. Do NOT delete anything from this skill. Route to the cleanup skill.

--- a/plugins/mem0-ops/skills/fleet-scan/SKILL.md
+++ b/plugins/mem0-ops/skills/fleet-scan/SKILL.md
@@ -7,12 +7,25 @@ description: "Scan ALL mem0 app_ids at once — per-app memory count, noise rati
 
 ## Hermes/Codex note
 
-Runs the same on Claude and Codex (script is plain `python3`). On Hermes,
-`Bash` maps to `terminal`.
+Script is plain `python3` on all runtimes. On Hermes, `Bash` maps to
+`terminal`. Codex 0.135 does NOT export `CLAUDE_PLUGIN_ROOT` — always
+resolve `PLUGIN_ROOT` first (block below).
 
 ## Steps
 
-1. Run `python3 ${CLAUDE_PLUGIN_ROOT}/scripts/fleet_scan.py`.
+1. Resolve the plugin root (cross-runtime), then run the scan:
+
+   ```bash
+   PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-}"
+   [ -z "$PLUGIN_ROOT" ] && [ -d plugins/mem0-ops/scripts ] && PLUGIN_ROOT=plugins/mem0-ops
+   if [ -z "$PLUGIN_ROOT" ]; then
+     cache_root="${CODEX_PLUGIN_CACHE:-$HOME/.codex/plugins/cache}"
+     PLUGIN_ROOT=$(ls -1d "$cache_root"/*/mem0-ops/* 2>/dev/null | sort | tail -1)
+   fi
+   [ -d "$PLUGIN_ROOT/scripts" ] || { echo "mem0-ops scripts not found"; exit 1; }
+   python3 "$PLUGIN_ROOT/scripts/fleet_scan.py"
+   ```
+
    - Requires `MEM0_API_KEY`; the script exits with guidance if unset.
    - Full-fleet scan pages every app — expect ~1-2 minutes on large stores.
 2. Interpret the report for the user:

--- a/plugins/mem0-ops/tests/test_cleanup_targets.py
+++ b/plugins/mem0-ops/tests/test_cleanup_targets.py
@@ -1,0 +1,30 @@
+"""Pure-logic tests for cleanup target selection. No network."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+from cleanup import select_targets
+
+MEMS = [
+    {"id": "a", "metadata": {"type": "session_summary"}},
+    {"id": "b", "metadata": {"type": "decision"}},
+    {"id": "c", "metadata": None},
+    {"id": "d"},
+]
+
+
+def test_type_filter_selects_only_matching():
+    assert select_targets(MEMS, mem_type="session_summary") == ["a"]
+
+
+def test_all_selects_everything():
+    assert select_targets(MEMS, all_types=True) == ["a", "b", "c", "d"]
+
+
+def test_no_selector_selects_nothing():
+    assert select_targets(MEMS) == []
+
+
+def test_missing_metadata_never_matches_type():
+    assert select_targets(MEMS, mem_type="decision") == ["b"]


### PR DESCRIPTION
Closes #96

## 요약

플릿 레벨 mem0 진단·정리 플러그인. upstream `mem0@mem0-plugins`(프로젝트 내부 품질, 200건 캡)와 역할 분리 — app_id 간 운영 전용. 스크립트는 stdlib + REST 직결(v1 entities/delete, v2 list), 결정론 구간 LLM 비용 0.

- Spec: `docs/superpowers/specs/2026-07-07-mem0-ops-plugin-design.md`
- Plan: `docs/superpowers/plans/2026-07-07-mem0-ops-plugin.md`

## 구성

| 스킬 | 스코프 | 동작 |
|---|---|---|
| fleet-scan | 전역 | 앱별 노이즈율·JUNK? 후보·FRAG 파편화 쌍 리포트 (read-only) |
| doctor | 전역 | rerank env / auto_save 파일 우선순위 함정 / decay / 훅 timeout / 정체성 파편화 점검 (제안만) |
| cleanup | cwd 프로젝트 (upstream 해석 체인 미러, basename fallback 거부) | 백업 필수 → 타입/앱 단위 삭제, dry-run 기본 + --execute + 앱별 확인 게이트 |

스크립트 4종: `_api.py`(공유 REST + 스코프 해석) / `fleet_scan.py` / `audit.py`(세션 검증 원형 이식) / `cleanup.py` / `doctor.py`

## 검증 (전부 실행 완료)

- `py_compile` 5/5, pytest 4 passed (`select_targets` 순수 로직), 스킬 frontmatter YAML 파싱 + desc<1024 OK
- 라이브 스모크: fleet_scan(10,009건/35앱, FRAG 8쌍 검출) · audit(230건, 정리 후 실측 일치) · cleanup dry-run(no-op) · doctor(rerank off·auto_save false PASS, timeout 8s·identity 9 users WARN)
- 수용 검증(스펙 §10): `tmp` 쓰레기 앱 57건 — dry-run 57 → execute ok=57 failed=0 → audit 0건 → 백업 `~/.mem0/backups/tmp-2026-07-07.json` 41KB
- `sync-codex-manifests --check` + `sync-hermes-manifests --check` 통과 (Codex 매니페스트 23개 생성, Hermes adapter 미생성 확인 — allowlist 밖)

## fan-out (plugin-versioning.md 계약)

marketplace `metadata.version` 1.83.0→1.84.0 · 카운트 23→24 (CLAUDE.md/README 배지·문장·트리) · Codex eligible 21→22 (CLAUDE.md/README/AGENTS.md `# 22 entries`) · `.claude/settings.json` plugins.local 등록

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `mem0-ops` 플러그인 추가: 전체 앱 단위 스캔(fleet-scan), 설정/환경 점검(doctor), 백업 후 정리(cleanup, 기본 dry-run).
  * 설치 가능/설치 시 인증 구성으로 플러그인 목록 및 표시 개수(23→24)에 반영.
* **Documentation**
  * README/CLAUDE/AGENTS 및 설치 메타데이터 업데이트: `mem0-ops` 스킬별 절차, `MEM0_API_KEY` 전제, 실행 제약 안내.
* **Tests**
  * cleanup 대상 선택 로직 관련 테스트 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->