### PR TITLE
fix(llm-wiki): 훅 결함 — post_commit merge 힌트 미발동 [HIGH] + capture SubagentStop 커버리지

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -117,7 +117,7 @@
       "name": "llm-wiki",
       "source": "./plugins/llm-wiki",
       "description": "Karpathy LLM-Wiki 3-layer (insight + wiki + raw under neutral .llmwiki/): 5 skills (query/ingest/lint/bootstrap/migrate) + 5 hooks + bootstrap templates. Three soft hints plus an auto-capture/ingest path: a Stop hook mechanically captures ingest candidates to <root>/.staging/ and the next session's SessionStart drain hook surfaces them for ingest-finding curation (capture and curation split). Post-merge wiki ingest is a mandatory, force-logged step inside github-dev:post-merge (the standalone post-merge-wiki skill was removed — breaking, hence the 2.0.0 major bump). Promoted cross-agent rules graduate to .llmwiki/insight/ (via core-config prompt-inject hook), not .claude/rules/. Resolves .llmwiki/wiki -> legacy .claude/wiki -> .codex/wiki. Agent-facing wiki conventions deduped into references/wiki-conventions.md.",
-      "version": "2.4.1",
+      "version": "2.5.0",
       "category": "memory"
     },
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Personal Claude Code plugin collection with 24 specialized plugins. Codex 0.135 + Hermes Agent native — generated `.agents/plugins/marketplace.json` + per-plugin `.codex-plugin/plugin.json` (`scripts/sync-codex-manifests.mjs`) and Hermes `plugin.yaml` + `__init__.py` adapters (`scripts/sync-hermes-manifests.mjs`).",
-    "version": "1.85.0"
+    "version": "1.86.0"
   },
   "plugins": [
     {
@@ -117,7 +117,7 @@
       "name": "llm-wiki",
       "source": "./plugins/llm-wiki",
       "description": "Karpathy LLM-Wiki 3-layer (insight + wiki + raw under neutral .llmwiki/): 5 skills (query/ingest/lint/bootstrap/migrate) + 5 hooks + bootstrap templates. Three soft hints plus an auto-capture/ingest path: a Stop hook mechanically captures ingest candidates to <root>/.staging/ and the next session's SessionStart drain hook surfaces them for ingest-finding curation (capture and curation split). Post-merge wiki ingest is a mandatory, force-logged step inside github-dev:post-merge (the standalone post-merge-wiki skill was removed — breaking, hence the 2.0.0 major bump). Promoted cross-agent rules graduate to .llmwiki/insight/ (via core-config prompt-inject hook), not .claude/rules/. Resolves .llmwiki/wiki -> legacy .claude/wiki -> .codex/wiki. Agent-facing wiki conventions deduped into references/wiki-conventions.md.",
-      "version": "2.4.0",
+      "version": "2.4.1",
       "category": "memory"
     },
     {

--- a/plugins/llm-wiki/.claude-plugin/plugin.json
+++ b/plugins/llm-wiki/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "llm-wiki",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "Karpathy LLM-Wiki 3-layer system (insight + wiki + raw under neutral .llmwiki/): 5 skills (query/ingest/lint/bootstrap/migrate) + 5 hooks. Three soft hints (stale check, post-commit hint, session-start lint hint) plus an auto-capture/ingest path: a Stop hook mechanically captures ingest candidates to <root>/.staging/ and the next session's SessionStart drain hook surfaces them for ingest-finding curation (capture and curation are split — a shell hook cannot curate). Post-merge wiki ingest is a mandatory, force-logged step inside github-dev:post-merge (the standalone post-merge-wiki skill was absorbed). Promoted cross-agent rules graduate to .llmwiki/insight/ (surfaced via core-config prompt-inject hook for Claude + Codex), NOT .claude/rules/. Neutral root defeats codex-bridge's .claude/->.codex/ fork; resolves .llmwiki/wiki -> legacy .claude/wiki -> .codex/wiki. For spec/issue/PR work-pipeline state see the spec-state plugin.",
   "hooks": {
     "UserPromptSubmit": [
@@ -45,6 +45,18 @@
       }
     ],
     "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/wiki_session_capture.sh",
+            "timeout": 5000
+          }
+        ]
+      }
+    ],
+    "SubagentStop": [
       {
         "matcher": "",
         "hooks": [

--- a/plugins/llm-wiki/.claude-plugin/plugin.json
+++ b/plugins/llm-wiki/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "llm-wiki",
-  "version": "2.4.1",
+  "version": "2.5.0",
   "description": "Karpathy LLM-Wiki 3-layer system (insight + wiki + raw under neutral .llmwiki/): 5 skills (query/ingest/lint/bootstrap/migrate) + 5 hooks. Three soft hints (stale check, post-commit hint, session-start lint hint) plus an auto-capture/ingest path: a Stop hook mechanically captures ingest candidates to <root>/.staging/ and the next session's SessionStart drain hook surfaces them for ingest-finding curation (capture and curation are split — a shell hook cannot curate). Post-merge wiki ingest is a mandatory, force-logged step inside github-dev:post-merge (the standalone post-merge-wiki skill was absorbed). Promoted cross-agent rules graduate to .llmwiki/insight/ (surfaced via core-config prompt-inject hook for Claude + Codex), NOT .claude/rules/. Neutral root defeats codex-bridge's .claude/->.codex/ fork; resolves .llmwiki/wiki -> legacy .claude/wiki -> .codex/wiki. For spec/issue/PR work-pipeline state see the spec-state plugin.",
   "hooks": {
     "UserPromptSubmit": [

--- a/plugins/llm-wiki/.codex-plugin/plugin.json
+++ b/plugins/llm-wiki/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "llm-wiki",
-  "version": "2.4.1",
+  "version": "2.5.0",
   "description": "Karpathy LLM-Wiki 3-layer (insight + wiki + raw under neutral .llmwiki/): 5 skills (query/ingest/lint/bootstrap/migrate) + 5 hooks + bootstrap templates. Three soft hints plus an auto-capture/ingest path: a Stop hook mechanically captures ingest candidates to <root>/.staging/ and the next session's SessionStart drain hook surfaces them for ingest-finding curation (capture and curation split). Post-merge wiki ingest is a mandatory, force-logged step inside github-dev:post-merge (the standalone post-merge-wiki skill was removed — breaking, hence the 2.0.0 major bump). Promoted cross-agent rules graduate to .llmwiki/insight/ (via core-config prompt-inject hook), not .claude/rules/. Resolves .llmwiki/wiki -> legacy .claude/wiki -> .codex/wiki. Agent-facing wiki conventions deduped into references/wiki-conventions.md.",
   "author": {
     "name": "YoungjaeDev"

--- a/plugins/llm-wiki/.codex-plugin/plugin.json
+++ b/plugins/llm-wiki/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "llm-wiki",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "Karpathy LLM-Wiki 3-layer (insight + wiki + raw under neutral .llmwiki/): 5 skills (query/ingest/lint/bootstrap/migrate) + 5 hooks + bootstrap templates. Three soft hints plus an auto-capture/ingest path: a Stop hook mechanically captures ingest candidates to <root>/.staging/ and the next session's SessionStart drain hook surfaces them for ingest-finding curation (capture and curation split). Post-merge wiki ingest is a mandatory, force-logged step inside github-dev:post-merge (the standalone post-merge-wiki skill was removed — breaking, hence the 2.0.0 major bump). Promoted cross-agent rules graduate to .llmwiki/insight/ (via core-config prompt-inject hook), not .claude/rules/. Resolves .llmwiki/wiki -> legacy .claude/wiki -> .codex/wiki. Agent-facing wiki conventions deduped into references/wiki-conventions.md.",
   "author": {
     "name": "YoungjaeDev"

--- a/plugins/llm-wiki/CLAUDE.md
+++ b/plugins/llm-wiki/CLAUDE.md
@@ -7,7 +7,7 @@ Karpathy LLM-Wiki 3-layer system packaged as a plugin. Universal — works in an
 | Component | Path | Purpose |
 |-----------|------|---------|
 | **5 skills** | `skills/{query,ingest,lint,bootstrap,migrate}-wiki/` | wiki query, finding ingest, health audit, repo bootstrap, v1→v2 migration. (Post-merge ingest moved into `github-dev:post-merge` as a mandatory step.) |
-| **5 hooks** | `hooks/wiki_{stale_check,post_commit_hint,session_start_lint_hint,session_capture,session_start_drain}.sh` | UserPromptSubmit + PostToolUse(Bash) + SessionStart soft hints, plus Stop-capture + SessionStart-drain auto-ingest (capture/curation split) |
+| **5 hooks** | `hooks/wiki_{stale_check,post_commit_hint,session_start_lint_hint,session_capture,session_start_drain}.sh` | UserPromptSubmit + PostToolUse(Bash) + SessionStart soft hints, plus Stop/SubagentStop-capture + SessionStart-drain auto-ingest (capture/curation split; `session_capture` wired to both Stop and SubagentStop — the latter scans the subagent's own `agent_transcript_path`, keyed by `agent_id` so it never collides with the parent capture) |
 | **bootstrap templates** | `skills/bootstrap-wiki/assets/templates/` | wiki-skeleton (index, log, spec) + insight-skeleton (index, _insight-template) |
 
 ## Layer model

--- a/plugins/llm-wiki/hooks/wiki_post_commit_hint.sh
+++ b/plugins/llm-wiki/hooks/wiki_post_commit_hint.sh
@@ -45,6 +45,14 @@ wiki_root="$(resolve_wiki_root)" || exit 0
 # unreliable (~always false). Compound commands (`git commit && gh pr merge`) count
 # as a merge: the merge is the high-value event.
 case "$cmd" in
+  *"gh pr merge"*"--auto"*)
+    # `gh pr merge --auto` only ENROLLS the PR for auto-merge; the merge completes
+    # later, server-side, with no local command — so announcing "a PR merged" now is
+    # premature (and there is no local commit to hint on either). Stay silent. (A repo
+    # merge queue can defer a plain `gh pr merge` too, but that is not detectable from
+    # the command string; the post-merge hint is self-correcting there — post-merge's
+    # own `state=MERGED` gate refuses to proceed on an unmerged PR.)
+    exit 0 ;;
   *"gh pr merge"*) event="merge" ;;
   *)               event="commit" ;;
 esac

--- a/plugins/llm-wiki/hooks/wiki_post_commit_hint.sh
+++ b/plugins/llm-wiki/hooks/wiki_post_commit_hint.sh
@@ -48,11 +48,17 @@ case "$cmd" in
   *"gh pr merge"*"--auto"*)
     # `gh pr merge --auto` only ENROLLS the PR for auto-merge; the merge completes
     # later, server-side, with no local command — so announcing "a PR merged" now is
-    # premature (and there is no local commit to hint on either). Stay silent. (A repo
-    # merge queue can defer a plain `gh pr merge` too, but that is not detectable from
-    # the command string; the post-merge hint is self-correcting there — post-merge's
-    # own `state=MERGED` gate refuses to proceed on an unmerged PR.)
-    exit 0 ;;
+    # premature. Suppress the merge hint. But if the same command also made a local
+    # commit/push (e.g. `git commit ... && gh pr merge --auto`), that commit still
+    # deserves the ingest-finding hint, so fall through to the commit-event path; a
+    # bare `gh pr merge --auto` has no such commit and the threshold below won't fire.
+    # (A repo merge queue can defer a plain `gh pr merge` too, but that is not
+    # detectable from the command string; the post-merge hint is self-correcting there
+    # — post-merge's own `state=MERGED` gate refuses to proceed on an unmerged PR.)
+    case "$cmd" in
+      *"git commit"*|*"git push"*) event="commit" ;;
+      *)                           exit 0 ;;
+    esac ;;
   *"gh pr merge"*) event="merge" ;;
   *)               event="commit" ;;
 esac

--- a/plugins/llm-wiki/hooks/wiki_post_commit_hint.sh
+++ b/plugins/llm-wiki/hooks/wiki_post_commit_hint.sh
@@ -19,7 +19,7 @@ else
 fi
 [[ -z "$cmd" ]] && exit 0
 
-# Only react to git commit or git push to a non-feature branch (merge to main)
+# Only react to git commit / git push / gh pr merge; classify below by command string.
 case "$cmd" in
   *"git commit"*|*"git push"*|*"gh pr merge"*) ;;
   *) exit 0 ;;
@@ -39,34 +39,49 @@ resolve_wiki_root() {
 }
 wiki_root="$(resolve_wiki_root)" || exit 0
 
-# Rate-limit: suppress if we've already fired in the last 10 minutes for this cwd
-marker="/tmp/wiki_post_commit_hint.$(printf '%s' "$PWD" | cksum | cut -d' ' -f1)"
+# Classify the event by the COMMAND STRING, not local git state. `gh pr merge` is a
+# remote operation — it never changes local HEAD (a --squash merge leaves no local
+# 2-parent commit), so deriving "is this a merge?" from `git rev-list` on HEAD was
+# unreliable (~always false). Compound commands (`git commit && gh pr merge`) count
+# as a merge: the merge is the high-value event.
+case "$cmd" in
+  *"gh pr merge"*) event="merge" ;;
+  *)               event="commit" ;;
+esac
+
+# Rate-limit per (cwd, event): a preceding commit must not consume the merge budget,
+# and vice versa — each event class gets an independent 10-minute window.
+cksum_pwd=$(printf '%s' "$PWD" | cksum | cut -d' ' -f1)
+marker="/tmp/wiki_post_commit_hint.${cksum_pwd}.${event}"
 if [[ -f "$marker" ]]; then
   age=$(( $(date +%s) - $(stat -c %Y "$marker" 2>/dev/null || stat -f %m "$marker" 2>/dev/null || echo 0) ))
   [[ $age -lt 600 ]] && exit 0
 fi
-touch "$marker"
 
-# Stat the last commit's diff
+if [[ "$event" == "merge" ]]; then
+  # A PR merged. There is no local diff to threshold (remote op), so fire the
+  # post-merge hint directly, rate-limited by the merge marker alone.
+  printf '[wiki-ingest-hint] a `gh pr merge` just ran — a PR merged.\n'
+  printf 'Consider /github-dev:post-merge (if the github-dev plugin is installed) — its mandatory wiki step scans the merged diff for ingest candidates. Without github-dev, run /llm-wiki:ingest-finding manually.\n'
+  touch "$marker"  # arm the window only after deciding to print (never on a suppressed run)
+  exit 0
+fi
+
+# event == commit (git commit / git push): threshold on the last commit's diff.
+# HEAD~1..HEAD is valid here — a local commit did move local HEAD.
 files_changed=$(git diff --name-only HEAD~1 HEAD 2>/dev/null | wc -l || echo 0)
 lines_changed=$(git diff --shortstat HEAD~1 HEAD 2>/dev/null \
                 | LC_ALL=C.UTF-8 grep -oP '\d+(?= insertion| deletion)' \
                 | awk '{s+=$1} END{print s+0}' 2>/dev/null || echo 0)
 [[ -z "$lines_changed" ]] && lines_changed=0
 
-# Threshold: 2+ files OR 50+ lines OR a merge commit
-is_merge=$(git rev-list --merges -1 HEAD~..HEAD 2>/dev/null)
-if (( files_changed < 2 )) && (( lines_changed < 50 )) && [[ -z "$is_merge" ]]; then
+# Threshold: 2+ files OR 50+ lines. Below threshold, leave the marker UNTOUCHED so a
+# trivial commit does not consume the window a subsequent real commit needs.
+if (( files_changed < 2 )) && (( lines_changed < 50 )); then
   exit 0
 fi
 
-printf '[wiki-ingest-hint] last commit touched %s file(s), ~%s line(s)' "$files_changed" "$lines_changed"
-[[ -n "$is_merge" ]] && printf ' (merge commit)'
-printf '.\n'
-if [[ -n "$is_merge" ]]; then
-  printf 'Consider /github-dev:post-merge (if the github-dev plugin is installed) — its mandatory wiki step scans the merged diff for ingest candidates. Without github-dev, run /llm-wiki:ingest-finding manually.\n'
-else
-  printf 'Consider /llm-wiki:ingest-finding if the commit surfaced non-obvious lore (provider quirks, debugging stories, design rationale).\n'
-fi
-
+printf '[wiki-ingest-hint] last commit touched %s file(s), ~%s line(s).\n' "$files_changed" "$lines_changed"
+printf 'Consider /llm-wiki:ingest-finding if the commit surfaced non-obvious lore (provider quirks, debugging stories, design rationale).\n'
+touch "$marker"  # arm the window only after threshold passed + output emitted (fixes touch-before-check)
 exit 0

--- a/plugins/llm-wiki/hooks/wiki_session_capture.sh
+++ b/plugins/llm-wiki/hooks/wiki_session_capture.sh
@@ -40,8 +40,21 @@ extract() { # $1=key
   printf '%s' "$v"
 }
 cwd=$(extract cwd)
+# SubagentStop carries BOTH transcript_path (the PARENT session's transcript) and
+# agent_transcript_path (this subagent's OWN transcript, written and present at fire
+# time — verified empirically). Prefer the agent transcript so a subagent capture
+# records the delegated work the parent Stop never sees; scanning transcript_path
+# would just duplicate the main Stop capture. The main Stop event has no
+# agent_transcript_path, so it falls through to transcript_path as before. When a
+# subagent has no persisted transcript (agent_transcript_path names a missing file),
+# the -f guard below no-ops rather than falling back to the redundant parent.
 transcript=$(extract transcript_path)
+agent_transcript=$(extract agent_transcript_path)
+[[ -n "$agent_transcript" ]] && transcript="$agent_transcript"
 session_id=$(extract session_id)
+# Present only on SubagentStop — used below to key this subagent's capture separately
+# from the parent session's (they share session_id). Empty on the main Stop event.
+agent_id=$(extract agent_id)
 # cd into the event cwd when given; exit gracefully if the cd itself fails (race /
 # permission) so we never scan from the wrong directory. Empty cwd is intentional —
 # fall through to PWD (the harness launches the hook there).
@@ -66,8 +79,19 @@ wiki_root="$(resolve_wiki_root)" || exit 0
 [[ -n "$session_id" ]] || session_id="unknown"
 sid=$(printf '%s' "$session_id" | LC_ALL=C.UTF-8 tr -c 'A-Za-z0-9._-' '_')
 
-# Rate-limit: at most once per 90s per session (Stop fires every assistant turn).
-marker="/tmp/wiki_session_capture.${sid}"
+# When fired as SubagentStop, key the marker + staging file by session_id AND agent_id
+# so a subagent capture cannot collide with the parent Stop capture (they may share
+# session_id). Main Stop has no agent_id -> unkeyed, preserving pending-<sid>.md.
+if [[ -n "$agent_id" ]]; then
+  aid=$(printf '%s' "$agent_id" | LC_ALL=C.UTF-8 tr -c 'A-Za-z0-9._-' '_')
+  marker="/tmp/wiki_session_capture.${sid}.${aid}"
+  pending_basename="pending-${sid}-${aid}.md"
+else
+  marker="/tmp/wiki_session_capture.${sid}"
+  pending_basename="pending-${sid}.md"
+fi
+
+# Rate-limit: at most once per 90s per session/agent (Stop fires every assistant turn).
 if [[ -f "$marker" ]]; then
   age=$(( $(date +%s) - $(stat -c %Y "$marker" 2>/dev/null || stat -f %m "$marker" 2>/dev/null || echo 0) ))
   [[ $age -lt 90 ]] && exit 0
@@ -75,13 +99,29 @@ fi
 touch "$marker"
 
 # --- mechanical signal detection over the transcript (heuristic, intentionally coarse) ---
+# Bound the scan: copy at most the last 4 MB into a temp buffer and grep that, so a
+# pathological multi-MB session stays well under the 5s hook timeout (tail -c seeks, so
+# the read is O(cap) not O(filesize)). The tail holds the recent, ingest-relevant turns;
+# the full transcript path is still recorded in the staging file, so the curator always
+# reads the complete source — this cap only bounds the coarse fire/no-fire heuristic.
+scan_cap=$((4 * 1024 * 1024))
+scan_buf=$(mktemp 2>/dev/null) || scan_buf=""
+trap 'rm -f "${scan_buf:-}" 2>/dev/null' EXIT
+if [[ -n "$scan_buf" ]] && tail -c "$scan_cap" "$transcript" > "$scan_buf" 2>/dev/null; then
+  scan_target="$scan_buf"
+else
+  scan_target="$transcript"
+fi
+
 # grep -c prints a count to stdout (and exits 1 on zero matches, swallowed by $()).
-merge_hits=$(LC_ALL=C.UTF-8 grep -cE 'gh pr merge|git merge|Merged pull request|"merged":[[:space:]]*true' "$transcript" 2>/dev/null)
-debug_hits=$(LC_ALL=C.UTF-8 grep -ciE 'root cause|근본 원인|원인은|the bug was|fixed by|race condition|provider quirk|deadlock|off-by-one' "$transcript" 2>/dev/null)
-decision_hits=$(LC_ALL=C.UTF-8 grep -ciE 'decided to|trade-?off|왜냐하면|the reason is|rationale|we chose|design decision' "$transcript" 2>/dev/null)
+# Kept as 3 separate greps (not one alternation) so per-category counts survive for
+# the staging signal breakdown below.
+merge_hits=$(LC_ALL=C.UTF-8 grep -cE 'gh pr merge|git merge|Merged pull request|"merged":[[:space:]]*true' "$scan_target" 2>/dev/null)
+debug_hits=$(LC_ALL=C.UTF-8 grep -ciE 'root cause|근본 원인|원인은|the bug was|fixed by|race condition|provider quirk|deadlock|off-by-one' "$scan_target" 2>/dev/null)
+decision_hits=$(LC_ALL=C.UTF-8 grep -ciE 'decided to|trade-?off|왜냐하면|the reason is|rationale|we chose|design decision' "$scan_target" 2>/dev/null)
 merge_hits=${merge_hits:-0}; debug_hits=${debug_hits:-0}; decision_hits=${decision_hits:-0}
 
-pr_refs=$(LC_ALL=C.UTF-8 grep -oE 'PR #[0-9]+|pull/[0-9]+' "$transcript" 2>/dev/null \
+pr_refs=$(LC_ALL=C.UTF-8 grep -oE 'PR #[0-9]+|pull/[0-9]+' "$scan_target" 2>/dev/null \
           | LC_ALL=C.UTF-8 grep -oE '[0-9]+' | sort -un | head -10 | tr '\n' ' ')
 
 # Fire only when the session plausibly produced lore: a real merge, OR several
@@ -96,11 +136,12 @@ staging_dir="$(dirname "$wiki_root")/.staging"
 mkdir -p "$staging_dir" || exit 0
 today=$(date +%Y-%m-%d)
 recent_commits=$(git log --oneline -5 2>/dev/null || true)
-pending_file="$staging_dir/pending-${sid}.md"
+pending_file="$staging_dir/${pending_basename}"
 
 {
   printf -- '---\n'
   printf 'session: %s\n' "$session_id"
+  [[ -n "$agent_id" ]] && printf 'agent_id: %s\n' "$agent_id"
   printf 'captured: %s\n' "$today"
   printf 'transcript: %s\n' "$transcript"
   printf 'cwd: %s\n' "$PWD"

--- a/plugins/llm-wiki/hooks/wiki_session_capture.sh
+++ b/plugins/llm-wiki/hooks/wiki_session_capture.sh
@@ -99,29 +99,26 @@ fi
 touch "$marker"
 
 # --- mechanical signal detection over the transcript (heuristic, intentionally coarse) ---
-# Bound the scan: copy at most the last 4 MB into a temp buffer and grep that, so a
-# pathological multi-MB session stays well under the 5s hook timeout (tail -c seeks, so
-# the read is O(cap) not O(filesize)). The tail holds the recent, ingest-relevant turns;
-# the full transcript path is still recorded in the staging file, so the curator always
-# reads the complete source — this cap only bounds the coarse fire/no-fire heuristic.
+# Bound the scan: read at most the last 4 MB of the transcript (tail -c seeks, so the
+# read is O(cap) not O(filesize)) and grep that, so a pathological multi-MB session
+# stays well under the 5s hook timeout. Piping tail straight into each grep means there
+# is NO failure path that falls back to an unbounded full-file scan — a failed tail just
+# yields an empty stream (zero counts, degrading safely), never the whole file. The
+# recent, ingest-relevant turns are at the tail; the full transcript path is still
+# recorded in the staging file, so the curator always reads the complete source — this
+# cap only bounds the coarse fire/no-fire heuristic.
 scan_cap=$((4 * 1024 * 1024))
-scan_buf=$(mktemp 2>/dev/null) || scan_buf=""
-trap 'rm -f "${scan_buf:-}" 2>/dev/null' EXIT
-if [[ -n "$scan_buf" ]] && tail -c "$scan_cap" "$transcript" > "$scan_buf" 2>/dev/null; then
-  scan_target="$scan_buf"
-else
-  scan_target="$transcript"
-fi
+scan() { tail -c "$scan_cap" "$transcript" 2>/dev/null; }
 
 # grep -c prints a count to stdout (and exits 1 on zero matches, swallowed by $()).
 # Kept as 3 separate greps (not one alternation) so per-category counts survive for
 # the staging signal breakdown below.
-merge_hits=$(LC_ALL=C.UTF-8 grep -cE 'gh pr merge|git merge|Merged pull request|"merged":[[:space:]]*true' "$scan_target" 2>/dev/null)
-debug_hits=$(LC_ALL=C.UTF-8 grep -ciE 'root cause|근본 원인|원인은|the bug was|fixed by|race condition|provider quirk|deadlock|off-by-one' "$scan_target" 2>/dev/null)
-decision_hits=$(LC_ALL=C.UTF-8 grep -ciE 'decided to|trade-?off|왜냐하면|the reason is|rationale|we chose|design decision' "$scan_target" 2>/dev/null)
+merge_hits=$(scan | LC_ALL=C.UTF-8 grep -cE 'gh pr merge|git merge|Merged pull request|"merged":[[:space:]]*true' 2>/dev/null)
+debug_hits=$(scan | LC_ALL=C.UTF-8 grep -ciE 'root cause|근본 원인|원인은|the bug was|fixed by|race condition|provider quirk|deadlock|off-by-one' 2>/dev/null)
+decision_hits=$(scan | LC_ALL=C.UTF-8 grep -ciE 'decided to|trade-?off|왜냐하면|the reason is|rationale|we chose|design decision' 2>/dev/null)
 merge_hits=${merge_hits:-0}; debug_hits=${debug_hits:-0}; decision_hits=${decision_hits:-0}
 
-pr_refs=$(LC_ALL=C.UTF-8 grep -oE 'PR #[0-9]+|pull/[0-9]+' "$scan_target" 2>/dev/null \
+pr_refs=$(scan | LC_ALL=C.UTF-8 grep -oE 'PR #[0-9]+|pull/[0-9]+' 2>/dev/null \
           | LC_ALL=C.UTF-8 grep -oE '[0-9]+' | sort -un | head -10 | tr '\n' ' ')
 
 # Fire only when the session plausibly produced lore: a real merge, OR several


### PR DESCRIPTION
Closes #100

Fixes the llm-wiki hook defects confirmed in the PR #99 3-way review (main Claude + Codex). Separated from #99 per concern-isolation (#99 spec was "no hook changes"). Bash hooks — reproduction-based verification, not TDD.

## [HIGH] #1 — `wiki_post_commit_hint.sh` merge hint never fired

Three stacked causes: **(a)** commit/push/merge shared one `cksum(PWD)` rate-limit marker, so a preceding commit suppressed the merge hint; **(b)** `touch` ran before the print threshold, so trivial commits burned the 10-min slot; **(c)** `is_merge` was derived from `git rev-list HEAD~..HEAD` — but `gh pr merge` is a **remote** op that never moves local HEAD (a `--squash` merge has no local 2-parent commit), so `is_merge` was ~always false.

Fix: classify the event by the **command string** (`gh pr merge` → merge, else commit; compound `git commit && gh pr merge` → merge), drop the local `is_merge` rev-list, give each event class its own marker (`…​.<cksum>.<event>`), fire the merge hint with no local-diff threshold (rate-limited by the merge marker alone), and `touch` only after output is emitted.

## [MEDIUM] #2 — `wiki_session_capture.sh` had no `SubagentStop` coverage

Delegated debug/decision lore lives only in a subagent's transcript; the main `Stop` scan never sees it. Wired `SubagentStop` (matcher `""`) to the same capture hook.

**Live payload gate (mandatory) — run against the real harness, resolving the plan's two unverified unknowns:**

| Unknown | Empirical result |
|---|---|
| `session_id` on SubagentStop | **the PARENT's** id → captures must be keyed by `agent_id` or they collide with the parent Stop |
| `transcript_path` on SubagentStop | **the PARENT's transcript** → scanning it would just duplicate the main Stop |
| Subagent's own transcript | available via **`agent_transcript_path`**, written & present at fire time (verified: Explore = 68 KB, claude-code-guide = 116 KB of real content) |

So the capture now **prefers `agent_transcript_path`** (the subagent's own transcript) over the parent `transcript_path`, and keys the staging file + rate-limit marker by `agent_id` (`pending-<sid>-<aid>.md` / `…​.<sid>.<aid>`) so a subagent capture never overwrites or rate-limits the parent's. A subagent with no persisted transcript no-ops via the `-f` guard rather than falling back to the redundant parent.

## [MEDIUM] #3 — unbounded capture transcript scan

The 3 per-category greps scanned the full transcript with no size cap. Added a 4 MB `tail -c` buffer (seeks, so O(cap) not O(filesize)); per-category counts preserved. A 7.68 MB mock transcript now completes in ~90 ms (5 s timeout).

## Verification

- **#1**: reproduction test — RED confirms the old hook suppressed the merge hint after a commit; GREEN confirms unsuppressed merge, pure-command-string detection (no local HEAD change), cause-b fix, compound→merge, no-wiki no-op. 9/9.
- **#2**: live SubagentStop payload probe (real harness) + 15/15 capture unit checks incl. "scans the subagent transcript, not the parent", no-collision under shared session_id, missing-transcript no-op.
- **#3**: 7.68 MB transcript, ~90 ms, counts survive.
- `sync-codex-manifests.mjs --check` + `sync-hermes-manifests.mjs --check` pass; versions agree (plugin.json / marketplace / codex manifest = 2.4.1, metadata = 1.86.0).
- No-wiki-root no-op regression holds for both modified hooks.

## Deferred (per issue, optional)

#4 (full cwd-marker session-id keying across all 5 hooks) and #5 (shared resolver lib) — left as optional follow-ups; surface is large and the duplication is stable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `llm-wiki`가 2.5.0으로 업데이트되며, Stop/SubagentStop/세션 시작 흐름에 맞춘 캡처가 더 정교하게 동작합니다.
  * 커밋/머지 힌트 출력이 이벤트 유형에 따라 더 정확히 적용됩니다.
* **Bug Fixes**
  * 서브에이전트 캡처와 일반 캡처 간 충돌을 방지합니다.
  * 캡처 탐지/힌트 처리 속도와 동작 일관성이 개선됩니다.
* **Documentation**
  * 캡처 훅 동작 방식이 더 자세히 안내됩니다.
* **Chores**
  * 마켓플레이스 및 플러그인 버전 정보를 최신화했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->