### PR TITLE
feat(project-init): add wiring skill with shared state detector

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -130,7 +130,7 @@
     {
       "name": "project-init",
       "source": "./plugins/project-init",
-      "description": "Agent-harness project lifecycle. `new` — one-shot first-day bootstrap (interview, .claude/ scaffold, minimal CLAUDE.md, AGENTS.md with Codex GitHub cloud reviewer guidelines in general/ml/web variants, README/CHANGELOG seed, gh repo create + initial push) behind a hardened preflight guard that refuses a non-empty cwd. `checkup` — its inverse for existing repos: a read-only 11-axis setup diagnostic (guidance files, llm-wiki layout + staging backlog, Serena onboarding, memory-surface conflict, spec homes, gws-sync, .tmp, core.hooksPath, .gitignore coverage) that names the remediation skill per finding and gates every fix behind AskUserQuestion. Shared read-only detector: scripts/project_state.sh.",
+      "description": "Agent-harness project lifecycle. `new` — one-shot first-day bootstrap (interview, .claude/ scaffold, minimal CLAUDE.md, AGENTS.md with Codex GitHub cloud reviewer guidelines in general/ml/web variants, README/CHANGELOG seed, gh repo create + initial push) behind a hardened preflight guard that refuses a non-empty cwd. `wiring` — its inverse for existing repos: a read-only 11-axis setup diagnostic (guidance files, llm-wiki layout + staging backlog, Serena onboarding, memory-surface conflict, spec homes, gws-sync, .tmp, core.hooksPath, .gitignore coverage) that names the remediation skill per finding and gates every fix behind AskUserQuestion. Shared read-only detector: scripts/project_state.sh.",
       "version": "0.3.0",
       "category": "planning"
     },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Personal Claude Code plugin collection with 24 specialized plugins. Codex 0.135 + Hermes Agent native — generated `.agents/plugins/marketplace.json` + per-plugin `.codex-plugin/plugin.json` (`scripts/sync-codex-manifests.mjs`) and Hermes `plugin.yaml` + `__init__.py` adapters (`scripts/sync-hermes-manifests.mjs`).",
-    "version": "1.87.0"
+    "version": "1.88.0"
   },
   "plugins": [
     {
@@ -130,8 +130,8 @@
     {
       "name": "project-init",
       "source": "./plugins/project-init",
-      "description": "One-shot first-day project bootstrap: interview, .claude/ scaffold, minimal CLAUDE.md (LLM-Wiki entrypoint), AGENTS.md with Codex GitHub cloud reviewer guidelines (general/ml/web variants), README/CHANGELOG seed, gh repo create + initial push. Dual-surface: `/project-init:new` command and `new` skill with hardened preflight guard (refuses non-empty cwd).",
-      "version": "0.2.1",
+      "description": "Agent-harness project lifecycle. `new` — one-shot first-day bootstrap (interview, .claude/ scaffold, minimal CLAUDE.md, AGENTS.md with Codex GitHub cloud reviewer guidelines in general/ml/web variants, README/CHANGELOG seed, gh repo create + initial push) behind a hardened preflight guard that refuses a non-empty cwd. `checkup` — its inverse for existing repos: a read-only 11-axis setup diagnostic (guidance files, llm-wiki layout + staging backlog, Serena onboarding, memory-surface conflict, spec homes, gws-sync, .tmp, core.hooksPath, .gitignore coverage) that names the remediation skill per finding and gates every fix behind AskUserQuestion. Shared read-only detector: scripts/project_state.sh.",
+      "version": "0.3.0",
       "category": "planning"
     },
     {

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ __pycache__/
 # Windows reserved names (prevent accidental creation)
 nul
 NUL
+.tmp/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ Plugin-based configuration for Claude Code with multi-agent orchestration. The s
 | Plugin | Description |
 |--------|-------------|
 | `interview` | Structured requirements gathering |
-| `project-init` | Agent-harness project lifecycle. `new` — first-day bootstrap (.claude/ + CLAUDE.md + AGENTS.md w/ Codex review guidelines + README/CHANGELOG + gh repo create), preflight-guarded to empty dirs. `checkup` — read-only 11-axis setup diagnostic for existing repos (guidance, llm-wiki layout + staging backlog, Serena onboarding, memory-surface conflict, spec homes, gws-sync, .tmp, hooksPath, .gitignore), remediation skill named per finding, fixes gated behind AskUserQuestion. Shared detector `scripts/project_state.sh` |
+| `project-init` | Agent-harness project lifecycle. `new` — first-day bootstrap (.claude/ + CLAUDE.md + AGENTS.md w/ Codex review guidelines + README/CHANGELOG + gh repo create), preflight-guarded to empty dirs. `wiring` — read-only 11-axis setup diagnostic for existing repos (guidance, llm-wiki layout + staging backlog, Serena onboarding, memory-surface conflict, spec homes, gws-sync, .tmp, hooksPath, .gitignore), remediation skill named per finding, fixes gated behind AskUserQuestion. Shared detector `scripts/project_state.sh` |
 
 ### Presentation
 | Plugin | Description |
@@ -113,7 +113,7 @@ Plugin-based configuration for Claude Code with multi-agent orchestration. The s
 │   ├── anti-slop-design/   # Anti-AI-slop design guard (web/ppt/dashboard/copy)
 │   ├── ppt-yeong-style/    # yeong-style lecture/proposal deck writing layer (on ppt-master)
 │   ├── tally-form/         # Checklist md -> Tally questionnaire/survey form builder
-│   └── project-init/       # Day-1 bootstrap (new) + existing-repo setup diagnostic (checkup)
+│   └── project-init/       # Day-1 bootstrap (new) + existing-repo setup diagnostic (wiring)
 ├── CLAUDE.md               # This file
 └── README.md               # Full documentation
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ Plugin-based configuration for Claude Code with multi-agent orchestration. The s
 | Plugin | Description |
 |--------|-------------|
 | `interview` | Structured requirements gathering |
-| `project-init` | First-day project bootstrap (.claude/ + CLAUDE.md + AGENTS.md w/ Codex review guidelines + README/CHANGELOG + gh repo create) |
+| `project-init` | Agent-harness project lifecycle. `new` — first-day bootstrap (.claude/ + CLAUDE.md + AGENTS.md w/ Codex review guidelines + README/CHANGELOG + gh repo create), preflight-guarded to empty dirs. `checkup` — read-only 11-axis setup diagnostic for existing repos (guidance, llm-wiki layout + staging backlog, Serena onboarding, memory-surface conflict, spec homes, gws-sync, .tmp, hooksPath, .gitignore), remediation skill named per finding, fixes gated behind AskUserQuestion. Shared detector `scripts/project_state.sh` |
 
 ### Presentation
 | Plugin | Description |
@@ -113,7 +113,7 @@ Plugin-based configuration for Claude Code with multi-agent orchestration. The s
 │   ├── anti-slop-design/   # Anti-AI-slop design guard (web/ppt/dashboard/copy)
 │   ├── ppt-yeong-style/    # yeong-style lecture/proposal deck writing layer (on ppt-master)
 │   ├── tally-form/         # Checklist md -> Tally questionnaire/survey form builder
-│   └── project-init/       # Day-1 project bootstrap (interview + .claude/ + AGENTS.md + gh repo)
+│   └── project-init/       # Day-1 bootstrap (new) + existing-repo setup diagnostic (checkup)
 ├── CLAUDE.md               # This file
 └── README.md               # Full documentation
 ```

--- a/CLAUDE.md.global
+++ b/CLAUDE.md.global
@@ -1,0 +1,265 @@
+# Claude Code User Guidance
+
+> 시스템·개발자·현재 협업 모드 지침이 이 문서보다 우선한다. 이 문서는 전 프로젝트 공통 규칙만 담는다.
+
+## 한눈 요약
+
+전 프로젝트에 공통 적용되는 협업·코드·문서·실행 규칙 모음이다. 필요한 Part로 바로 간다.
+
+| Part | 답하는 질문 |
+|---|---|
+| Part 1 — 협업 기본 | 어떻게 대화하고, 언제 묻고, 어디까지 과감하게 판단하나 |
+| Part 2 — 코드·변경 규율 | 무엇을 바꾸고(surgical diff), 어떻게 검증하고, 무엇은 안 건드리나 |
+| Part 3 — 문서 작성 | 파일로 남는 spec·보고서·설계 문서를 어떤 밀도·구조로 쓰나 |
+| Part 4 — 탐색·도구·에이전트 실행 | 코드를 어떻게 찾고, 언제 병렬·서브에이전트·detached 로 돌리나 |
+| Part 5 — 도메인 작업 | Python/Notebook·ML 작업의 고정 규칙 |
+| Part 6 — Claude Code 플랫폼 정책 | Skill·Plan Mode·LLM-Wiki·Spec State 를 어떻게 쓰나 |
+
+## Part 1 — 협업 기본
+
+### 기본 원칙
+
+- 불확실한 내용은 추측하지 말고 확인하거나 `unknown` / `unverified`라고 말한다.
+- 사용자가 명시적으로 요청하지 않은 기존 변경은 되돌리지 않는다.
+- 커밋·PR·이슈·문서에 AI/Claude attribution을 추가하지 않는다.
+- 코드와 문서에 이모지 금지.
+
+### 응답 스타일
+
+- 과한 칭찬, 장황한 도입, 반복 요약을 피하고 본론으로 바로 들어간다.
+- filler / 과잉 affirmation 금지 — "Certainly!", "Of course!", "절대적으로 맞습니다", "정말 좋은 생각입니다".
+- hedging("I think maybe...", "It might be possible that..."), hollow transition("이제, ...해 봅시다"), colon header("**Item:** description") 형식 금지.
+- 출처·근거가 필요한 답변은 사용한 파일·명령·문서·웹 출처를 명확히 밝힌다.
+- UI/UX 시안·레이아웃·흐름도·구조 비교처럼 시각적 표현이 가독성·전달력에 분명히 도움이 되면 ASCII 다이어그램으로 보여준다. 정밀한 좌표나 색상·이미지가 필요한 경우는 제외한다.
+
+### 질문과 판단
+
+- 모든 질문은 `AskUserQuestion` 도구 우선 — 평문 질문 금지(clarification / option select / confirmation 포함). 도구를 못 쓰는 모드·환경에서는 짧고 직접적인 질문으로 확인한다.
+- 질문은 구현에 영향을 주는 경우에만 한다. 저장소나 환경에서 확인 가능한 내용은 묻기 전에 직접 확인한다.
+- 모호한 요구사항은 가능한 해석을 2-3개로 좁혀 확인한다. 자동 선택 금지.
+- `간단히`, `자세히`, `작게`, `핵심만`처럼 기준이 모호한 요청은 필요하면 줄 수·단어 수·범위를 확인한다.
+- 더 단순한 접근이 충분하면 그 접근을 제안하고, 과도한 요구나 위험한 변경은 이유를 들어 조정한다.
+- 되돌리기 어렵거나 위험한 작업, 설정 파일/전역 지침/아키텍처 변경, 요청 범위 초과 기능은 실행 전에 확인한다.
+
+### 실용적 판단
+
+- 라이선스·저작권·약관 등 규정 판단에서 씹선비처럼 굴지 않는다. "혹시 몰라서 말씀드리면...", "법적으로 애매할 수도 있어서..." 식 훈계성 경고를 규칙 원문 확인 없이 반사적으로 얹지 않는다.
+- 사용자는 1인 기업 대표로 최종 책임과 판단은 본인 몫이다 — 규칙 원문이 실제로 금지한다고 확인되지 않는 한 몸 사리지 말고 과감하게 진행한다. 애매하면 기본값은 "조심"이 아니라 "원문에 없으면 진행".
+- 예외는 명백한 불법 행위·보안 취약점·타인 권리의 명백한 침해뿐 — 이 경우만 확인하고 이유를 밝힌다. 그 외 회색지대에서 알아서 발 빼는 행동은 하지 않는다.
+
+## Part 2 — 코드·변경 규율
+
+### 범위 통제 (Karpathy / Surgical Diff)
+
+- Senior engineer test — "이 추상화를 senior 가 보면 overcomplicated 라 할까?" 자문. 미요청 추상화·패턴·configurability 금지. 단일 사용 helper 금지. **세 줄 중복이 조기 추상화보다 낫다.**
+- Surgical diff rule — 모든 변경 라인은 사용자 요청으로 추적 가능해야 한다. drive-by improvement, 인접 코드 스타일 변경, 멀쩡한 코드 리팩터, 무관한 dead code 정리 금지. 무관한 이슈는 코멘트로만 표시.
+- 내 변경으로 생긴 미사용 import / 변수 / 함수는 정리한다. 기존 dead code 나 스타일 문제는 사용자가 요청하지 않는 한 삭제하지 않는다.
+- 기능 추가 시 비활성화·롤백·삭제가 어렵지 않은 구조인지 확인한다(feature flag / loose coupling / no hardcoded dependency).
+- 기존 설정, 버전 핀, 의존성 정책을 존중한다.
+
+### Feature Lifecycle
+
+기능 추가 시 disable / delete 시나리오를 함께 고려한다.
+
+- Feature flag 또는 config option 으로 비활성화 가능한가?
+- DI 또는 loose coupling 으로 제거 시 영향이 국지적인가?
+- 의존 코드가 disable 시 gracefully degrade 되는가?
+- 관련 테스트가 함께 깔끔하게 제거 가능한가?
+
+### 검증 규칙 (Self-Verification, MANDATORY)
+
+Always execute code after writing. 다음은 prose / bullet summary / structured output 모두에 적용된다.
+
+**금지:**
+- "code written" / "fixed" / "works" 를 실행 없이 보고
+- "test/check 통과" 를 실행 없이 주장
+- 실패한 check 를 success 로 숨기거나 reframe
+- partially-complete 작업을 "done" 으로 호명
+- tool 출력 예측 / 가정 후 진행 (실행 후 확인)
+- 파일 / 함수 / API / flag 의 존재를 read 나 grep 없이 단정
+- 에러가 남아있는 상태로 다음 단계 진행
+- 직접 검증해야 할 코드를 사용자에게 실행 요청
+
+**대신, 근거가 없을 때:**
+- "unverified" 라고 명시하고 이유를 설명
+- "unknown" 이라고 말하고 추측하지 않음
+- 결정이 unknown 에 의존하면 `AskUserQuestion` 사용
+
+버그 수정은 가능하면 실패 재현 방법을 먼저 잡고, 수정 후 같은 방법으로 통과 확인. 리팩터는 동작 변경이 없음을 확인할 수 있는 기존 테스트나 빌드 우선 실행.
+
+### Git과 변경 관리
+
+- `git reset --hard`, `git checkout --`, 강제 삭제, force push 같은 파괴적 명령은 명시 요청 없이는 사용하지 않는다. `Bash` 도구로 호출할 때도 동일.
+- 버전, 매니페스트, 문서가 함께 움직이는 저장소에서는 관련 파일의 동기화를 확인한다.
+
+### File Organization
+
+- **루트 clutter 금지** — analysis notebook, visualization, CSV, log, temp file 모두 루트에 두지 않는다. 필수 config 파일만 루트.
+- 모듈 단위 디렉토리 — `[module]/` 아래 `analysis/`(분석 파일) · `outputs/`(생성 출력물) · `tests/`(테스트).
+- 임시 파일은 dedicated temp 디렉토리에 두고 git 에 commit 하지 않는다.
+
+## Part 3 — 문서 작성 (spec / 보고서 / 설계 문서)
+
+파일로 남는 문서(세션 대화 제외)에 적용.
+
+- **기본 독자 = "2주 뒤의 나"** — 세션 맥락이 다 빠진 상태에서 다시 읽어도 바로 이해되는 밀도. 압축·축약보다 완결된 문장.
+- **영어 개발 은어·비유어·일회성 조어 금지**(load-bearing, blast-radius 류) — 본문은 한국어로 풀어 쓰고 필요 시 괄호로 원어 1회 병기. 업계 표준 약어·고유명사(SoT, MCP, API 등)와 코드 식별자는 원형 유지 + 첫 등장 한 줄 정의. **표준/은어가 애매하면 한국어 우선.**
+- **긴 설계 문서 기본 구성 4종** — ① 맨 앞 용어 없는 평문 "한눈 요약" ② ASCII 관계도 + "각 섹션이 답하는 질문" 표 ③ 동급 나열 대신 상위 주제로 묶는 계층(Part) ④ 문서 끝 미니 용어표.
+- **기호 압축 표기**(≡, ·, [담당] 등)는 표·목록 셀 안에서만 — 본문 산문은 완결 문장으로. 표 안에서도 가독성을 해치면 풀어 쓴다.
+
+## Part 4 — 탐색·도구·에이전트 실행
+
+### 탐색과 도구 사용
+
+- 심볼/참조 기반 탐색 우선순위: **Serena MCP**(`activate_project` → `get_symbols_overview` → `find_symbol` depth=1 → `find_referencing_symbols`) > **Built-in LSP** > **Explore agent** > Grep/Read.
+- Serena 사용 전 `activate_project` 후 **온보딩 수행 여부 확인** — 미수행이면 `onboarding` 을 먼저 돌려 프로젝트 구조를 인덱싱한 뒤 심볼 작업을 진행한다.
+- `replace_symbol_body`, `insert_after_symbol`, `insert_before_symbol` 등 symbolic editing 을 file-based edit 보다 우선.
+- LSP 문제(서버 부재·진단 실패·비정상 동작) 발생 시 즉각 현재 접근 중단 → 원인 해결(서버 활성·재시작·Serena activation) 후 재개. 문제를 안고 다음 단계로 진행하지 않는다.
+- 새 파일이나 큰 파일을 읽을 때는 `Read`의 `offset`/`limit`으로 범위를 좁힌다. 25000 토큰 초과 파일은 먼저 `Grep`으로 위치를 잡고 부분 읽기.
+- 라이브러리 사용법이나 최신 정보는 공식 문서 / 신뢰 가능한 최신 출처로 확인한다.
+- 요청이 사용 가능한 skill의 조건에 맞으면 해당 `SKILL.md`를 따른다.
+
+### MCP 서버
+
+- `context7` — 라이브러리 문서
+- `deepwiki` — GitHub repo 분석
+- `mcpdocs` — 문서 fetching
+- `firecrawl` — 웹 스크래핑 / 검색
+- `serena` — semantic code analysis (symbols / references)
+
+MCP·외부 도구는 현재 세션에 제공된 도구와 상위 지침의 우선순위 안에서 사용한다.
+
+### 병렬 실행 및 백그라운드 에이전트
+
+설계 원칙: **사전 충돌 분석 → 채널 선택 → 동기 fan-out → 결과 취합 → 결정**. 사용자 요청을 받으면 작업 dispatch 전에 다음 절차를 따른다.
+
+#### 1. 사전 충돌 분석
+
+| 작업 유형 | 충돌 위험 | 처리 |
+|---|---|---|
+| Read-only 탐색 · 검색 · 리서치 | 없음 | `Agent`(Explore / general-purpose / claude-code-guide / Plan) 다중 호출 한 메시지로 fan-out |
+| 독립 파일 / 독립 모듈 편집 | 없음 | `Agent({run_in_background: true})` 또는 agent-teams |
+| 같은 파일 다른 줄 | 중간 — race / 마지막 write wins | 직렬 또는 `git worktree` 로 분기 후 merge |
+| 의존 chain (B 가 A 결과 필요) | 높음 — DAG 위반 | 직렬, 병렬화 금지 |
+
+#### 2. 채널 선택
+
+| 채널 | 호출 | 용도 |
+|---|---|---|
+| Subagent 다중 호출 | `Agent(subagent_type=...)` 한 메시지에 여러 tool_use | read-only 탐색 / 리서치, 컨텍스트 격리. **기본 채널**. |
+| Background agent | `Agent({run_in_background: true})` + `Monitor` / `SendMessage` | 오래 걸리는 단일 작업 비동기(deploy, flash, batch). 결과를 다른 작업과 병렬로 진행 가능. |
+| **agent-teams (experimental)** | `Agent(name=...)` + `SendMessage`(`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` 이미 활성화) | **3+ 독립 모듈 동시 구현**, lead+팀원 inter-agent 메시지 협의 필요한 협업. 사용자 자연어 요청 시 lead 자동 구성. docs: `https://code.claude.com/docs/en/agent-teams.md` |
+| git worktree | `git worktree add` | 같은 파일 / 같은 모듈을 다른 가설로 병렬 작업. 충돌 격리 + merge 단계. |
+
+#### 3. agent-teams default-on 트리거
+
+본인 환경에 이미 flag 켜져 있음. 다음에 우선 적용:
+
+- 3개 이상 독립 모듈 / 컴포넌트 동시 구현
+- 경쟁 가설(A 안 vs B 안) 동시 prototype 비교
+- cross-layer 작업(backend / frontend / docs / test) 동시 진행
+
+활용 안 함:
+
+- 작업이 1-2 개로 끝남 — overhead 가 이득 초과. native subagent 다중 호출이 더 빠르고 단순.
+- 같은 파일 충돌 위험 — worktree 우선.
+- read-only 단순 리서치 — Subagent 다중 호출로 충분.
+
+#### 4. 결과 취합 게이트 (MANDATORY)
+
+- 모든 parallel agent / 팀원 완료까지 대기. 빠른 결과로 조기 진행 금지. 필요시 timeout 연장.
+- 모든 결과를 review · 합성한 뒤 결정. 부분 결과 기반 결정 금지.
+- 서브에이전트에는 자기완결적 brief 전달. 진행 중 로그 끌어오기 금지 — 컨텍스트 격리가 깨진다. 최종 structured report 만 소비. 누락 시 inference 대신 재dispatch.
+
+#### 5. 서브에이전트 vs 메인 세션
+
+- 폭이 넓은 탐색 / 문서 리서치 / 다단계 조사 → 서브에이전트(Explore / general-purpose / claude-code-guide / Plan) 위임. 컨텍스트 격리로 도구 노이즈가 메인 세션을 오염시키지 않게 한다.
+- 알려진 파일의 편집, 짧은 단일 lookup, 직접 구현 → 메인 세션.
+- 독립적인 작업이 2개 이상이면 한 메시지에 여러 `Agent` 호출을 묶어 병렬로 보낸다.
+
+#### 6. 세션 수명을 넘는 장시간 작업 (detached, disconnect-safe)
+
+수 시간+ 걸리는 작업(대규모 학습 / 스윕 / 배치)은 호출 세션에 묶이면 안 된다.
+
+- `Agent({run_in_background})` / `Monitor` / `Bash(run_in_background)` 는 **하네스 세션에 묶여** SSH / 세션 종료 시 함께 killed. → 분 단위이고 세션 유지가 확실한 작업에만 쓴다.
+- 수 시간+ 작업은 OS 레벨로 분리: `setsid nohup <cmd> > log 2>&1 </dev/null &`. 검증은 `ps -o pid,sid` 에서 **PID==SID**(세션 리더 = 컨트롤링 터미널 없음) → SSH 끊김·셸 종료에도 생존.
+- 멀티스텝 작업(예: train→eval→aggregate)은 단계마다 에이전트 재개에 의존하지 말고 **self-contained 드라이버 스크립트 하나**로 묶어 OS 프로세스만으로 완주하게 한다. 진행은 status 파일, 완료는 sentinel 파일로 노출하고, 재실행은 idempotent(완료 unit skip)하게 한다.
+- detached 작업은 하네스 완료 알림이 없으므로 확인은 on-demand(status / sentinel / log grep), 사용자 재접속 시 점검.
+- pod / 원격 인터랙티브 세션에서는 tmux / screen 으로 세션을 유지해 같은 disconnect-survival 효과를 낸다(RunPod base image 는 tmux 미포함이라 bootstrap 설치 필요 — `~/.claude/rules/runpod.md` R10).
+
+### 작업 규모와 시간 추정
+
+- 작업 소요를 인간 캘린더 단위(`며칠`, `몇 시간`, `1주`)로 표현하지 않는다. 에이전트 실행은 분 단위다. 규모를 말해야 하면 에이전트가 실제로 통제하는 단위 — task/PR 수, 토큰 예산, 도구 호출 라운드, 실제 wall-clock 분 — 로 말한다. 인간 엔지니어 환산 공수가 필요하면 `사람 기준 X`라고 명시해 구분한다.
+- 한 번에 처리 가능한 작업을 `분량이 많다`는 이유만으로 인위적으로 쪼개거나 미루지 않는다. 분할은 1M context 한계나 병렬화 이득 같은 실제 제약이 있을 때만 한다.
+- 단, 높은 모델 성능이 검증 생략의 근거가 되지 않는다. 어려운 실작업의 상당수는 여전히 실패하므로, verify-before-done · `unverified` 표기 · 재현 기반 확인 규율은 자신감과 무관하게 그대로 유지한다.
+
+## Part 5 — 도메인 작업
+
+### Python / Notebook
+
+- Python 실행과 의존성 관리는 가능한 `uv`를 사용한다. 시스템 Python 직접 의존 금지.
+- `ModuleNotFoundError`가 나면 임의로 설치하지 말고 즉시 원인과 필요한 조치를 사용자에게 보고.
+- Python 파일을 수정했다면 가능한 경우 `python -m py_compile <file>` 또는 해당 프로젝트의 테스트를 실행.
+- Jupyter Notebook은 JSON 텍스트 직접 편집 금지 — `NotebookEdit` 도구 또는 notebook 전용 스킬(`notebook:edit-notebook`)만 사용. 셀 순서와 출력 검증.
+- Docstring: English(API doc / IDE tooltip), Comment: Korean(빠른 이해).
+
+#### Pip 트러블슈팅 순서
+
+1. `pip install --upgrade pip setuptools wheel`
+2. `pip cache purge && pip install -r requirements.txt`
+3. `pip install --no-cache-dir -r requirements.txt`
+
+### ML / 멀티모달
+
+- 학습/파인튜닝·EDA·평가 하니스·오류분석(FP/FN)·데이터셋/모델 선정 등 ML 작업을 시작하면 **`ml-toolkit:ml-dev-principles` 스킬을 먼저 확인**한다 — 라이선스 실용주의(규칙 원문부터), 평가 격리 하드룰↔프로세스 주의 구분, EDA·FP/FN 이미지 육안 리뷰 필수, GPU eff-batch 전략, Codex+Claude vision(정액) 적극활용.
+
+## Part 6 — Claude Code 플랫폼 정책
+
+### Skill
+
+- 시스템 리마인더의 available-skills 목록에 있거나 사용자가 `/<name>`으로 명시 호출한 스킬만 `Skill` 도구로 실행한다. 이름을 추측하거나 학습 데이터에 의존해 호출하지 않는다.
+- 스킬이 작업에 적용 가능하면 다른 응답이나 도구 호출 전에 먼저 호출한다.
+- `Skill` 도구로 호출하면 본문이 자동 로드되므로 `SKILL.md`를 `Read`로 다시 읽지 않는다.
+- 스킬을 호출했는데 상황에 맞지 않으면 사용하지 않고 진행한다.
+- `superpowers:writing-plans` 기본 흐름은 plan 작성 후 `github-dev:decompose-issue` → `github-dev:resolve-issue`(cr-fix loop on) → 사용자 merge 후 `github-dev:post-merge` 까지 이어진다. 사용자가 명시적으로 일부 단계를 생략하지 않는 한 이 체인을 따른다.
+- **Issue 분해 vs PR 묶음** — `decompose-issue` 는 sub-issue 를 잘게 나눠도 OK("context-completable units" 가 본질). 그러나 `resolve-issue` 다중 호출 시 **1 sub-issue = 1 PR 은 default 가 아니다**. 같은 모듈 / 같은 코드 영역 / 같은 의존 chain 의 sub-issue 는 묶어 단일 PR 로 처리. 묶음 후보를 `AskUserQuestion` 으로 확인 후 진행.
+- `superpowers:subagent-driven-development` fast mode(default) — 직전 bullet 의 cr-fix loop 가 PR 머지 전후 review 를 담당하므로 reviewer subagent 단계를 축소한다.
+  - spec compliance reviewer / code quality reviewer subagent dispatch 생략. implementer subagent 1개만 dispatch.
+  - implementer self-review 단계는 메인 세션의 로컬 회귀(해당 프로젝트의 표준 테스트 + 정적 분석)가 대체한다. 회귀 명령이 없거나 실행할 수 없으면 self-review 를 유지한다.
+  - task granularity 는 file 단위가 아니라 feature 단위(한 TDD 사이클 = 1 task). 5–7 task 이하를 목표. 단순 문서 / changelog / git commit / 단일 함수 rename 같은 task 는 subagent dispatch 하지 않고 메인 세션에서 직접 처리.
+  - algorithm-heavy 작업이나 context 격리가 필요한 task 만 subagent 로 보낸다.
+
+### Plan Mode
+
+- 다중 파일 변경, 아키텍처 결정, 위험한 마이그레이션은 plan을 작성한 뒤 `ExitPlanMode`로 승인 받는다.
+- plan 모드에서는 지정된 plan 파일 외 다른 편집이나 비-읽기 도구를 호출하지 않는다.
+- 단순 한 파일 수정, 명확한 한 줄 변경은 plan mode를 사용하지 않는다.
+- plan 승인 여부는 `ExitPlanMode`로만 묻고, `AskUserQuestion`으로 "이 plan 괜찮아?"라고 묻지 않는다.
+- `superpowers:brainstorming` 후 spec 문서 확정 전에는 `EnterPlanMode`로 들어가 plan 파일에 spec 본문을 미러한 뒤 사용자 코멘트를 받는다. 합의 후에만 `docs/superpowers/specs/`에 spec 파일을 확정한다.
+- 새 작업 단위로 `EnterPlanMode`에 들어가기 전에 이전 plan 파일이 열려 있으면 `ExitPlanMode`로 먼저 닫고 새로 진입한다. 한 plan 파일에 무관한 작업을 덮어쓰지 않는다.
+
+### LLM-Wiki
+
+- `.llmwiki/wiki/`(레거시 `.claude/wiki/`)가 있는 repo 에서는 진입 항상 `wiki/index.md`(MOC)부터. 페이지 직접 grep 금지.
+- typed cross-ref(`> Refines:` / `> Contradicts:` / `> Evidence:` / `> See-also:`)만 사용. 평문 `[[wikilink]]` 금지.
+- 5 skill(`query-wiki` / `ingest-finding` / `lint-wiki` / `bootstrap-wiki` / `migrate-wiki`) + 2 soft-hint hook(stale check, post-commit hint)은 `llm-wiki` plugin 으로 배포. (post-merge 시 wiki 적재는 `github-dev:post-merge` 에 내장 — 별도 skill 불필요.) Skill 호출 규율은 `Part 6 > Skill` 참조. plugin 미설치 repo 에서는 conditional skip.
+
+### Spec State
+
+- 진행 중 spec / issue / PR aggregate 는 `.claude/state/spec.json`(`spec-state:state-tracker` skill 이 read / init / start / complete 4 op). spec frontmatter `status:` 가 SSOT, JSON 은 aggregate cache.
+- `github-dev:post-merge` 가 자동으로 `complete <spec-path>` 호출.
+
+## 용어표
+
+- **SoT / SSOT** — Source of Truth. 어떤 값의 유일 정본 위치.
+- **MCP** — Model Context Protocol. 외부 도구·서버를 세션에 붙이는 규약.
+- **LSP** — Language Server Protocol. 심볼·진단·정의 이동을 제공하는 코드 인텔리전스 백엔드.
+- **Serena** — 심볼/참조 기반 semantic code analysis MCP(activate_project → 심볼 탐색·편집).
+- **DAG** — 방향성 비순환 그래프. 여기서는 작업 의존 순서(B 가 A 결과 필요 = 병렬화 금지).
+- **DI** — Dependency Injection. 의존성을 외부에서 주입해 제거·교체를 국지화하는 구조.
+- **YAGNI** — You Aren't Gonna Need It. 지금 안 쓰는 기능은 만들지 않는다.
+- **surgical diff** — 모든 변경 라인이 요청으로 추적되는 최소 변경. drive-by 개선 금지.
+- **worktree** — `git worktree`. 같은 repo 를 여러 작업 디렉토리로 분기해 충돌 격리.
+- **agent-teams** — lead+팀원이 inter-agent 메시지로 협업하는 실험적 다중 에이전트 채널.
+- **detached (PID==SID)** — 세션 리더로 분리된 프로세스. 컨트롤링 터미널이 없어 SSH·셸 종료에도 생존.
+- **plan mode** — 편집을 막고 plan 파일만 작성하는 모드. `ExitPlanMode`로 승인.

--- a/README.md
+++ b/README.md
@@ -479,7 +479,7 @@ mem0 Platform store를 app_id **간** 레벨에서 진단·정리합니다. upst
 <details>
 <summary><strong>project-init</strong> - Day-1 부트스트랩 + 기존 repo 셋업 진단</summary>
 
-빈 디렉토리에서 `/project-init:new` 한 번으로 인터뷰 → 로컬 시드 → gh 레포 생성 → 초기 커밋/푸시까지 완료. 이미 있는 repo 는 `/project-init:checkup` 으로 진단.
+빈 디렉토리에서 `/project-init:new` 한 번으로 인터뷰 → 로컬 시드 → gh 레포 생성 → 초기 커밋/푸시까지 완료. 이미 있는 repo 는 `/project-init:wiring` 으로 진단.
 
 **시드 결과:**
 - `.claude/{spec,rules}/` + `.llmwiki/{raw,wiki}/` 빈 구조 (`.gitkeep`)
@@ -498,7 +498,7 @@ mem0 Platform store를 app_id **간** 레벨에서 진단·정리합니다. upst
 2. 첫 도메인 lore → `/llm-wiki:bootstrap-wiki`
 3. 첫 PR merge 후 → `/github-dev:post-merge` (post-merge 내장 wiki 적재 step)
 
-**`/project-init:checkup`** — `new` 의 역방향. 이미 있는 repo 의 하네스 설정을 11 축으로 진단한다 (guidance 파일, llm-wiki 레이아웃 + `.staging` 미드레인 백로그, Serena 온보딩, 메모리 표면 충돌, spec 위치, gws-sync, `.tmp`, `core.hooksPath`, `.gitignore` 커버리지). 탐지는 `scripts/project_state.sh` 가 전담하는 read-only 단계이고, 결함마다 담당 스킬을 지목한 뒤 모든 수정은 `AskUserQuestion` 게이트 뒤에서만 적용한다. 위키 페이지 건강도는 `/llm-wiki:lint-wiki`, mem0 스토어는 `/mem0-ops:doctor` 가 담당 — 중복하지 않는다.
+**`/project-init:wiring`** — `new` 의 역방향. 이미 있는 repo 의 하네스 설정을 11 축으로 진단한다 (guidance 파일, llm-wiki 레이아웃 + `.staging` 미드레인 백로그, Serena 온보딩, 메모리 표면 충돌, spec 위치, gws-sync, `.tmp`, `core.hooksPath`, `.gitignore` 커버리지). 탐지는 `scripts/project_state.sh` 가 전담하는 read-only 단계이고, 결함마다 담당 스킬을 지목한 뒤 모든 수정은 `AskUserQuestion` 게이트 뒤에서만 적용한다. 위키 페이지 건강도는 `/llm-wiki:lint-wiki`, mem0 스토어는 `/mem0-ops:doctor` 가 담당 — 중복하지 않는다.
 
 **Requirements:** `gh` CLI authenticated, `git`, `jq`
 

--- a/README.md
+++ b/README.md
@@ -477,9 +477,9 @@ mem0 Platform store를 app_id **간** 레벨에서 진단·정리합니다. upst
 </details>
 
 <details>
-<summary><strong>project-init</strong> - Day-1 프로젝트 부트스트랩</summary>
+<summary><strong>project-init</strong> - Day-1 부트스트랩 + 기존 repo 셋업 진단</summary>
 
-새 디렉토리에서 단일 `/project-init:new` 한 번으로 인터뷰 → 로컬 시드 → gh 레포 생성 → 초기 커밋/푸시까지 완료.
+빈 디렉토리에서 `/project-init:new` 한 번으로 인터뷰 → 로컬 시드 → gh 레포 생성 → 초기 커밋/푸시까지 완료. 이미 있는 repo 는 `/project-init:checkup` 으로 진단.
 
 **시드 결과:**
 - `.claude/{spec,rules}/` + `.llmwiki/{raw,wiki}/` 빈 구조 (`.gitkeep`)
@@ -497,6 +497,8 @@ mem0 Platform store를 app_id **간** 레벨에서 진단·정리합니다. upst
 1. 코드 쌓이면 → `/rules-forge:write-rules`
 2. 첫 도메인 lore → `/llm-wiki:bootstrap-wiki`
 3. 첫 PR merge 후 → `/github-dev:post-merge` (post-merge 내장 wiki 적재 step)
+
+**`/project-init:checkup`** — `new` 의 역방향. 이미 있는 repo 의 하네스 설정을 11 축으로 진단한다 (guidance 파일, llm-wiki 레이아웃 + `.staging` 미드레인 백로그, Serena 온보딩, 메모리 표면 충돌, spec 위치, gws-sync, `.tmp`, `core.hooksPath`, `.gitignore` 커버리지). 탐지는 `scripts/project_state.sh` 가 전담하는 read-only 단계이고, 결함마다 담당 스킬을 지목한 뒤 모든 수정은 `AskUserQuestion` 게이트 뒤에서만 적용한다. 위키 페이지 건강도는 `/llm-wiki:lint-wiki`, mem0 스토어는 `/mem0-ops:doctor` 가 담당 — 중복하지 않는다.
 
 **Requirements:** `gh` CLI authenticated, `git`, `jq`
 

--- a/plugins/project-init/.claude-plugin/plugin.json
+++ b/plugins/project-init/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-init",
-  "version": "0.2.1",
-  "description": "One-shot first-day project bootstrap: .claude/ scaffold, minimal CLAUDE.md (LLM-Wiki entrypoint), AGENTS.md with Codex GitHub cloud reviewer guidelines, README/CHANGELOG seed, gh repo create + push. Dual-surface: /project-init:new command and `new` skill — both gated by a preflight guard that refuses non-empty directories.",
+  "version": "0.3.0",
+  "description": "Agent-harness project lifecycle. `new` bootstraps an empty dir (.claude/ scaffold, minimal CLAUDE.md, AGENTS.md with Codex GitHub cloud reviewer guidelines, README/CHANGELOG seed, gh repo create + push) behind a preflight guard that refuses non-empty directories. `checkup` is its inverse for existing repos: a read-only 11-axis diagnostic (guidance files, llm-wiki layout + staging backlog, Serena onboarding, memory-surface conflict, spec homes, gws-sync, .tmp, core.hooksPath, .gitignore coverage) that names the remediation skill per finding and gates every fix behind AskUserQuestion. Both consume the shared read-only detector scripts/project_state.sh.",
   "author": {
     "name": "YoungjaeDev"
   },
@@ -9,6 +9,7 @@
     "./commands/new.md"
   ],
   "skills": [
-    "./skills/new"
+    "./skills/new",
+    "./skills/checkup"
   ]
 }

--- a/plugins/project-init/.claude-plugin/plugin.json
+++ b/plugins/project-init/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-init",
   "version": "0.3.0",
-  "description": "Agent-harness project lifecycle. `new` bootstraps an empty dir (.claude/ scaffold, minimal CLAUDE.md, AGENTS.md with Codex GitHub cloud reviewer guidelines, README/CHANGELOG seed, gh repo create + push) behind a preflight guard that refuses non-empty directories. `checkup` is its inverse for existing repos: a read-only 11-axis diagnostic (guidance files, llm-wiki layout + staging backlog, Serena onboarding, memory-surface conflict, spec homes, gws-sync, .tmp, core.hooksPath, .gitignore coverage) that names the remediation skill per finding and gates every fix behind AskUserQuestion. Both consume the shared read-only detector scripts/project_state.sh.",
+  "description": "Agent-harness project lifecycle. `new` bootstraps an empty dir (.claude/ scaffold, minimal CLAUDE.md, AGENTS.md with Codex GitHub cloud reviewer guidelines, README/CHANGELOG seed, gh repo create + push) behind a preflight guard that refuses non-empty directories. `wiring` is its inverse for existing repos: a read-only 11-axis diagnostic (guidance files, llm-wiki layout + staging backlog, Serena onboarding, memory-surface conflict, spec homes, gws-sync, .tmp, core.hooksPath, .gitignore coverage) that names the remediation skill per finding and gates every fix behind AskUserQuestion. Both consume the shared read-only detector scripts/project_state.sh.",
   "author": {
     "name": "YoungjaeDev"
   },
@@ -10,6 +10,6 @@
   ],
   "skills": [
     "./skills/new",
-    "./skills/checkup"
+    "./skills/wiring"
   ]
 }

--- a/plugins/project-init/.codex-plugin/plugin.json
+++ b/plugins/project-init/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-init",
   "version": "0.3.0",
-  "description": "Agent-harness project lifecycle. `new` — one-shot first-day bootstrap (interview, .claude/ scaffold, minimal CLAUDE.md, AGENTS.md with Codex GitHub cloud reviewer guidelines in general/ml/web variants, README/CHANGELOG seed, gh repo create + initial push) behind a hardened preflight guard that refuses a non-empty cwd. `checkup` — its inverse for existing repos: a read-only 11-axis setup diagnostic (guidance files, llm-wiki layout + staging backlog, Serena onboarding, memory-surface conflict, spec homes, gws-sync, .tmp, core.hooksPath, .gitignore coverage) that names the remediation skill per finding and gates every fix behind AskUserQuestion. Shared read-only detector: scripts/project_state.sh.",
+  "description": "Agent-harness project lifecycle. `new` — one-shot first-day bootstrap (interview, .claude/ scaffold, minimal CLAUDE.md, AGENTS.md with Codex GitHub cloud reviewer guidelines in general/ml/web variants, README/CHANGELOG seed, gh repo create + initial push) behind a hardened preflight guard that refuses a non-empty cwd. `wiring` — its inverse for existing repos: a read-only 11-axis setup diagnostic (guidance files, llm-wiki layout + staging backlog, Serena onboarding, memory-surface conflict, spec homes, gws-sync, .tmp, core.hooksPath, .gitignore coverage) that names the remediation skill per finding and gates every fix behind AskUserQuestion. Shared read-only detector: scripts/project_state.sh.",
   "author": {
     "name": "YoungjaeDev"
   },

--- a/plugins/project-init/.codex-plugin/plugin.json
+++ b/plugins/project-init/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-init",
-  "version": "0.2.1",
-  "description": "One-shot first-day project bootstrap: interview, .claude/ scaffold, minimal CLAUDE.md (LLM-Wiki entrypoint), AGENTS.md with Codex GitHub cloud reviewer guidelines (general/ml/web variants), README/CHANGELOG seed, gh repo create + initial push. Dual-surface: `/project-init:new` command and `new` skill with hardened preflight guard (refuses non-empty cwd).",
+  "version": "0.3.0",
+  "description": "Agent-harness project lifecycle. `new` — one-shot first-day bootstrap (interview, .claude/ scaffold, minimal CLAUDE.md, AGENTS.md with Codex GitHub cloud reviewer guidelines in general/ml/web variants, README/CHANGELOG seed, gh repo create + initial push) behind a hardened preflight guard that refuses a non-empty cwd. `checkup` — its inverse for existing repos: a read-only 11-axis setup diagnostic (guidance files, llm-wiki layout + staging backlog, Serena onboarding, memory-surface conflict, spec homes, gws-sync, .tmp, core.hooksPath, .gitignore coverage) that names the remediation skill per finding and gates every fix behind AskUserQuestion. Shared read-only detector: scripts/project_state.sh.",
   "author": {
     "name": "YoungjaeDev"
   },

--- a/plugins/project-init/CLAUDE.md
+++ b/plugins/project-init/CLAUDE.md
@@ -3,7 +3,7 @@
 프로젝트의 **에이전트 하네스 lifecycle** 을 orchestrate. 두 방향이 대칭을 이룬다.
 
 - `new` — Day-1 셋업 (`.claude/`, CLAUDE.md, AGENTS.md, README/CHANGELOG, gh repo create+push). **빈 디렉토리 전용.**
-- `checkup` — 이미 존재하는 repo 의 하네스 설정 진단. **`new` 의 역방향.** read-only 탐지 후 `AskUserQuestion` 게이트 뒤에서만 수정.
+- `wiring` — 이미 존재하는 repo 의 하네스 설정 진단. **`new` 의 역방향.** read-only 탐지 후 `AskUserQuestion` 게이트 뒤에서만 수정.
 
 ## Surfaces
 
@@ -11,15 +11,15 @@
 |---------|-------|-------------|
 | Command | `/project-init:new` | 명시적 사용자 호출 — bootstrap 의 primary surface. |
 | Skill | `new` | Codex (및 Claude Code) 의 capability-discovery 용. description 이 좁게 잡혀 "bootstrap a new project in this empty dir" 류만 매치. |
-| Skill | `checkup` | 기존 repo 진단. command surface 없음 — `/project-init:checkup` 스킬 호출로 충분하고, command 는 Codex 로 emit 되지 않아 본문만 이중화된다. |
+| Skill | `wiring` | 기존 repo 진단. command surface 없음 — `/project-init:wiring` 스킬 호출로 충분하고, command 는 Codex 로 emit 되지 않아 본문만 이중화된다. |
 
-`new` 의 두 surface 는 본문 첫 블록에 **preflight hard guard** 를 둔다 — `.git/` / `.claude/` / source-file 이 cwd 에 하나라도 있으면 abort. description 기반 매칭에만 기대지 않고 runtime 에서 강제. `checkup` 에는 이 가드가 없다 (정의상 비어있지 않은 repo 에서만 의미).
+`new` 의 두 surface 는 본문 첫 블록에 **preflight hard guard** 를 둔다 — `.git/` / `.claude/` / source-file 이 cwd 에 하나라도 있으면 abort. description 기반 매칭에만 기대지 않고 runtime 에서 강제. `wiring` 에는 이 가드가 없다 (정의상 비어있지 않은 repo 에서만 의미).
 
 ## 탐지 SSOT
 
 `scripts/project_state.sh` 가 프로젝트 상태 탐지를 **혼자** 담당한다. 순수 read-only, JSON 한 덩어리 출력.
 
-- `checkup` 은 11 축 전체를 소비한다.
+- `wiring` 은 11 축 전체를 소비한다.
 - `idempotent-seed.sh diagnose` 는 이 스크립트를 감싸 legacy 출력 형태(`cwd`/`dir_name`/`git`/`seeded`/`code_signal`)만 골라낸다. 탐지 로직을 다시 구현하지 않는다.
 - **`new` 의 Step 0 hard guard 는 여기에 흡수하지 않는다.** 가드는 의존성 0 (순수 `find`) 이고 `PLUGIN_ROOT` 리졸버보다 **먼저** 돌아야 한다. 스크립트 호출로 바꾸면 "PLUGIN_ROOT 해석 실패 시 가드가 조용히 실행되지 않는" 실패 모드가 새로 생긴다. 안전 장치는 lazy-load 뒤로 옮기지 않는다.
 
@@ -28,8 +28,8 @@
 ## 원칙
 
 - **Preflight hard guard is non-negotiable**: `commands/new.md` 와 `skills/new/SKILL.md` 양쪽 Step 0 에 동일한 가드가 박혀 있다. description 만으로 잘못된 트리거를 막을 수 없다는 전제 — 모델이 description 을 잘못 해석해도 runtime 이 막는다. 가드 제거는 사용자의 명시적 (high-friction, 의도적) 결정이어야 한다.
-- **checkup 은 남의 영역을 진단하지 않는다**: 위키 페이지 건강도는 `/llm-wiki:lint-wiki`, mem0 스토어/설정 자세는 `/mem0-ops:doctor` 가 소유한다. checkup 은 파일시스템 신호만 본다 — "위키가 있는가 / 레이아웃이 맞는가 / 미드레인 캡처가 쌓였는가" 까지. 겹치면 두 진단이 서로 다른 답을 내는 날이 온다.
-- **결함마다 담당 스킬을 지목한다**: 다음 행동이 없는 판정은 노이즈다. 기계적·되돌릴 수 있는 수정 (`.gitignore` 라인, `.tmp/` 생성, `core.hooksPath`, serena `project_name`) 만 checkup 이 직접 고치고, 판단이 필요한 것 (`.staging` 큐레이션, wiki bootstrap/migrate, CLAUDE.md 저작, spec 이전, Serena 온보딩, mem0 변경) 은 전부 위임한다.
+- **wiring 은 남의 영역을 진단하지 않는다**: 위키 페이지 건강도는 `/llm-wiki:lint-wiki`, mem0 스토어/설정 자세는 `/mem0-ops:doctor` 가 소유한다. wiring 은 파일시스템 신호만 본다 — "위키가 있는가 / 레이아웃이 맞는가 / 미드레인 캡처가 쌓였는가" 까지. 겹치면 두 진단이 서로 다른 답을 내는 날이 온다.
+- **결함마다 담당 스킬을 지목한다**: 다음 행동이 없는 판정은 노이즈다. 기계적·되돌릴 수 있는 수정 (`.gitignore` 라인, `.tmp/` 생성, `core.hooksPath`, serena `project_name`) 만 wiring 이 직접 고치고, 판단이 필요한 것 (`.staging` 큐레이션, wiki bootstrap/migrate, CLAUDE.md 저작, spec 이전, Serena 온보딩, mem0 변경) 은 전부 위임한다.
 - **Minimal seeding, explicit follow-ups**: Day-1 에 필요한 것만 시드. tech-stack 기반 rules 생성과 wiki 도메인 인터뷰는 **호출 X, 안내만**. 빈 프로젝트에 generic 콘텐츠 만들면 사용자 덮어쓰기 비용 발생.
 - **Owner gate is mandatory**: 사용자가 personal + 다중 org 컨텍스트라 owner 자동 결정 금지. `AskUserQuestion` 으로 명시 선택.
 - **Codex GitHub reviewer surface**: AGENTS.md `## Review guidelines` 섹션이 Codex GitHub cloud reviewer 가 자동으로 읽는 영역. **레포 생성 시점에 시드**해야 첫 PR 부터 효과.
@@ -43,7 +43,7 @@ plugins/project-init/
 ├── commands/new.md                     # 명시적 슬래시 surface (preflight guard + 포인터)
 ├── skills/
 │   ├── new/SKILL.md                    # bootstrap 스킬 surface (동일 preflight guard + 포인터)
-│   └── checkup/SKILL.md                # 기존 repo 진단 (read-only 탐지 + 게이트 수정)
+│   └── wiring/SKILL.md                # 기존 repo 진단 (read-only 탐지 + 게이트 수정)
 ├── references/
 │   ├── new-procedure.md                # 본문 (Phase 0–7) — 두 surface 가 공유
 │   ├── codex-review-discovery.md       # AGENTS.md vs /review CLI

--- a/plugins/project-init/CLAUDE.md
+++ b/plugins/project-init/CLAUDE.md
@@ -1,19 +1,35 @@
 # Project-Init Plugin
 
-새 프로젝트의 Day-1 셋업 (`.claude/`, CLAUDE.md, AGENTS.md, README/CHANGELOG, gh repo create+push) 을 orchestrate. **Dual-surface**: 명시적 슬래시 호출 (`/project-init:new`) 과 capability-discovery 용 skill (`new`) 양쪽으로 노출, 본문은 `references/new-procedure.md` 한 곳.
+프로젝트의 **에이전트 하네스 lifecycle** 을 orchestrate. 두 방향이 대칭을 이룬다.
+
+- `new` — Day-1 셋업 (`.claude/`, CLAUDE.md, AGENTS.md, README/CHANGELOG, gh repo create+push). **빈 디렉토리 전용.**
+- `checkup` — 이미 존재하는 repo 의 하네스 설정 진단. **`new` 의 역방향.** read-only 탐지 후 `AskUserQuestion` 게이트 뒤에서만 수정.
 
 ## Surfaces
 
 | Surface | Entry | Description |
 |---------|-------|-------------|
-| Command | `/project-init:new` | 명시적 사용자 호출 — primary surface. |
+| Command | `/project-init:new` | 명시적 사용자 호출 — bootstrap 의 primary surface. |
 | Skill | `new` | Codex (및 Claude Code) 의 capability-discovery 용. description 이 좁게 잡혀 "bootstrap a new project in this empty dir" 류만 매치. |
+| Skill | `checkup` | 기존 repo 진단. command surface 없음 — `/project-init:checkup` 스킬 호출로 충분하고, command 는 Codex 로 emit 되지 않아 본문만 이중화된다. |
 
-두 surface 모두 본문 첫 블록에 **preflight hard guard** 를 둔다 — `.git/` / `.claude/` / source-file 이 cwd 에 하나라도 있으면 abort. description 기반 매칭에만 기대지 않고 runtime 에서 강제.
+`new` 의 두 surface 는 본문 첫 블록에 **preflight hard guard** 를 둔다 — `.git/` / `.claude/` / source-file 이 cwd 에 하나라도 있으면 abort. description 기반 매칭에만 기대지 않고 runtime 에서 강제. `checkup` 에는 이 가드가 없다 (정의상 비어있지 않은 repo 에서만 의미).
+
+## 탐지 SSOT
+
+`scripts/project_state.sh` 가 프로젝트 상태 탐지를 **혼자** 담당한다. 순수 read-only, JSON 한 덩어리 출력.
+
+- `checkup` 은 11 축 전체를 소비한다.
+- `idempotent-seed.sh diagnose` 는 이 스크립트를 감싸 legacy 출력 형태(`cwd`/`dir_name`/`git`/`seeded`/`code_signal`)만 골라낸다. 탐지 로직을 다시 구현하지 않는다.
+- **`new` 의 Step 0 hard guard 는 여기에 흡수하지 않는다.** 가드는 의존성 0 (순수 `find`) 이고 `PLUGIN_ROOT` 리졸버보다 **먼저** 돌아야 한다. 스크립트 호출로 바꾸면 "PLUGIN_ROOT 해석 실패 시 가드가 조용히 실행되지 않는" 실패 모드가 새로 생긴다. 안전 장치는 lazy-load 뒤로 옮기지 않는다.
+
+`find` 는 "없음" 을 exit 1 로 표현한다. `set -o pipefail` 아래서 `find ... | wc -l` 는 정상적인 빈 결과에 스크립트를 죽인다. 모든 `find` 는 `find_or_empty` / `count_files` 헬퍼를 거치고, `code_signal` 은 `head` 로 인한 SIGPIPE 오탐을 피하려고 `-print -quit` 를 쓴다.
 
 ## 원칙
 
 - **Preflight hard guard is non-negotiable**: `commands/new.md` 와 `skills/new/SKILL.md` 양쪽 Step 0 에 동일한 가드가 박혀 있다. description 만으로 잘못된 트리거를 막을 수 없다는 전제 — 모델이 description 을 잘못 해석해도 runtime 이 막는다. 가드 제거는 사용자의 명시적 (high-friction, 의도적) 결정이어야 한다.
+- **checkup 은 남의 영역을 진단하지 않는다**: 위키 페이지 건강도는 `/llm-wiki:lint-wiki`, mem0 스토어/설정 자세는 `/mem0-ops:doctor` 가 소유한다. checkup 은 파일시스템 신호만 본다 — "위키가 있는가 / 레이아웃이 맞는가 / 미드레인 캡처가 쌓였는가" 까지. 겹치면 두 진단이 서로 다른 답을 내는 날이 온다.
+- **결함마다 담당 스킬을 지목한다**: 다음 행동이 없는 판정은 노이즈다. 기계적·되돌릴 수 있는 수정 (`.gitignore` 라인, `.tmp/` 생성, `core.hooksPath`, serena `project_name`) 만 checkup 이 직접 고치고, 판단이 필요한 것 (`.staging` 큐레이션, wiki bootstrap/migrate, CLAUDE.md 저작, spec 이전, Serena 온보딩, mem0 변경) 은 전부 위임한다.
 - **Minimal seeding, explicit follow-ups**: Day-1 에 필요한 것만 시드. tech-stack 기반 rules 생성과 wiki 도메인 인터뷰는 **호출 X, 안내만**. 빈 프로젝트에 generic 콘텐츠 만들면 사용자 덮어쓰기 비용 발생.
 - **Owner gate is mandatory**: 사용자가 personal + 다중 org 컨텍스트라 owner 자동 결정 금지. `AskUserQuestion` 으로 명시 선택.
 - **Codex GitHub reviewer surface**: AGENTS.md `## Review guidelines` 섹션이 Codex GitHub cloud reviewer 가 자동으로 읽는 영역. **레포 생성 시점에 시드**해야 첫 PR 부터 효과.
@@ -25,7 +41,9 @@
 plugins/project-init/
 ├── .claude-plugin/plugin.json
 ├── commands/new.md                     # 명시적 슬래시 surface (preflight guard + 포인터)
-├── skills/new/SKILL.md                 # 스킬 surface (동일 preflight guard + 포인터)
+├── skills/
+│   ├── new/SKILL.md                    # bootstrap 스킬 surface (동일 preflight guard + 포인터)
+│   └── checkup/SKILL.md                # 기존 repo 진단 (read-only 탐지 + 게이트 수정)
 ├── references/
 │   ├── new-procedure.md                # 본문 (Phase 0–7) — 두 surface 가 공유
 │   ├── codex-review-discovery.md       # AGENTS.md vs /review CLI
@@ -38,7 +56,8 @@ plugins/project-init/
 │   └── CHANGELOG.initial.md
 ├── scripts/
 │   ├── infer-github-context.sh         # gh api user + orgs
-│   └── idempotent-seed.sh              # 충돌 가드 + .claude/ + .llmwiki/ 시드
+│   ├── idempotent-seed.sh              # 충돌 가드 + .claude/ + .llmwiki/ 시드 (diagnose = 래퍼)
+│   └── project_state.sh                # 탐지 SSOT — read-only 11 축 JSON
 └── CLAUDE.md                           # this file
 ```
 

--- a/plugins/project-init/scripts/idempotent-seed.sh
+++ b/plugins/project-init/scripts/idempotent-seed.sh
@@ -75,63 +75,18 @@ cmd_check_collision() {
   exit 0
 }
 
+# 탐지는 project_state.sh 가 SSOT. 여기서는 기존 diagnose 출력 형태만 유지하도록
+# 필요한 필드를 골라낸다 (project_state.sh 는 git 아래 hooks_* 등 상위 집합을 낸다).
 cmd_diagnose() {
-  local cwd
-  cwd=$(pwd)
-  local has_git="false"
-  [ -d .git ] && has_git="true"
-  local has_claude="false"
-  [ -d .claude ] && has_claude="true"
-  local has_claude_md="false"
-  [ -f CLAUDE.md ] && has_claude_md="true"
-  local has_agents_md="false"
-  [ -f AGENTS.md ] && has_agents_md="true"
-  local has_readme="false"
-  [ -f README.md ] && has_readme="true"
-  local has_changelog="false"
-  [ -f CHANGELOG.md ] && has_changelog="true"
-  local commit_count="0"
-  if [ "$has_git" = "true" ]; then
-    commit_count=$(git rev-list --count HEAD 2>/dev/null || echo "0")
-  fi
-  local has_remote="false"
-  if [ "$has_git" = "true" ] && git remote get-url origin >/dev/null 2>&1; then
-    has_remote="true"
-  fi
-  # Quick code signal — first detected ext, else "none"
-  local code_signal="none"
-  for ext in py ts tsx js jsx go rs java rb php; do
-    if find . -maxdepth 3 -type f -name "*.${ext}" 2>/dev/null | head -1 | grep -q .; then
-      code_signal="${ext}"
-      break
-    fi
-  done
-
-  jq -nc \
-    --arg cwd "$cwd" \
-    --arg dir_name "$(basename "$cwd")" \
-    --argjson has_git "$has_git" \
-    --argjson has_claude "$has_claude" \
-    --argjson has_claude_md "$has_claude_md" \
-    --argjson has_agents_md "$has_agents_md" \
-    --argjson has_readme "$has_readme" \
-    --argjson has_changelog "$has_changelog" \
-    --argjson commit_count "$commit_count" \
-    --argjson has_remote "$has_remote" \
-    --arg code_signal "$code_signal" \
-    '{
-      cwd: $cwd,
-      dir_name: $dir_name,
-      git: { initialized: $has_git, commits: $commit_count, remote_origin: $has_remote },
-      seeded: {
-        claude_dir: $has_claude,
-        claude_md: $has_claude_md,
-        agents_md: $has_agents_md,
-        readme: $has_readme,
-        changelog: $has_changelog
-      },
-      code_signal: $code_signal
-    }'
+  local script_dir
+  script_dir="$(cd "$(dirname "$0")" && pwd)"
+  bash "$script_dir/project_state.sh" | jq -c '{
+    cwd,
+    dir_name,
+    git: { initialized: .git.initialized, commits: .git.commits, remote_origin: .git.remote_origin },
+    seeded,
+    code_signal
+  }'
 }
 
 case "$CMD" in

--- a/plugins/project-init/scripts/project_state.sh
+++ b/plugins/project-init/scripts/project_state.sh
@@ -1,0 +1,239 @@
+#!/usr/bin/env bash
+# project_state.sh
+#
+# 프로젝트의 에이전트 하네스 설정 상태를 탐지해 JSON 한 덩어리로 출력한다.
+# 순수 read-only — 어떤 파일도 만들거나 고치지 않는다.
+#
+# `/project-init:checkup` 의 탐지 SSOT. `idempotent-seed.sh diagnose` 도 이걸 감싼다.
+#
+# Usage:
+#   bash project_state.sh            # 전체 상태 JSON
+#
+# Env:
+#   CHECKUP_TMP_STALE_DAYS   .tmp/ stale 판정 기준 (기본 14)
+#
+# 의존성: jq (infer-github-context.sh / idempotent-seed.sh 와 동일한 기존 의존성)
+
+set -euo pipefail
+
+STALE_DAYS="${CHECKUP_TMP_STALE_DAYS:-14}"
+
+b() { if "$@" >/dev/null 2>&1; then echo true; else echo false; fi; }
+
+# `find` 는 "없음" 을 exit 1 로 표현한다. pipefail 아래서 그대로 파이프에 물리면
+# 정상적인 빈 결과가 스크립트를 죽인다 — 모든 find 는 이 두 헬퍼를 거친다.
+find_or_empty() { find "$@" 2>/dev/null || true; }
+
+count_files() { find_or_empty "$@" | wc -l | tr -d ' '; }
+
+# 디렉토리가 없으면 0. -maxdepth 1 로 최상위만.
+count_md() {
+  [ -d "$1" ] || { echo 0; return; }
+  count_files "$1" -maxdepth 1 -type f -name '*.md'
+}
+
+# YAML frontmatter (첫 줄이 ---) 가 없는 .md 개수
+count_no_frontmatter() {
+  local dir="$1" n=0 f
+  [ -d "$dir" ] || { echo 0; return; }
+  while IFS= read -r f; do
+    [ -n "$f" ] || continue
+    if [ "$(head -1 "$f" 2>/dev/null)" != "---" ]; then n=$((n + 1)); fi
+  done <<EOF
+$(find_or_empty "$dir" -maxdepth 1 -type f -name '*.md')
+EOF
+  echo "$n"
+}
+
+ignored() {
+  # git repo 가 아니면 판정 불가 -> false
+  [ "$GIT_INIT" = true ] || { echo false; return; }
+  if git check-ignore -q "$1" 2>/dev/null; then echo true; else echo false; fi
+}
+
+CWD="$(pwd)"
+DIR_NAME="$(basename "$CWD")"
+
+# --- git -----------------------------------------------------------------
+GIT_INIT=$(b test -d .git)
+COMMITS=0
+REMOTE=false
+if [ "$GIT_INIT" = true ]; then
+  COMMITS=$(git rev-list --count HEAD 2>/dev/null || echo 0)
+  REMOTE=$(b git remote get-url origin)
+fi
+HOOKS_PATH=$(git config core.hooksPath 2>/dev/null || true)
+HOOKS_DIR=$(b test -d .githooks)
+
+# --- seeded files (idempotent-seed.sh diagnose 호환 필드) -----------------
+S_CLAUDE_DIR=$(b test -d .claude)
+S_CLAUDE_MD=$(b test -f CLAUDE.md)
+S_AGENTS_MD=$(b test -f AGENTS.md)
+S_README=$(b test -f README.md)
+S_CHANGELOG=$(b test -f CHANGELOG.md)
+
+# `find | head -1 | grep -q .` 는 head 의 조기 종료가 find 를 SIGPIPE(141) 로 죽여
+# pipefail 아래서 "찾았는데 못 찾았다" 로 뒤집힌다. -print -quit 로 파이프를 제거.
+CODE_SIGNAL=none
+for ext in py ts tsx js jsx go rs java rb php; do
+  if [ -n "$(find_or_empty . -maxdepth 3 -type f -name "*.${ext}" -print -quit)" ]; then
+    CODE_SIGNAL="$ext"
+    break
+  fi
+done
+
+# --- guidance (CLAUDE.md / AGENTS.md / .claude/rules) ---------------------
+RULES_COUNT=$(count_md .claude/rules)
+# 크로스런타임 공백: Claude 전용 rules 가 있는데 Codex/Hermes 가 읽는 AGENTS.md 가 없음.
+# Codex/Hermes 는 `@import` 를 확장하지 않으므로 AGENTS.md 부재 = 지침 소실.
+CROSS_RUNTIME_GAP=false
+if [ "$RULES_COUNT" -gt 0 ] && [ "$S_AGENTS_MD" = false ]; then CROSS_RUNTIME_GAP=true; fi
+
+# --- llm-wiki ------------------------------------------------------------
+# 루트 판정은 hooks/skills 와 동일한 규칙: index.md 또는 log.md 가 있어야 카운트.
+wiki_root_at() { [ -f "$1/index.md" ] || [ -f "$1/log.md" ]; }
+WIKI_STATE=absent
+if wiki_root_at .llmwiki/wiki; then
+  WIKI_STATE=current
+elif wiki_root_at .claude/wiki || wiki_root_at .codex/wiki; then
+  WIKI_STATE=legacy
+fi
+WIKI_INSIGHT=$(b test -f .llmwiki/insight/index.md)
+# post-2.4.0 신호: raw/ 가 source-type 버킷 구조
+WIKI_RAW_BUCKETS=false
+if [ -d .llmwiki/raw/external ] && [ -d .llmwiki/raw/research ] \
+  && [ -d .llmwiki/raw/transcripts ] && [ -d .llmwiki/raw/audits ]; then
+  WIKI_RAW_BUCKETS=true
+fi
+STAGING_PENDING=$(count_files .llmwiki/.staging -maxdepth 1 -name 'pending-*.md')
+
+# --- serena --------------------------------------------------------------
+SERENA_MEMS=$(count_files .serena/memories -maxdepth 1 -type f -name '*.md')
+SERENA_STATE=not-registered
+if [ -f .serena/project.yml ]; then
+  if [ "$SERENA_MEMS" -gt 0 ]; then SERENA_STATE=onboarded; else SERENA_STATE=registered; fi
+fi
+SERENA_NAME=""
+SERENA_DRIFT=false
+if [ -f .serena/project.yml ]; then
+  SERENA_NAME=$(sed -n 's/^project_name:[[:space:]]*//p' .serena/project.yml | head -1 | tr -d '"'"'" | tr -d '\r')
+  if [ -n "$SERENA_NAME" ] && [ "$SERENA_NAME" != "$DIR_NAME" ]; then SERENA_DRIFT=true; fi
+fi
+
+# --- memory surfaces -----------------------------------------------------
+# 네이티브 auto-memory 는 cwd 를 '/'->'-' 치환한 slug 로 ~/.claude/projects/ 아래 산다.
+SLUG=$(printf '%s' "$CWD" | sed 's#/#-#g')
+NATIVE_MEM=$(b test -f "$HOME/.claude/projects/$SLUG/memory/MEMORY.md")
+MEM0_SETTINGS=$(b test -f "$HOME/.mem0/settings.json")
+MEM0_MAPPED=false
+if [ -f "$HOME/.mem0/project_map.json" ]; then
+  MEM0_MAPPED=$(b grep -qF "\"$CWD\"" "$HOME/.mem0/project_map.json")
+fi
+
+# 파일 존재는 기능 활성화의 프록시일 뿐이다. MEMORY.md 는 auto-memory 를 끈 뒤에도
+# 남으므로, 두 writer 가 정말 동시에 살아있는지는 설정을 직접 읽어야 안다.
+# 설정 cascade: user < project < local. 미설정이면 기본 ON.
+SETTINGS_CASCADE=("$HOME/.claude/settings.json" ".claude/settings.json" ".claude/settings.local.json")
+NATIVE_ENABLED=true
+for f in "${SETTINGS_CASCADE[@]}"; do
+  [ -f "$f" ] || continue
+  v=$(jq -r 'if has("autoMemoryEnabled") then (.autoMemoryEnabled|tostring) else empty end' "$f" 2>/dev/null || true)
+  if [ -n "$v" ]; then NATIVE_ENABLED="$v"; fi
+done
+
+# 연합 라벨: 런타임 env 가 우선, 없으면 settings 의 env 블록. 기본 off (=0).
+FED_RAW="${CORE_CONFIG_FEDERATE_MEM0:-}"
+if [ -z "$FED_RAW" ]; then
+  for f in "${SETTINGS_CASCADE[@]}"; do
+    [ -f "$f" ] || continue
+    v=$(jq -r '.env.CORE_CONFIG_FEDERATE_MEM0 // empty' "$f" 2>/dev/null || true)
+    if [ -n "$v" ]; then FED_RAW="$v"; fi
+  done
+fi
+FEDERATE=false
+if [ "$FED_RAW" = "1" ]; then FEDERATE=true; fi
+
+# --- spec ----------------------------------------------------------------
+SPEC_CLAUDE=$(count_md .claude/spec)
+SPEC_SUPERPOWERS=$(count_md docs/superpowers/specs)
+SPEC_STATE=$(b test -f .claude/state/spec.json)
+SPEC_NO_FM=$(( $(count_no_frontmatter .claude/spec) + $(count_no_frontmatter docs/superpowers/specs) ))
+
+# --- gws-sync ------------------------------------------------------------
+GWS_CLI=$(b command -v gws)
+GWS_CONFIG=$(b test -f .gws-sync.json)
+
+# --- .tmp ----------------------------------------------------------------
+TMP_DIR=$(b test -d .tmp)
+TMP_IGNORED=$(ignored .tmp/)
+TMP_STALE=0
+if [ "$TMP_DIR" = true ]; then
+  TMP_STALE=$(count_files .tmp -type f -mtime "+${STALE_DAYS}")
+fi
+
+# --- .gitignore coverage -------------------------------------------------
+GI_STATE=$(ignored .claude/state/)
+GI_SERENA=$(ignored .serena/)
+GI_STAGING=$(ignored .llmwiki/.staging/)
+GI_ENV=$(ignored .env)
+
+jq -nc \
+  --arg cwd "$CWD" --arg dir_name "$DIR_NAME" \
+  --argjson git_init "$GIT_INIT" --argjson commits "$COMMITS" --argjson remote "$REMOTE" \
+  --arg hooks_path "$HOOKS_PATH" --argjson hooks_dir "$HOOKS_DIR" \
+  --argjson s_claude_dir "$S_CLAUDE_DIR" --argjson s_claude_md "$S_CLAUDE_MD" \
+  --argjson s_agents_md "$S_AGENTS_MD" --argjson s_readme "$S_README" --argjson s_changelog "$S_CHANGELOG" \
+  --arg code_signal "$CODE_SIGNAL" \
+  --argjson rules_count "$RULES_COUNT" --argjson cross_gap "$CROSS_RUNTIME_GAP" \
+  --arg wiki_state "$WIKI_STATE" --argjson wiki_insight "$WIKI_INSIGHT" \
+  --argjson wiki_buckets "$WIKI_RAW_BUCKETS" --argjson staging "$STAGING_PENDING" \
+  --arg serena_state "$SERENA_STATE" --argjson serena_mems "$SERENA_MEMS" \
+  --arg serena_name "$SERENA_NAME" --argjson serena_drift "$SERENA_DRIFT" \
+  --argjson native_mem "$NATIVE_MEM" --argjson native_enabled "$NATIVE_ENABLED" \
+  --argjson mem0_settings "$MEM0_SETTINGS" --argjson mem0_mapped "$MEM0_MAPPED" \
+  --argjson federate "$FEDERATE" \
+  --argjson spec_claude "$SPEC_CLAUDE" --argjson spec_sp "$SPEC_SUPERPOWERS" \
+  --argjson spec_state "$SPEC_STATE" --argjson spec_no_fm "$SPEC_NO_FM" \
+  --argjson gws_cli "$GWS_CLI" --argjson gws_config "$GWS_CONFIG" \
+  --argjson tmp_dir "$TMP_DIR" --argjson tmp_ignored "$TMP_IGNORED" \
+  --argjson tmp_stale "$TMP_STALE" --argjson stale_days "$STALE_DAYS" \
+  --argjson gi_state "$GI_STATE" --argjson gi_serena "$GI_SERENA" --argjson gi_staging "$GI_STAGING" \
+  --argjson gi_env "$GI_ENV" \
+  '{
+    cwd: $cwd,
+    dir_name: $dir_name,
+    git: {
+      initialized: $git_init, commits: $commits, remote_origin: $remote,
+      hooks_path: (if $hooks_path == "" then null else $hooks_path end),
+      hooks_dir_present: $hooks_dir
+    },
+    seeded: {
+      claude_dir: $s_claude_dir, claude_md: $s_claude_md, agents_md: $s_agents_md,
+      readme: $s_readme, changelog: $s_changelog
+    },
+    code_signal: $code_signal,
+    guidance: { rules_count: $rules_count, cross_runtime_gap: $cross_gap },
+    llmwiki: {
+      state: $wiki_state, insight_layer: $wiki_insight,
+      raw_source_buckets: $wiki_buckets, staging_pending: $staging
+    },
+    serena: {
+      state: $serena_state, memories: $serena_mems,
+      project_name: (if $serena_name == "" then null else $serena_name end),
+      name_drift: $serena_drift
+    },
+    memory: {
+      native_memory_md: $native_mem,
+      native_auto_memory_enabled: $native_enabled,
+      mem0_settings: $mem0_settings,
+      mem0_project_mapped: $mem0_mapped,
+      federate_labels: $federate
+    },
+    spec: {
+      claude_spec: $spec_claude, superpowers_spec: $spec_sp,
+      state_json: $spec_state, missing_frontmatter: $spec_no_fm
+    },
+    gws_sync: { cli: $gws_cli, config: $gws_config },
+    tmp: { dir: $tmp_dir, gitignored: $tmp_ignored, stale_files: $tmp_stale, stale_days: $stale_days },
+    gitignore: { claude_state: $gi_state, serena: $gi_serena, llmwiki_staging: $gi_staging, tmp: $tmp_ignored, env: $gi_env }
+  }'

--- a/plugins/project-init/scripts/project_state.sh
+++ b/plugins/project-init/scripts/project_state.sh
@@ -17,6 +17,14 @@
 set -euo pipefail
 
 STALE_DAYS="${CHECKUP_TMP_STALE_DAYS:-14}"
+# 비정수면 `find -mtime +$STALE_DAYS` 와 `jq --argjson` 이 둘 다 깨진다.
+# jq 의 usage dump 대신 원인을 말하고 죽는다.
+case "$STALE_DAYS" in
+  '' | *[!0-9]*)
+    echo "[project_state] CHECKUP_TMP_STALE_DAYS must be a non-negative integer (got: $STALE_DAYS)" >&2
+    exit 2
+    ;;
+esac
 
 b() { if "$@" >/dev/null 2>&1; then echo true; else echo false; fi; }
 
@@ -55,14 +63,23 @@ CWD="$(pwd)"
 DIR_NAME="$(basename "$CWD")"
 
 # --- git -----------------------------------------------------------------
-GIT_INIT=$(b test -d .git)
+# `test -d .git` 은 worktree 와 submodule 에서 false 다 — 거기선 .git 이 gitdir
+# 포인터 *파일*이다. 그러면 ignored() 가 전부 false 를 뱉어 .gitignore 축이
+# 통째로 거짓 FAIL 이 된다 (github-dev 는 worktree 를 쓴다).
+GIT_INIT=false
+if [ "$(git rev-parse --is-inside-work-tree 2>/dev/null)" = "true" ]; then GIT_INIT=true; fi
 COMMITS=0
 REMOTE=false
 if [ "$GIT_INIT" = true ]; then
   COMMITS=$(git rev-list --count HEAD 2>/dev/null || echo 0)
   REMOTE=$(b git remote get-url origin)
 fi
-HOOKS_PATH=$(git config core.hooksPath 2>/dev/null || true)
+# repo 밖에서 core.hooksPath 를 읽으면 남의 global 값을 이 프로젝트 것인 양 보고한다.
+# 단 scope 는 좁히지 않는다 — 실제로 적용되는 값은 local > global > system 의 해석 결과다.
+HOOKS_PATH=""
+if [ "$GIT_INIT" = true ]; then
+  HOOKS_PATH=$(git config core.hooksPath 2>/dev/null || true)
+fi
 HOOKS_DIR=$(b test -d .githooks)
 
 # --- seeded files (idempotent-seed.sh diagnose 호환 필드) -----------------

--- a/plugins/project-init/scripts/project_state.sh
+++ b/plugins/project-init/scripts/project_state.sh
@@ -4,24 +4,24 @@
 # 프로젝트의 에이전트 하네스 설정 상태를 탐지해 JSON 한 덩어리로 출력한다.
 # 순수 read-only — 어떤 파일도 만들거나 고치지 않는다.
 #
-# `/project-init:checkup` 의 탐지 SSOT. `idempotent-seed.sh diagnose` 도 이걸 감싼다.
+# `/project-init:wiring` 의 탐지 SSOT. `idempotent-seed.sh diagnose` 도 이걸 감싼다.
 #
 # Usage:
 #   bash project_state.sh            # 전체 상태 JSON
 #
 # Env:
-#   CHECKUP_TMP_STALE_DAYS   .tmp/ stale 판정 기준 (기본 14)
+#   WIRING_TMP_STALE_DAYS   .tmp/ stale 판정 기준 (기본 14)
 #
 # 의존성: jq (infer-github-context.sh / idempotent-seed.sh 와 동일한 기존 의존성)
 
 set -euo pipefail
 
-STALE_DAYS="${CHECKUP_TMP_STALE_DAYS:-14}"
+STALE_DAYS="${WIRING_TMP_STALE_DAYS:-14}"
 # 비정수면 `find -mtime +$STALE_DAYS` 와 `jq --argjson` 이 둘 다 깨진다.
 # jq 의 usage dump 대신 원인을 말하고 죽는다.
 case "$STALE_DAYS" in
   '' | *[!0-9]*)
-    echo "[project_state] CHECKUP_TMP_STALE_DAYS must be a non-negative integer (got: $STALE_DAYS)" >&2
+    echo "[project_state] WIRING_TMP_STALE_DAYS must be a non-negative integer (got: $STALE_DAYS)" >&2
     exit 2
     ;;
 esac

--- a/plugins/project-init/skills/checkup/SKILL.md
+++ b/plugins/project-init/skills/checkup/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: checkup
+description: "This skill should be used when the user asks to run a project setup diagnostic on an EXISTING repository — phrases like '프로젝트 진단', '셋업 점검', '이 repo 설정 제대로 됐는지 확인', 'project checkup', 'is this repo wired up', 'diagnose my project setup', or an explicit /project-init:checkup invocation. Detects 11 axes of agent-harness configuration (git, CLAUDE.md/AGENTS.md guidance, .claude/rules, llm-wiki layout + staging backlog, Serena onboarding, memory surfaces, spec locations, gws-sync, .tmp convention, git hooksPath, .gitignore coverage), reports a verdict per axis with the remediation skill named, then gates every fix behind AskUserQuestion. Read-only until the user approves. Complements /project-init:new (which bootstraps an EMPTY dir and refuses to run here). Not for mem0 store diagnostics (use /mem0-ops:doctor) or wiki-content health (use /llm-wiki:lint-wiki)."
+---
+
+# project-init `checkup` skill
+
+Diagnose whether an existing repository's agent-harness conventions are actually wired up, then fix what the user approves.
+
+Sibling of `new`: `new` bootstraps an empty directory and hard-aborts on a non-empty one. `checkup` is the inverse — it only makes sense on a repo that already exists.
+
+## Contract
+
+- **Detection is read-only.** `scripts/project_state.sh` never writes. Run it first, always.
+- **Nothing is fixed before approval.** Present the full report, then a single `AskUserQuestion` gate.
+- **Delegate, do not reimplement.** Every remediation that needs judgment routes to the skill that owns it. Only mechanical, reversible edits are applied here.
+- **Absent tooling is not a defect.** An unconfigured optional integration (gws-sync without the `gws` CLI) reports `SKIP`, never `FAIL`.
+
+## Step 0 — Resolve PLUGIN_ROOT
+
+Codex does not export `CLAUDE_PLUGIN_ROOT`. Resolve across runtimes before calling any bundled script:
+
+```bash
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-}"
+[ -z "$PLUGIN_ROOT" ] && [ -d plugins/project-init/scripts ] && PLUGIN_ROOT=plugins/project-init
+if [ -z "$PLUGIN_ROOT" ]; then
+  cache_root="${CODEX_PLUGIN_CACHE:-$HOME/.codex/plugins/cache}"
+  PLUGIN_ROOT=$(ls -1d "$cache_root"/*/project-init/* 2>/dev/null | sort | tail -1)
+fi
+[ -d "$PLUGIN_ROOT/scripts" ] || { echo "project-init scripts not found"; exit 1; }
+```
+
+## Step 1 — Detect
+
+```bash
+bash "$PLUGIN_ROOT/scripts/project_state.sh"
+```
+
+Emits one JSON object. `CHECKUP_TMP_STALE_DAYS` (default 14) sets the `.tmp/` staleness window. Requires `jq`.
+
+Do not re-derive any field with ad-hoc `test -f` calls — the script is the detection SSOT, and duplicating it is how the three pre-existing detectors drifted.
+
+## Step 2 — Verdict per axis
+
+Map the JSON to verdicts. `FAIL` = broken or losing data. `WARN` = works but degraded. `SKIP` = optional and not adopted. `OK` = healthy.
+
+| Axis | JSON | FAIL when | WARN when | Remediation |
+|---|---|---|---|---|
+| git | `.git` | `initialized: false` | `commits: 0` or `remote_origin: false` | `git init` / `gh repo create` |
+| hooksPath | `.git.hooks_path`, `.hooks_dir_present` | — | `hooks_dir_present: true` but `hooks_path: null` | `git config core.hooksPath .githooks` |
+| guidance | `.seeded.claude_md`, `.guidance` | `claude_md: false` | `cross_runtime_gap: true` | `/rules-forge:write-rules` |
+| llm-wiki | `.llmwiki` | `staging_pending > 0` | `state: absent`; `state: legacy`; `state: current` but `insight_layer: false` or `raw_source_buckets: false` | pending → `/llm-wiki:ingest-finding`; absent → `/llm-wiki:bootstrap-wiki`; legacy → `/llm-wiki:migrate-wiki` |
+| serena | `.serena` | — | `state: not-registered` / `registered`; `name_drift: true` | onboard via Serena MCP `onboarding`; drift → edit `.serena/project.yml` |
+| memory | `.memory` | `native_auto_memory_enabled: true` **and** `mem0_settings: true` | `native_memory_md: true` but auto-memory disabled (orphan files); `mem0_settings: true` but `federate_labels: false`; `mem0_project_mapped: false` | see "Memory posture" below |
+| spec | `.spec` | — | `claude_spec > 0` **and** `superpowers_spec > 0` (split home); `missing_frontmatter > 0` | `/spec-state:state-tracker init` |
+| gws-sync | `.gws_sync` | — | `cli: true` but `config: false` | `/gws-sync:gws-sync` |
+| .tmp | `.tmp` | — | `dir: true` and `gitignored: false`; `stale_files > 0` | mechanical fix (Step 4) |
+| gitignore | `.gitignore` | `env: false` | any of `claude_state` / `serena` / `llmwiki_staging` false | mechanical fix (Step 4) |
+| code_signal | `.code_signal` | — | — | informational only |
+
+Three verdicts need an explanation the JSON cannot carry:
+
+- **`staging_pending > 0` is FAIL, not WARN.** The llm-wiki Stop-hook captured session lore into `.llmwiki/.staging/`, and the SessionStart drain never curated it. That directory is gitignored, so the lore is one `rm` from being lost permanently.
+- **The memory FAIL keys on `native_auto_memory_enabled`, never on `native_memory_md`.** File presence is a proxy for a feature being on, and the two diverge the moment auto-memory is disabled: `MEMORY.md` survives the setting change. Keying the verdict on the file would keep reporting a conflict this skill already helped resolve. A leftover `MEMORY.md` with auto-memory off is a WARN (dead files), not a FAIL.
+- **`gitignore.env: false` is FAIL.** An untracked-but-uncovered `.env` is one `git add -A` from committing credentials. The other gitignore entries only leak local state.
+
+`llm-wiki` layout note: there is no version stamp in `.llmwiki/`. `state: current` + `insight_layer: true` + `raw_source_buckets: true` together mean the post-2.4.0 layout. Any one of them false means a partial migration, not a plugin-version mismatch.
+
+## Step 3 — Report
+
+Print a fixed-width table, most severe first. Name the remediation on every non-OK row — a verdict without a next action is noise.
+
+```
+## Project Checkup — <dir_name>
+
+[FAIL] llm-wiki    .llmwiki/.staging: 2 pending captures uncurated
+                   -> /llm-wiki:ingest-finding  (gitignored; lore is unrecoverable if cleaned)
+[WARN] serena      project.yml name "oh-my-claudecode" != dir "my-claude-plugins"
+                   -> edit .serena/project.yml
+[WARN] .tmp        not covered by .gitignore
+                   -> mechanical fix available
+[SKIP] gws-sync    gws CLI not installed
+[ OK ] llm-wiki    post-2.4.0 layout (insight + raw buckets)
+[ OK ] serena      onboarded (1 memory)
+```
+
+State the scan is filesystem-only. Two things it deliberately does not check, to avoid duplicating their owners:
+
+- wiki page staleness / identity duplication → `/llm-wiki:lint-wiki`
+- mem0 store contents and config posture → `/mem0-ops:doctor`
+
+## Step 4 — Gate, then fix
+
+Present ONE `AskUserQuestion`. Put "Apply all mechanical fixes (Recommended)" first, "Let me pick" second, "Report only" last. If the user picks "Let me pick", follow with one `multiSelect` question, one option per fix group.
+
+**Mechanically fixable here** (reversible, no judgment):
+
+| Fix | Edit |
+|---|---|
+| `.gitignore` coverage | append missing lines for `.env`, `.claude/state/`, `.serena/`, `.llmwiki/.staging/`, `.tmp/` |
+| `.tmp/` convention | `mkdir -p .tmp && : > .tmp/.gitkeep` + the `.gitignore` line |
+| hooksPath | `git config core.hooksPath .githooks` |
+| serena name drift | rewrite the `project_name:` line in `.serena/project.yml` |
+
+**Never fixed here** — delegate, and say so:
+
+`.staging` drain, wiki bootstrap/migrate, CLAUDE.md authoring, spec relocation, Serena onboarding, mem0 changes. Each needs LLM judgment or touches a store this skill does not own.
+
+Deleting stale `.tmp/` files is destructive: list them, confirm separately, and never widen the glob beyond `.tmp/`.
+
+## Memory posture
+
+This axis checks **posture consistency** — which writers are live and whether their authority relationship is declared. It does **not** check **content consistency**: whether mem0 and `.llmwiki/` hold contradicting versions of the same fact. That comparison spans a cloud API and a markdown tree, no tool in this toolchain performs it, and claiming otherwise would be a lie. Say so when reporting.
+
+Four surfaces, one role each:
+
+- `.llmwiki/` — authoritative lore (git-tracked, dated, sourced).
+- mem0 — recall assistance (cloud, ephemeral).
+- Serena memories — symbol/structure maps.
+- `.claude/rules/` — mechanical tool invariants only, never lore.
+
+When `native_auto_memory_enabled` and `mem0_settings` are both true, two writers fight: mem0's `block_memory_write.sh` PreToolUse hook blocks `Write`/`Edit` to `MEMORY.md`, so the native file is loaded into every session's context yet cannot be updated. It rots silently.
+
+Resolving it means user-scope settings changes — `autoMemoryEnabled: false`, plus `CORE_CONFIG_FEDERATE_MEM0=1` to activate the `[AUTHORITATIVE]` / `[RECALL]` labels in the prompt-inject hook. Both live outside this repo. Report the conflict, name the change, apply only with explicit approval, and never edit `~/.claude/settings.json` as part of "apply all".
+
+`autoMemoryEnabled` resolves through the settings cascade (user < project < local); unset means native auto-memory is ON.
+
+## Relationship to `new`
+
+`new` and `checkup` share `scripts/project_state.sh` for state detection. They do **not** share the preflight guard: `new`'s Step 0 hard guard stays inline, dependency-free, and runs before `PLUGIN_ROOT` is resolved. Moving a safety gate behind a script lookup would add a failure mode where the guard silently does not run.

--- a/plugins/project-init/skills/wiring/SKILL.md
+++ b/plugins/project-init/skills/wiring/SKILL.md
@@ -1,13 +1,13 @@
 ---
-name: checkup
-description: "This skill should be used when the user asks to run a project setup diagnostic on an EXISTING repository — phrases like '프로젝트 진단', '셋업 점검', '이 repo 설정 제대로 됐는지 확인', 'project checkup', 'is this repo wired up', 'diagnose my project setup', or an explicit /project-init:checkup invocation. Detects 11 axes of agent-harness configuration (git, CLAUDE.md/AGENTS.md guidance, .claude/rules, llm-wiki layout + staging backlog, Serena onboarding, memory surfaces, spec locations, gws-sync, .tmp convention, git hooksPath, .gitignore coverage), reports a verdict per axis with the remediation skill named, then gates every fix behind AskUserQuestion. Read-only until the user approves. Complements /project-init:new (which bootstraps an EMPTY dir and refuses to run here). Not for mem0 store diagnostics (use /mem0-ops:doctor) or wiki-content health (use /llm-wiki:lint-wiki)."
+name: wiring
+description: "This skill should be used when the user asks to run a project setup diagnostic on an EXISTING repository — phrases like '프로젝트 진단', '셋업 점검', '하네스 배선 확인', '이 repo 설정 제대로 됐는지 확인', 'check my project wiring', 'is this repo wired up', 'diagnose my project setup', or an explicit /project-init:wiring invocation. Detects 11 axes of agent-harness configuration (git, CLAUDE.md/AGENTS.md guidance, .claude/rules, llm-wiki layout + staging backlog, Serena onboarding, memory surfaces, spec locations, gws-sync, .tmp convention, git hooksPath, .gitignore coverage), reports a verdict per axis with the remediation skill named, then gates every fix behind AskUserQuestion. Read-only until the user approves. Complements /project-init:new (which bootstraps an EMPTY dir and refuses to run here). Not for mem0 store diagnostics (use /mem0-ops:doctor) or wiki-content health (use /llm-wiki:lint-wiki)."
 ---
 
-# project-init `checkup` skill
+# project-init `wiring` skill
 
 Diagnose whether an existing repository's agent-harness conventions are actually wired up, then fix what the user approves.
 
-Sibling of `new`: `new` bootstraps an empty directory and hard-aborts on a non-empty one. `checkup` is the inverse — it only makes sense on a repo that already exists.
+Sibling of `new`: `new` bootstraps an empty directory and hard-aborts on a non-empty one. `wiring` is the inverse — it only makes sense on a repo that already exists.
 
 ## Contract
 
@@ -36,7 +36,7 @@ fi
 bash "$PLUGIN_ROOT/scripts/project_state.sh"
 ```
 
-Emits one JSON object. `CHECKUP_TMP_STALE_DAYS` (default 14) sets the `.tmp/` staleness window. Requires `jq`.
+Emits one JSON object. `WIRING_TMP_STALE_DAYS` (default 14) sets the `.tmp/` staleness window. Requires `jq`.
 
 Do not re-derive any field with ad-hoc `test -f` calls — the script is the detection SSOT, and duplicating it is how the three pre-existing detectors drifted.
 
@@ -71,7 +71,7 @@ Three verdicts need an explanation the JSON cannot carry:
 Print a fixed-width table, most severe first. Name the remediation on every non-OK row — a verdict without a next action is noise.
 
 ```
-## Project Checkup — <dir_name>
+## Project Wiring — <dir_name>
 
 [FAIL] llm-wiki    .llmwiki/.staging: 2 pending captures uncurated
                    -> /llm-wiki:ingest-finding  (gitignored; lore is unrecoverable if cleaned)
@@ -127,4 +127,4 @@ Resolving it means user-scope settings changes — `autoMemoryEnabled: false`, p
 
 ## Relationship to `new`
 
-`new` and `checkup` share `scripts/project_state.sh` for state detection. They do **not** share the preflight guard: `new`'s Step 0 hard guard stays inline, dependency-free, and runs before `PLUGIN_ROOT` is resolved. Moving a safety gate behind a script lookup would add a failure mode where the guard silently does not run.
+`new` and `wiring` share `scripts/project_state.sh` for state detection. They do **not** share the preflight guard: `new`'s Step 0 hard guard stays inline, dependency-free, and runs before `PLUGIN_ROOT` is resolved. Moving a safety gate behind a script lookup would add a failure mode where the guard silently does not run.


### PR DESCRIPTION
## What

`/project-init:wiring` — the inverse of `/project-init:new`. `new` bootstraps an empty directory and hard-aborts on a non-empty one; `wiring` diagnoses an existing repo's agent-harness setup across 11 axes, names the skill that owns each remediation, and gates every fix behind `AskUserQuestion`.

Axes: git, `core.hooksPath`, guidance files (CLAUDE.md / AGENTS.md / `.claude/rules`), llm-wiki layout + `.staging` backlog, Serena onboarding, memory posture, spec homes, gws-sync, `.tmp`, `.gitignore` coverage, code signal.

## Design decisions worth reviewing

- **`scripts/project_state.sh` is the detection SSOT.** Three detectors existed before (`new`'s Step 0 guard, `idempotent-seed.sh diagnose`, and whatever wiring would have grown). `diagnose` is now a 9-line wrapper over the new script; its output shape is byte-identical (verified across 4 directory fixtures).
- **`new`'s Step 0 preflight guard was NOT folded in.** It is dependency-free and runs before `PLUGIN_ROOT` is resolved. Routing it through a bundled script would introduce a failure mode where a `PLUGIN_ROOT` miss silently skips the guard. Safety gates do not move behind lazy loading.
- **The memory verdict keys on `autoMemoryEnabled`, not on `MEMORY.md` existing.** The file outlives the setting, so a file-keyed verdict would keep reporting a conflict the skill itself just helped resolve. Resolved through the settings cascade (user < project < local); unset means ON.
- **Scope boundary.** Posture consistency (which memory writers are live, is the authority relationship declared) is in scope. Cross-store *content* consistency between mem0 and `.llmwiki/` is not — no tool here performs that comparison, and the skill says so instead of implying coverage. Wiki page health stays with `/llm-wiki:lint-wiki`; mem0 store/config posture stays with `/mem0-ops:doctor`.
- **No `commands/wiring.md`.** Codex does not emit command surfaces, so a command would duplicate the body for one runtime's benefit.

## Shell correctness

`find` signals "no match" with exit 1. Under `set -o pipefail`, `find … | wc -l` kills the script on a normal empty result — which is exactly what a "count things that may not exist" detector does. All `find` calls route through `find_or_empty` / `count_files`.

`code_signal` previously used `find | head -1 | grep -q .`. `head`'s early close races `find` into SIGPIPE (141), and `pipefail` reads that as pipeline failure — so a tree *with* `.py` files could report `none`. Replaced with `-print -quit`, removing the pipeline. Regression-tested with 400 files.

## Verification

- `bash -n` clean; 10 fixture tests pass: empty dir, non-git dir, legacy `.claude/wiki/`, `.gitkeep`-only wiki (correctly `absent`, matching the llm-wiki hook rule), this repo, 400-file SIGPIPE regression, `autoMemoryEnabled` unset/default-on, settings cascade override, plus two regression re-runs.
- `diagnose` output compared before/after refactor across 4 directories — identical, legacy key shape preserved.
- Skill `description` 866 chars (Codex cap 1024); YAML frontmatter parses.
- `.githooks/pre-commit` passes (`sync-codex-manifests --check` + `sync-hermes-manifests --check`).
- `shellcheck` is not installed on this machine — shell linting is unverified.

Versions: project-init `0.2.1 -> 0.3.0`, marketplace `metadata.version 1.87.0 -> 1.88.0`. Plugin count unchanged (24), Codex-eligible unchanged (22).
---

## Update — skill renamed `checkup` -> `wiring`

`checkup` shares a lexical family with the built-in `/doctor`, `mem0-ops:doctor`, and `mem0:health`. Nothing collided on the invocation path (namespaced `/project-init:<name>`), but the name was awkward to reach for. `wiring` names what is inspected: whether the agent harness is connected. Nothing had shipped under the old name, so no alias is kept. `CHECKUP_TMP_STALE_DAYS` -> `WIRING_TMP_STALE_DAYS`; a stale old-name export is ignored (falls back to the default 14, covered by a test).

## Review

CodeRabbit's PR bot was rate-limited (Fair Usage, ~41 min), so review ran through the local CodeRabbit CLI. Converged clean in 2 iterations: 3 findings, 2 applied, 1 skipped.

- **applied** — `test -d .git` is false inside a git worktree or submodule (`.git` is a gitdir pointer *file*). That made `initialized=false`, `commits=0`, and — because `ignored()` short-circuits on `GIT_INIT` — every `git check-ignore` probe false, turning the `.env` coverage axis into a guaranteed false FAIL. Reproduced in a real `git worktree`; `github-dev` drives work from worktrees, so this was on a live path. The reviewer's paired suggestion to scope the lookup with `git config --local` was **rejected**: the effective value (local > global > system) is what applies, and `--local` would false-WARN anyone configuring `core.hooksPath` globally.
- **applied** — a non-integer `WIRING_TMP_STALE_DAYS` reached both `find -mtime` and `jq --argjson`, surfacing as a jq usage dump instead of naming its cause. Now rejected up front.
- **skipped** — a suggestion to strip `autoMemoryEnabled` / `CORE_CONFIG_FEDERATE_MEM0` from the memory section. Keying the memory verdict on filesystem presence alone reintroduces the exact false positive the settings read was added to fix: `MEMORY.md` outlives the setting that disables it. `mem0-ops:doctor` owns mem0 *store* posture, not Claude's native `autoMemoryEnabled` — no skill owns that signal.
