### PR TITLE
feat(project-init): ASK verdict class + three efficacy axes for wiring

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Personal Claude Code plugin collection with 24 specialized plugins. Codex 0.135 + Hermes Agent native — generated `.agents/plugins/marketplace.json` + per-plugin `.codex-plugin/plugin.json` (`scripts/sync-codex-manifests.mjs`) and Hermes `plugin.yaml` + `__init__.py` adapters (`scripts/sync-hermes-manifests.mjs`).",
-    "version": "1.88.0"
+    "version": "1.89.0"
   },
   "plugins": [
     {
@@ -130,8 +130,8 @@
     {
       "name": "project-init",
       "source": "./plugins/project-init",
-      "description": "Agent-harness project lifecycle. `new` — one-shot first-day bootstrap (interview, .claude/ scaffold, minimal CLAUDE.md, AGENTS.md with Codex GitHub cloud reviewer guidelines in general/ml/web variants, README/CHANGELOG seed, gh repo create + initial push) behind a hardened preflight guard that refuses a non-empty cwd. `wiring` — its inverse for existing repos: a read-only 11-axis setup diagnostic (guidance files, llm-wiki layout + staging backlog, Serena onboarding, memory-surface conflict, spec homes, gws-sync, .tmp, core.hooksPath, .gitignore coverage) that names the remediation skill per finding and gates every fix behind AskUserQuestion. Shared read-only detector: scripts/project_state.sh.",
-      "version": "0.3.0",
+      "description": "Agent-harness project lifecycle. `new` — one-shot first-day bootstrap (interview, .claude/ scaffold, minimal CLAUDE.md, AGENTS.md with Codex GitHub cloud reviewer guidelines in general/ml/web variants, README/CHANGELOG seed, gh repo create + initial push) behind a hardened preflight guard that refuses a non-empty cwd. `wiring` — its inverse for existing repos: a read-only 14-axis setup diagnostic (FAIL / WARN / ASK / INFO / SKIP / OK) covering guidance files, .claude/rules paths: scoping defeated by @import, llm-wiki layout + staging backlog, Serena onboarding, memory posture, MCP duplicate registration, Codex CLI posture + AGENTS.md byte budget, spec homes, gws-sync, .tmp, core.hooksPath, .gitignore coverage. ASK answers persist to .claude/state/wiring.json. Shared read-only detector: scripts/project_state.sh.",
+      "version": "0.4.0",
       "category": "planning"
     },
     {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ Plugin-based configuration for Claude Code with multi-agent orchestration. The s
 | Plugin | Description |
 |--------|-------------|
 | `interview` | Structured requirements gathering |
-| `project-init` | Agent-harness project lifecycle. `new` — first-day bootstrap (.claude/ + CLAUDE.md + AGENTS.md w/ Codex review guidelines + README/CHANGELOG + gh repo create), preflight-guarded to empty dirs. `wiring` — read-only 11-axis setup diagnostic for existing repos (guidance, llm-wiki layout + staging backlog, Serena onboarding, memory-surface conflict, spec homes, gws-sync, .tmp, hooksPath, .gitignore), remediation skill named per finding, fixes gated behind AskUserQuestion. Shared detector `scripts/project_state.sh` |
+| `project-init` | Agent-harness project lifecycle. `new` — first-day bootstrap (.claude/ + CLAUDE.md + AGENTS.md w/ Codex review guidelines + README/CHANGELOG + gh repo create), preflight-guarded to empty dirs. `wiring` — read-only 14-axis setup diagnostic for existing repos, verdicts `FAIL/WARN/ASK/INFO/SKIP/OK`. Four axes ask whether config takes *effect*, not just exists: `core.hooksPath`, an `@import` that defeats `.claude/rules` `paths:` scoping, MCP servers registered twice (one copy silently discarded), Codex `AGENTS.md` byte budget. `ASK` = a decision nobody made yet — asked once, persisted to `.claude/state/wiring.json`. Shared detector `scripts/project_state.sh` |
 
 ### Presentation
 | Plugin | Description |
@@ -146,5 +146,11 @@ Adapter fields derive from `marketplace.json` (`plugin.yaml` name/version/descri
 
 ## Modular Rules
 
-- See @.claude/rules/plugin-versioning.md for plugin version bump contract and cache-refresh workflow.
-- See @.claude/rules/dual-integration.md for keeping the Claude Code, Codex, and Hermes surfaces in sync when editing guidance, hooks, or derived artifacts (mirrored into `AGENTS.md` since Codex/Hermes cannot `@import` `.claude/rules/`).
+`.claude/rules/*.md` is auto-loaded by Claude Code — no `@import` required. A rule carrying `paths:` frontmatter loads only when Claude touches a matching file; `@import`ing that same rule expands it unconditionally at launch and kills the scoping, so the first pointer below is deliberately plain (backticks, not `@`).
+
+- `.claude/rules/plugin-versioning.md` — plugin version bump contract and cache-refresh workflow. Scoped via `paths:` to the manifest files, so it loads only when you touch them.
+- See @.claude/rules/dual-integration.md for keeping the Claude Code, Codex, and Hermes surfaces in sync when editing guidance, hooks, or derived artifacts (unscoped, always loaded; mirrored into `AGENTS.md` because Codex and Hermes have no `@import` mechanism at all and read that file verbatim).
+
+## Setup answers
+
+`/project-init:wiring` records decisions the filesystem cannot infer — whether this project wants a git remote, whether its deliverables go to Drive — in `.claude/state/wiring.json` (gitignored; values are machine-local). Read that file before re-asking.

--- a/README.md
+++ b/README.md
@@ -498,7 +498,13 @@ mem0 Platform store를 app_id **간** 레벨에서 진단·정리합니다. upst
 2. 첫 도메인 lore → `/llm-wiki:bootstrap-wiki`
 3. 첫 PR merge 후 → `/github-dev:post-merge` (post-merge 내장 wiki 적재 step)
 
-**`/project-init:wiring`** — `new` 의 역방향. 이미 있는 repo 의 하네스 설정을 11 축으로 진단한다 (guidance 파일, llm-wiki 레이아웃 + `.staging` 미드레인 백로그, Serena 온보딩, 메모리 표면 충돌, spec 위치, gws-sync, `.tmp`, `core.hooksPath`, `.gitignore` 커버리지). 탐지는 `scripts/project_state.sh` 가 전담하는 read-only 단계이고, 결함마다 담당 스킬을 지목한 뒤 모든 수정은 `AskUserQuestion` 게이트 뒤에서만 적용한다. 위키 페이지 건강도는 `/llm-wiki:lint-wiki`, mem0 스토어는 `/mem0-ops:doctor` 가 담당 — 중복하지 않는다.
+**`/project-init:wiring`** — `new` 의 역방향. 이미 있는 repo 의 하네스 설정을 14 축으로 진단한다. 판정은 `FAIL / WARN / ASK / INFO / SKIP / OK`.
+
+존재 검사("파일이 있나") 위에 **효력 검사**("그게 실제로 먹나") 4 축이 얹혀 있다 — clone 마다 따로 켜야 하는 `core.hooksPath`, `.claude/rules` 의 `paths:` 스코핑을 `@import` 가 무력화한 경우, 같은 MCP 서버가 두 파일에 등록돼 한쪽 정의가 통째로 버려지는 경우, Codex 의 `AGENTS.md` 바이트 예산. 전부 "설정은 있는데 안 먹는" 실패 모드다.
+
+`ASK` 는 결함이 아니라 **아직 아무도 안 정한 결정**이다 (원격 저장소를 만들지, 산출물을 Drive 에 올릴지). 한 번만 묻고 답을 `.claude/state/wiring.json` 에 적어 다음 실행부터 조용해진다 — 매번 짖는 경고는 사람이 무시하게 되고, 그러면 진짜 `FAIL` 도 같이 묻힌다.
+
+탐지는 `scripts/project_state.sh` 가 전담하는 read-only 단계이고, 결함마다 담당 스킬을 지목한 뒤 모든 수정은 `AskUserQuestion` 게이트 뒤에서만 적용한다. 위키 페이지 건강도는 `/llm-wiki:lint-wiki`, mem0 스토어는 `/mem0-ops:doctor`, 삭제된 플러그인이 남긴 고아 MCP 등록과 미사용 확장은 내장 `/doctor` 가 담당 — 중복하지 않는다.
 
 **Requirements:** `gh` CLI authenticated, `git`, `jq`
 

--- a/plugins/project-init/.claude-plugin/plugin.json
+++ b/plugins/project-init/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-init",
-  "version": "0.3.0",
-  "description": "Agent-harness project lifecycle. `new` bootstraps an empty dir (.claude/ scaffold, minimal CLAUDE.md, AGENTS.md with Codex GitHub cloud reviewer guidelines, README/CHANGELOG seed, gh repo create + push) behind a preflight guard that refuses non-empty directories. `wiring` is its inverse for existing repos: a read-only 11-axis diagnostic (guidance files, llm-wiki layout + staging backlog, Serena onboarding, memory-surface conflict, spec homes, gws-sync, .tmp, core.hooksPath, .gitignore coverage) that names the remediation skill per finding and gates every fix behind AskUserQuestion. Both consume the shared read-only detector scripts/project_state.sh.",
+  "version": "0.4.0",
+  "description": "Agent-harness project lifecycle. `new` bootstraps an empty dir (.claude/ scaffold, minimal CLAUDE.md, AGENTS.md with Codex GitHub cloud reviewer guidelines, README/CHANGELOG seed, gh repo create + push) behind a preflight guard that refuses non-empty directories. `wiring` is its inverse for existing repos: a read-only 14-axis diagnostic whose verdicts are FAIL / WARN / ASK / INFO / SKIP / OK. Four axes check whether config takes EFFECT rather than merely exists — core.hooksPath, an @import that defeats .claude/rules paths: scoping, MCP servers registered twice so one copy is discarded, and the Codex AGENTS.md byte budget. An ASK is a decision nobody made yet: asked once, persisted to .claude/state/wiring.json. Both consume the shared read-only detector scripts/project_state.sh.",
   "author": {
     "name": "YoungjaeDev"
   },

--- a/plugins/project-init/.codex-plugin/plugin.json
+++ b/plugins/project-init/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-init",
-  "version": "0.3.0",
-  "description": "Agent-harness project lifecycle. `new` — one-shot first-day bootstrap (interview, .claude/ scaffold, minimal CLAUDE.md, AGENTS.md with Codex GitHub cloud reviewer guidelines in general/ml/web variants, README/CHANGELOG seed, gh repo create + initial push) behind a hardened preflight guard that refuses a non-empty cwd. `wiring` — its inverse for existing repos: a read-only 11-axis setup diagnostic (guidance files, llm-wiki layout + staging backlog, Serena onboarding, memory-surface conflict, spec homes, gws-sync, .tmp, core.hooksPath, .gitignore coverage) that names the remediation skill per finding and gates every fix behind AskUserQuestion. Shared read-only detector: scripts/project_state.sh.",
+  "version": "0.4.0",
+  "description": "Agent-harness project lifecycle. `new` — one-shot first-day bootstrap (interview, .claude/ scaffold, minimal CLAUDE.md, AGENTS.md with Codex GitHub cloud reviewer guidelines in general/ml/web variants, README/CHANGELOG seed, gh repo create + initial push) behind a hardened preflight guard that refuses a non-empty cwd. `wiring` — its inverse for existing repos: a read-only 14-axis setup diagnostic (FAIL / WARN / ASK / INFO / SKIP / OK) covering guidance files, .claude/rules paths: scoping defeated by @import, llm-wiki layout + staging backlog, Serena onboarding, memory posture, MCP duplicate registration, Codex CLI posture + AGENTS.md byte budget, spec homes, gws-sync, .tmp, core.hooksPath, .gitignore coverage. ASK answers persist to .claude/state/wiring.json. Shared read-only detector: scripts/project_state.sh.",
   "author": {
     "name": "YoungjaeDev"
   },

--- a/plugins/project-init/CLAUDE.md
+++ b/plugins/project-init/CLAUDE.md
@@ -19,7 +19,9 @@
 
 `scripts/project_state.sh` 가 프로젝트 상태 탐지를 **혼자** 담당한다. 순수 read-only, JSON 한 덩어리 출력.
 
-- `wiring` 은 11 축 전체를 소비한다.
+- `wiring` 은 14 축 전체를 소비한다. 그중 4 축은 "파일이 있나"가 아니라 **"그 설정이 실제로 발효하나"** 를 본다 — `core.hooksPath`(clone 마다 켜야 함), `.claude/rules` 의 `paths:` 스코핑을 `@import` 가 무력화했는지, 같은 MCP 서버가 두 user-scope 파일에 등록돼 한쪽 정의가 통째로 버려지는지, Codex `AGENTS.md` 가 `project_doc_max_bytes` 예산 안에 드는지.
+- 결함이 아니라 **결정**인 축(`git remote`, `gws-sync`)은 `ASK` 로 낸다. 답은 `.claude/state/wiring.json` 의 `answers` 에 적히고 스크립트가 그대로 실어 보낸다 — 스킬은 이미 답한 항목을 다시 묻지 않는다. 값은 머신마다 다르므로(Drive 폴더 id 등) gitignored state 에 남고, `CLAUDE.md` 에는 **경로 포인터 한 줄**만 둔다. 매번 짖는 경고는 사람이 무시하게 되고, 그러면 진짜 `FAIL` 도 같이 묻힌다.
+- **고아 MCP 등록은 다루지 않는다.** 삭제된 플러그인이 남긴 서버는 사용 이력이 있어야 판정 가능해 내장 `/doctor` 의 영역이다. 반면 **중복 등록**은 두 파일 키의 교집합이라 순수 계산이다 — 결정론으로 못 잡는 걸 잡는 척하지 않는다.
 - `idempotent-seed.sh diagnose` 는 이 스크립트를 감싸 legacy 출력 형태(`cwd`/`dir_name`/`git`/`seeded`/`code_signal`)만 골라낸다. 탐지 로직을 다시 구현하지 않는다.
 - **`new` 의 Step 0 hard guard 는 여기에 흡수하지 않는다.** 가드는 의존성 0 (순수 `find`) 이고 `PLUGIN_ROOT` 리졸버보다 **먼저** 돌아야 한다. 스크립트 호출로 바꾸면 "PLUGIN_ROOT 해석 실패 시 가드가 조용히 실행되지 않는" 실패 모드가 새로 생긴다. 안전 장치는 lazy-load 뒤로 옮기지 않는다.
 
@@ -57,7 +59,7 @@ plugins/project-init/
 ├── scripts/
 │   ├── infer-github-context.sh         # gh api user + orgs
 │   ├── idempotent-seed.sh              # 충돌 가드 + .claude/ + .llmwiki/ 시드 (diagnose = 래퍼)
-│   └── project_state.sh                # 탐지 SSOT — read-only 11 축 JSON
+│   └── project_state.sh                # 탐지 SSOT — read-only 14 축 JSON
 └── CLAUDE.md                           # this file
 ```
 

--- a/plugins/project-init/scripts/project_state.sh
+++ b/plugins/project-init/scripts/project_state.sh
@@ -226,14 +226,29 @@ fi
 
 # --- codex CLI 자세 -------------------------------------------------------
 # 값 판단은 스킬이 한다 — 여기서는 읽기만. 의도적 설정일 수 있으므로 결함이 아니다.
-toml_val() { sed -n "s/^$1 *= *//p" "$HOME/.codex/config.toml" 2>/dev/null | head -1 | tr -d '"'; }
+# TOML allows an inline comment after a value. Cut from the first space-hash so
+# `approval_policy = "never" # yolo` reads as `never`, while a `#` inside a quoted
+# value (`model = "gpt#5"`) survives.
+toml_val() {
+  sed -n "s/^$1 *= *//p" "$HOME/.codex/config.toml" 2>/dev/null | head -1 \
+    | sed -e 's/[[:space:]]#.*$//' -e 's/[[:space:]]*$//' | tr -d '"'
+}
 CODEX_CONFIG=$(b test -f "$HOME/.codex/config.toml")
 CODEX_APPROVAL=""; CODEX_SANDBOX=""; CODEX_MODEL=""; CODEX_DOC_MAX=32768
 if [ "$CODEX_CONFIG" = true ]; then
   CODEX_APPROVAL=$(toml_val approval_policy)
   CODEX_SANDBOX=$(toml_val sandbox_mode)
   CODEX_MODEL=$(toml_val model)
-  v=$(toml_val project_doc_max_bytes); [ -n "$v" ] && CODEX_DOC_MAX="$v"
+  # Only this value reaches jq through `--argjson`, which demands strict JSON.
+  # A valid TOML integer may carry `_` digit separators (`65_536`), and anything
+  # non-numeric that slips through aborts jq *before the script prints anything* —
+  # the whole diagnostic dies, not just this axis. Accept digits only; otherwise
+  # keep the documented default.
+  v=$(toml_val project_doc_max_bytes | tr -d '_')
+  case "$v" in
+    '' | *[!0-9]*) : ;;
+    *) CODEX_DOC_MAX="$v" ;;
+  esac
 fi
 AGENTS_BYTES=0; [ -f AGENTS.md ] && AGENTS_BYTES=$(wc -c < AGENTS.md | tr -d ' ')
 AGENTS_GLOBAL_BYTES=0; [ -f "$HOME/.codex/AGENTS.md" ] && AGENTS_GLOBAL_BYTES=$(wc -c < "$HOME/.codex/AGENTS.md" | tr -d ' ')

--- a/plugins/project-init/scripts/project_state.sh
+++ b/plugins/project-init/scripts/project_state.sh
@@ -194,6 +194,58 @@ GI_SERENA=$(ignored .serena/)
 GI_STAGING=$(ignored .llmwiki/.staging/)
 GI_ENV=$(ignored .env)
 
+# --- MCP 설정 중복 --------------------------------------------------------
+# 같은 서버가 두 user-scope 파일에 있으면 Claude 는 한쪽 정의를 통째로 고르고
+# 나머지는 버린다 (필드 병합 없음). 두 정의가 갈라지면 한쪽 편집이 조용히 죽는다.
+# 고아 등록(삭제된 플러그인의 서버)은 사용 이력이 있어야 알 수 있어 여기서 다루지 않는다.
+mcp_keys() { jq -r '.mcpServers // {} | keys[]' "$1" 2>/dev/null | sort; }
+MCP_USER=0; MCP_SETTINGS=0; MCP_DUPES='[]'
+if [ -f "$HOME/.claude.json" ]; then MCP_USER=$(mcp_keys "$HOME/.claude.json" | wc -l | tr -d ' '); fi
+if [ -f "$HOME/.claude/settings.json" ]; then MCP_SETTINGS=$(mcp_keys "$HOME/.claude/settings.json" | wc -l | tr -d ' '); fi
+if [ "$MCP_USER" -gt 0 ] && [ "$MCP_SETTINGS" -gt 0 ]; then
+  MCP_DUPES=$(comm -12 <(mcp_keys "$HOME/.claude.json") <(mcp_keys "$HOME/.claude/settings.json") | jq -Rsc 'split("\n") | map(select(length>0))')
+fi
+
+# --- .claude/rules 스코핑 무력화 -------------------------------------------
+# `paths:` frontmatter 는 조건부 로드다. 그런데 CLAUDE.md 가 같은 파일을 `@import`
+# 하면 launch 때 무조건 전개돼 스코핑이 죽는다 (import 는 조건을 모른다).
+RULES_DEFEATED='[]'
+if [ -f CLAUDE.md ] && [ -d .claude/rules ]; then
+  RULES_DEFEATED=$(
+    while IFS= read -r f; do
+      [ -n "$f" ] || continue
+      [ "$(head -1 "$f")" = "---" ] || continue
+      sed -n '1,10p' "$f" | grep -q '^paths:' || continue
+      grep -q "@\.claude/rules/$(basename "$f")" CLAUDE.md && basename "$f"
+    done <<EOF
+$(find_or_empty .claude/rules -maxdepth 1 -type f -name '*.md')
+EOF
+  ) || true
+  RULES_DEFEATED=$(printf '%s' "${RULES_DEFEATED:-}" | jq -Rsc 'split("\n") | map(select(length>0))')
+fi
+
+# --- codex CLI 자세 -------------------------------------------------------
+# 값 판단은 스킬이 한다 — 여기서는 읽기만. 의도적 설정일 수 있으므로 결함이 아니다.
+toml_val() { sed -n "s/^$1 *= *//p" "$HOME/.codex/config.toml" 2>/dev/null | head -1 | tr -d '"'; }
+CODEX_CONFIG=$(b test -f "$HOME/.codex/config.toml")
+CODEX_APPROVAL=""; CODEX_SANDBOX=""; CODEX_MODEL=""; CODEX_DOC_MAX=32768
+if [ "$CODEX_CONFIG" = true ]; then
+  CODEX_APPROVAL=$(toml_val approval_policy)
+  CODEX_SANDBOX=$(toml_val sandbox_mode)
+  CODEX_MODEL=$(toml_val model)
+  v=$(toml_val project_doc_max_bytes); [ -n "$v" ] && CODEX_DOC_MAX="$v"
+fi
+AGENTS_BYTES=0; [ -f AGENTS.md ] && AGENTS_BYTES=$(wc -c < AGENTS.md | tr -d ' ')
+AGENTS_GLOBAL_BYTES=0; [ -f "$HOME/.codex/AGENTS.md" ] && AGENTS_GLOBAL_BYTES=$(wc -c < "$HOME/.codex/AGENTS.md" | tr -d ' ')
+
+# --- 사용자가 이미 답한 ASK 항목 -------------------------------------------
+# 결함이 아니라 결정인 축(git remote, gws-sync ...)의 답을 보관한다.
+# 답이 있으면 스킬은 다시 묻지 않는다.
+ANSWERS='{}'
+if [ -f .claude/state/wiring.json ]; then
+  ANSWERS=$(jq -c '.answers // {}' .claude/state/wiring.json 2>/dev/null || echo '{}')
+fi
+
 jq -nc \
   --arg cwd "$CWD" --arg dir_name "$DIR_NAME" \
   --argjson git_init "$GIT_INIT" --argjson commits "$COMMITS" --argjson remote "$REMOTE" \
@@ -216,6 +268,13 @@ jq -nc \
   --argjson tmp_stale "$TMP_STALE" --argjson stale_days "$STALE_DAYS" \
   --argjson gi_state "$GI_STATE" --argjson gi_serena "$GI_SERENA" --argjson gi_staging "$GI_STAGING" \
   --argjson gi_env "$GI_ENV" \
+  --argjson mcp_user "$MCP_USER" --argjson mcp_settings "$MCP_SETTINGS" --argjson mcp_dupes "$MCP_DUPES" \
+  --argjson rules_defeated "$RULES_DEFEATED" \
+  --argjson codex_config "$CODEX_CONFIG" --arg codex_approval "$CODEX_APPROVAL" \
+  --arg codex_sandbox "$CODEX_SANDBOX" --arg codex_model "$CODEX_MODEL" \
+  --argjson codex_doc_max "$CODEX_DOC_MAX" --argjson agents_bytes "$AGENTS_BYTES" \
+  --argjson agents_global_bytes "$AGENTS_GLOBAL_BYTES" \
+  --argjson answers "$ANSWERS" \
   '{
     cwd: $cwd,
     dir_name: $dir_name,
@@ -252,5 +311,17 @@ jq -nc \
     },
     gws_sync: { cli: $gws_cli, config: $gws_config },
     tmp: { dir: $tmp_dir, gitignored: $tmp_ignored, stale_files: $tmp_stale, stale_days: $stale_days },
-    gitignore: { claude_state: $gi_state, serena: $gi_serena, llmwiki_staging: $gi_staging, tmp: $tmp_ignored, env: $gi_env }
+    gitignore: { claude_state: $gi_state, serena: $gi_serena, llmwiki_staging: $gi_staging, tmp: $tmp_ignored, env: $gi_env },
+    mcp: { user_json: $mcp_user, settings_json: $mcp_settings, duplicates: $mcp_dupes },
+    rules_scoping: { paths_defeated_by_import: $rules_defeated },
+    codex: {
+      config: $codex_config,
+      approval_policy: (if $codex_approval == "" then null else $codex_approval end),
+      sandbox_mode: (if $codex_sandbox == "" then null else $codex_sandbox end),
+      model_pinned: (if $codex_model == "" then null else $codex_model end),
+      project_doc_max_bytes: $codex_doc_max,
+      agents_md_bytes: $agents_bytes,
+      global_agents_md_bytes: $agents_global_bytes
+    },
+    answers: $answers
   }'

--- a/plugins/project-init/scripts/project_state.sh
+++ b/plugins/project-init/scripts/project_state.sh
@@ -202,16 +202,25 @@ GI_ENV=$(ignored .env)
 # 명령 치환을 타고 올라와 스크립트 전체를 죽인다 — 중복 하나 못 세는 대신 진단이
 # 통째로 사라진다. 파싱 실패를 이 축 안에 가두고, 대신 unreadable 로 실어 보낸다:
 # 조용히 "중복 없음" 이라고 답하는 것이 제일 나쁘다.
-mcp_keys() { jq -r '.mcpServers // {} | keys[]' "$1" 2>/dev/null | sort || true; }
-mcp_broken() { [ -f "$1" ] && [ -s "$1" ] && ! jq empty "$1" >/dev/null 2>&1; }
+# "읽을 수 있나" 는 "유효한 JSON 인가" 보다 좁다. 빈 파일은 jq 에게 유효한 입력이고,
+# `mcpServers` 가 객체가 아니면 (`[]`, `"x"`) `keys[]` 가 죽거나 인덱스를 뱉는다.
+# 둘 다 "중복 없음" 으로 조용히 통과했다 — 못 본 것을 봤다고 답하는 셈이다.
+mcp_readable() { jq -e 'type == "object" and ((.mcpServers // {}) | type) == "object"' "$1" >/dev/null 2>&1; }
+mcp_keys() { jq -r '.mcpServers // {} | keys[]' "$1" 2>/dev/null | sort; }
 MCP_USER=0; MCP_SETTINGS=0; MCP_DUPES='[]'
 _bad=""
 for f in "$HOME/.claude.json" "$HOME/.claude/settings.json"; do
-  if mcp_broken "$f"; then _bad="${_bad}${f#$HOME/}"$'\n'; fi
+  [ -f "$f" ] || continue
+  # `${f#$HOME/}` 는 HOME 에 glob 문자가 있으면 오작동한다 — 접두사는 따옴표로 고정.
+  if ! mcp_readable "$f"; then _bad="${_bad}${f#"$HOME/"}"$'\n'; fi
 done
 MCP_UNREADABLE=$(printf '%s' "$_bad" | jq -Rsc 'split("\n") | map(select(length>0))')
-if [ -f "$HOME/.claude.json" ]; then MCP_USER=$(mcp_keys "$HOME/.claude.json" | wc -l | tr -d ' '); fi
-if [ -f "$HOME/.claude/settings.json" ]; then MCP_SETTINGS=$(mcp_keys "$HOME/.claude/settings.json" | wc -l | tr -d ' '); fi
+if [ -f "$HOME/.claude.json" ] && mcp_readable "$HOME/.claude.json"; then
+  MCP_USER=$(mcp_keys "$HOME/.claude.json" | wc -l | tr -d ' ')
+fi
+if [ -f "$HOME/.claude/settings.json" ] && mcp_readable "$HOME/.claude/settings.json"; then
+  MCP_SETTINGS=$(mcp_keys "$HOME/.claude/settings.json" | wc -l | tr -d ' ')
+fi
 if [ "$MCP_USER" -gt 0 ] && [ "$MCP_SETTINGS" -gt 0 ]; then
   MCP_DUPES=$(comm -12 <(mcp_keys "$HOME/.claude.json") <(mcp_keys "$HOME/.claude/settings.json") | jq -Rsc 'split("\n") | map(select(length>0))')
 fi
@@ -236,14 +245,18 @@ fi
 
 # --- codex CLI 자세 -------------------------------------------------------
 # 값 판단은 스킬이 한다 — 여기서는 읽기만. 의도적 설정일 수 있으므로 결함이 아니다.
+# Codex 는 `$CODEX_HOME` 을 존중한다 (`codex --help`: "Layer $CODEX_HOME/<name>.config.toml").
+# `$HOME/.codex` 만 보면 그 환경에서 설정이 있는데도 config:false 로 보고해
+# approval/sandbox 자세와 doc-budget WARN 이 통째로 사라진다.
+CODEX_HOME_DIR="${CODEX_HOME:-$HOME/.codex}"
 # TOML allows an inline comment after a value. Cut from the first space-hash so
 # `approval_policy = "never" # yolo` reads as `never`, while a `#` inside a quoted
 # value (`model = "gpt#5"`) survives.
 toml_val() {
-  sed -n "s/^$1 *= *//p" "$HOME/.codex/config.toml" 2>/dev/null | head -1 \
+  sed -n "s/^$1 *= *//p" "$CODEX_HOME_DIR/config.toml" 2>/dev/null | head -1 \
     | sed -e 's/[[:space:]]#.*$//' -e 's/[[:space:]]*$//' | tr -d '"'
 }
-CODEX_CONFIG=$(b test -f "$HOME/.codex/config.toml")
+CODEX_CONFIG=$(b test -f "$CODEX_HOME_DIR/config.toml")
 CODEX_APPROVAL=""; CODEX_SANDBOX=""; CODEX_MODEL=""; CODEX_DOC_MAX=32768
 if [ "$CODEX_CONFIG" = true ]; then
   CODEX_APPROVAL=$(toml_val approval_policy)
@@ -261,7 +274,7 @@ if [ "$CODEX_CONFIG" = true ]; then
   esac
 fi
 AGENTS_BYTES=0; [ -f AGENTS.md ] && AGENTS_BYTES=$(wc -c < AGENTS.md | tr -d ' ')
-AGENTS_GLOBAL_BYTES=0; [ -f "$HOME/.codex/AGENTS.md" ] && AGENTS_GLOBAL_BYTES=$(wc -c < "$HOME/.codex/AGENTS.md" | tr -d ' ')
+AGENTS_GLOBAL_BYTES=0; [ -f "$CODEX_HOME_DIR/AGENTS.md" ] && AGENTS_GLOBAL_BYTES=$(wc -c < "$CODEX_HOME_DIR/AGENTS.md" | tr -d ' ')
 
 # --- 사용자가 이미 답한 ASK 항목 -------------------------------------------
 # 결함이 아니라 결정인 축(git remote, gws-sync ...)의 답을 보관한다.

--- a/plugins/project-init/scripts/project_state.sh
+++ b/plugins/project-init/scripts/project_state.sh
@@ -198,8 +198,18 @@ GI_ENV=$(ignored .env)
 # 같은 서버가 두 user-scope 파일에 있으면 Claude 는 한쪽 정의를 통째로 고르고
 # 나머지는 버린다 (필드 병합 없음). 두 정의가 갈라지면 한쪽 편집이 조용히 죽는다.
 # 고아 등록(삭제된 플러그인의 서버)은 사용 이력이 있어야 알 수 있어 여기서 다루지 않는다.
-mcp_keys() { jq -r '.mcpServers // {} | keys[]' "$1" 2>/dev/null | sort; }
+# 손상된 JSON 에서 jq 는 non-zero 로 끝난다. `set -euo pipefail` 아래서 그 실패는
+# 명령 치환을 타고 올라와 스크립트 전체를 죽인다 — 중복 하나 못 세는 대신 진단이
+# 통째로 사라진다. 파싱 실패를 이 축 안에 가두고, 대신 unreadable 로 실어 보낸다:
+# 조용히 "중복 없음" 이라고 답하는 것이 제일 나쁘다.
+mcp_keys() { jq -r '.mcpServers // {} | keys[]' "$1" 2>/dev/null | sort || true; }
+mcp_broken() { [ -f "$1" ] && [ -s "$1" ] && ! jq empty "$1" >/dev/null 2>&1; }
 MCP_USER=0; MCP_SETTINGS=0; MCP_DUPES='[]'
+_bad=""
+for f in "$HOME/.claude.json" "$HOME/.claude/settings.json"; do
+  if mcp_broken "$f"; then _bad="${_bad}${f#$HOME/}"$'\n'; fi
+done
+MCP_UNREADABLE=$(printf '%s' "$_bad" | jq -Rsc 'split("\n") | map(select(length>0))')
 if [ -f "$HOME/.claude.json" ]; then MCP_USER=$(mcp_keys "$HOME/.claude.json" | wc -l | tr -d ' '); fi
 if [ -f "$HOME/.claude/settings.json" ]; then MCP_SETTINGS=$(mcp_keys "$HOME/.claude/settings.json" | wc -l | tr -d ' '); fi
 if [ "$MCP_USER" -gt 0 ] && [ "$MCP_SETTINGS" -gt 0 ]; then
@@ -284,6 +294,7 @@ jq -nc \
   --argjson gi_state "$GI_STATE" --argjson gi_serena "$GI_SERENA" --argjson gi_staging "$GI_STAGING" \
   --argjson gi_env "$GI_ENV" \
   --argjson mcp_user "$MCP_USER" --argjson mcp_settings "$MCP_SETTINGS" --argjson mcp_dupes "$MCP_DUPES" \
+  --argjson mcp_unreadable "$MCP_UNREADABLE" \
   --argjson rules_defeated "$RULES_DEFEATED" \
   --argjson codex_config "$CODEX_CONFIG" --arg codex_approval "$CODEX_APPROVAL" \
   --arg codex_sandbox "$CODEX_SANDBOX" --arg codex_model "$CODEX_MODEL" \
@@ -327,7 +338,7 @@ jq -nc \
     gws_sync: { cli: $gws_cli, config: $gws_config },
     tmp: { dir: $tmp_dir, gitignored: $tmp_ignored, stale_files: $tmp_stale, stale_days: $stale_days },
     gitignore: { claude_state: $gi_state, serena: $gi_serena, llmwiki_staging: $gi_staging, tmp: $tmp_ignored, env: $gi_env },
-    mcp: { user_json: $mcp_user, settings_json: $mcp_settings, duplicates: $mcp_dupes },
+    mcp: { user_json: $mcp_user, settings_json: $mcp_settings, duplicates: $mcp_dupes, unreadable: $mcp_unreadable },
     rules_scoping: { paths_defeated_by_import: $rules_defeated },
     codex: {
       config: $codex_config,

--- a/plugins/project-init/skills/wiring/SKILL.md
+++ b/plugins/project-init/skills/wiring/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wiring
-description: "This skill should be used when the user asks to run a project setup diagnostic on an EXISTING repository — phrases like '프로젝트 진단', '셋업 점검', '하네스 배선 확인', '이 repo 설정 제대로 됐는지 확인', 'check my project wiring', 'is this repo wired up', 'diagnose my project setup', or an explicit /project-init:wiring invocation. Detects 11 axes of agent-harness configuration (git, CLAUDE.md/AGENTS.md guidance, .claude/rules, llm-wiki layout + staging backlog, Serena onboarding, memory surfaces, spec locations, gws-sync, .tmp convention, git hooksPath, .gitignore coverage), reports a verdict per axis with the remediation skill named, then gates every fix behind AskUserQuestion. Read-only until the user approves. Complements /project-init:new (which bootstraps an EMPTY dir and refuses to run here). Not for mem0 store diagnostics (use /mem0-ops:doctor) or wiki-content health (use /llm-wiki:lint-wiki)."
+description: "This skill should be used when the user asks to run a project setup diagnostic on an EXISTING repository — phrases like '프로젝트 진단', '셋업 점검', '하네스 배선 확인', '이 repo 설정 제대로 됐는지 확인', 'check my project wiring', 'is this repo wired up', 'diagnose my project setup', or an explicit /project-init:wiring invocation. Detects 14 axes of agent-harness configuration, including four that check whether config takes EFFECT rather than merely exists: git core.hooksPath, an @import that defeats .claude/rules paths: scoping, MCP servers registered twice so one copy is silently discarded, and the Codex AGENTS.md byte budget. Verdicts are FAIL / WARN / ASK / INFO / SKIP / OK — an ASK is a decision nobody made yet, asked once and persisted to .claude/state/wiring.json. Read-only until approved. Complements /project-init:new (empty dirs only). Not for mem0 store diagnostics (/mem0-ops:doctor) or wiki-content health (/llm-wiki:lint-wiki)."
 ---
 
 # project-init `wiring` skill
@@ -15,6 +15,34 @@ Sibling of `new`: `new` bootstraps an empty directory and hard-aborts on a non-e
 - **Nothing is fixed before approval.** Present the full report, then a single `AskUserQuestion` gate.
 - **Delegate, do not reimplement.** Every remediation that needs judgment routes to the skill that owns it. Only mechanical, reversible edits are applied here.
 - **Absent tooling is not a defect.** An unconfigured optional integration (gws-sync without the `gws` CLI) reports `SKIP`, never `FAIL`.
+- **A decision is not a defect.** Some axes have no correct answer the filesystem can know — whether this project wants a git remote, whether its deliverables belong on a shared Drive. Those report `ASK`, are put to the user once, and the answer is persisted so the next run stays quiet. An axis that barks the same un-answerable warning every run trains the user to ignore the ones that matter.
+
+## Verdict classes
+
+| Class | Means | Next run |
+|---|---|---|
+| `FAIL` | broken, or losing data | keeps failing until fixed |
+| `WARN` | works but degraded | keeps warning until fixed |
+| `ASK` | a decision nobody has made yet — not a defect | silent once answered |
+| `INFO` | worth seeing, no action implied | always shown |
+| `SKIP` | optional and not adopted | silent |
+| `OK` | healthy | one line |
+
+## Answers file
+
+`ASK` answers live in `.claude/state/wiring.json` (gitignored, alongside `spec.json` and `cr-fix-*.json`). Values are machine-local — a Drive folder id is not the same on another clone — so they do not belong in a committed file. `CLAUDE.md` carries only a pointer to this path, never the values.
+
+```json
+{
+  "schema": 1,
+  "answers": {
+    "git_remote": { "value": "none-intended", "answered_at": "2026-07-10" },
+    "gws_sync":   { "value": "not-for-this-repo", "answered_at": "2026-07-10" }
+  }
+}
+```
+
+`project_state.sh` surfaces the file's `answers` object verbatim under `.answers`. Before raising any `ASK`, check whether its key is already answered; if so, report the recorded value as `OK` or `SKIP` and move on. Re-ask only when the user says so, or when an answer is older than a year.
 
 ## Step 0 — Resolve PLUGIN_ROOT
 
@@ -42,21 +70,49 @@ Do not re-derive any field with ad-hoc `test -f` calls — the script is the det
 
 ## Step 2 — Verdict per axis
 
-Map the JSON to verdicts. `FAIL` = broken or losing data. `WARN` = works but degraded. `SKIP` = optional and not adopted. `OK` = healthy.
+Map the JSON to verdicts. Suppress any `ASK` whose key already appears in `.answers`.
 
-| Axis | JSON | FAIL when | WARN when | Remediation |
-|---|---|---|---|---|
-| git | `.git` | `initialized: false` | `commits: 0` or `remote_origin: false` | `git init` / `gh repo create` |
-| hooksPath | `.git.hooks_path`, `.hooks_dir_present` | — | `hooks_dir_present: true` but `hooks_path: null` | `git config core.hooksPath .githooks` |
-| guidance | `.seeded.claude_md`, `.guidance` | `claude_md: false` | `cross_runtime_gap: true` | `/rules-forge:write-rules` |
-| llm-wiki | `.llmwiki` | `staging_pending > 0` | `state: absent`; `state: legacy`; `state: current` but `insight_layer: false` or `raw_source_buckets: false` | pending → `/llm-wiki:ingest-finding`; absent → `/llm-wiki:bootstrap-wiki`; legacy → `/llm-wiki:migrate-wiki` |
-| serena | `.serena` | — | `state: not-registered` / `registered`; `name_drift: true` | onboard via Serena MCP `onboarding`; drift → edit `.serena/project.yml` |
-| memory | `.memory` | `native_auto_memory_enabled: true` **and** `mem0_settings: true` | `native_memory_md: true` but auto-memory disabled (orphan files); `mem0_settings: true` but `federate_labels: false`; `mem0_project_mapped: false` | see "Memory posture" below |
-| spec | `.spec` | — | `claude_spec > 0` **and** `superpowers_spec > 0` (split home); `missing_frontmatter > 0` | `/spec-state:state-tracker init` |
-| gws-sync | `.gws_sync` | — | `cli: true` but `config: false` | `/gws-sync:gws-sync` |
-| .tmp | `.tmp` | — | `dir: true` and `gitignored: false`; `stale_files > 0` | mechanical fix (Step 4) |
-| gitignore | `.gitignore` | `env: false` | any of `claude_state` / `serena` / `llmwiki_staging` false | mechanical fix (Step 4) |
-| code_signal | `.code_signal` | — | — | informational only |
+| Axis | JSON | FAIL when | WARN when | ASK / INFO when | Remediation |
+|---|---|---|---|---|---|
+| git | `.git` | `initialized: false` | `commits: 0` | **ASK** `remote_origin: false` — "push할 원격을 만들까요?" (`git_remote`) | `git init` / `gh repo create` |
+| hooksPath | `.git.hooks_path`, `.hooks_dir_present` | — | `hooks_dir_present: true` but `hooks_path: null` | — | `git config core.hooksPath .githooks` |
+| guidance | `.seeded.claude_md`, `.guidance` | `claude_md: false` | `cross_runtime_gap: true` | — | `/rules-forge:write-rules` |
+| rules scoping | `.rules_scoping` | — | `paths_defeated_by_import` non-empty | — | drop the `@` (mechanical, Step 4) |
+| llm-wiki | `.llmwiki` | `staging_pending > 0` | `state: absent`; `state: legacy`; `state: current` but `insight_layer: false` or `raw_source_buckets: false` | — | pending → `/llm-wiki:ingest-finding`; absent → `/llm-wiki:bootstrap-wiki`; legacy → `/llm-wiki:migrate-wiki` |
+| serena | `.serena` | — | `state: not-registered` / `registered`; `name_drift: true` | — | onboard via Serena MCP `onboarding`; drift → edit `.serena/project.yml` |
+| memory | `.memory` | `native_auto_memory_enabled: true` **and** `mem0_settings: true` | orphan `MEMORY.md`; `mem0_settings: true` but `federate_labels: false`; `mem0_project_mapped: false` | — | see "Memory posture" below |
+| mcp config | `.mcp` | — | `duplicates` non-empty | — | collapse to one file (see below) |
+| codex | `.codex` | — | — | **INFO** always when `config: true` | none — visibility only |
+| spec | `.spec` | — | `missing_frontmatter > 0` | **INFO** `claude_spec > 0` **and** `superpowers_spec > 0` | `/spec-state:state-tracker init` |
+| gws-sync | `.gws_sync` | — | — | **ASK** unless answered (`gws_sync`) — see below | `/gws-sync:gws-sync` |
+| .tmp | `.tmp` | — | `dir: true` and `gitignored: false`; `stale_files > 0` | — | mechanical fix (Step 4) |
+| gitignore | `.gitignore` | `env: false` | any of `claude_state` / `serena` / `llmwiki_staging` false | — | mechanical fix (Step 4) |
+| code_signal | `.code_signal` | — | — | **INFO** | — |
+
+### The three efficacy axes
+
+Existence checks answer "is it there?". These four answer "**does it take effect?**" — the failure mode where a file exists, looks configured, and is inert.
+
+- **hooksPath.** `.githooks/` is tracked; `core.hooksPath` is per-clone git config that is *not*. A fresh clone has the hook scripts and no hook. Silent until CI catches it after the push. When `.githooks/` is absent the axis says nothing — plenty of repos don't use it.
+- **rules scoping.** A `.claude/rules/*.md` carrying `paths:` frontmatter is meant to load only when Claude touches matching files. `@import`ing that same file from `CLAUDE.md` expands it unconditionally at launch, so the scoping is dead and its tokens are paid every session. Fix: drop the `@` and wrap the path in backticks — import parsing skips code spans, so the line survives as a human pointer.
+- **mcp config.** When the same server name appears in both `~/.claude.json` and `~/.claude/settings.json`, Claude Code picks one entry whole and discards the other — fields are never merged. Two definitions that have drifted mean one file's edits have never once taken effect. Report the duplicate names and say plainly that editing the losing copy does nothing. Orphan registrations (a server left behind by a deleted plugin) need usage history to identify — that is the built-in `/doctor`'s job, not this skill's.
+
+### `codex` is INFO, never a verdict
+
+`approval_policy: "never"` with `sandbox_mode: "danger-full-access"` means a `/codex:rescue` edits the working tree without asking. That is a legitimate dev-box choice, so it is not a defect — but it should never be a surprise. Print it. Same for `model_pinned`: pinning freezes the model that `codex-image` deliberately leaves unpinned to auto-track the latest, which is maintenance debt, not breakage.
+
+Also print the Codex doc budget when `AGENTS.md` exists: `agents_md_bytes + global_agents_md_bytes` against `project_doc_max_bytes`. Codex concatenates root-down and truncates at the cap — and the tail of `AGENTS.md` is usually `## Review guidelines`, the part the GitHub cloud reviewer needs. Warn past 80%.
+
+### gws-sync is a two-step ASK
+
+Never a defect — it is a question about what this project produces.
+
+1. If `cli: false` → ASK: "이 프로젝트 산출물을 Google Drive 에 올리나요?" If yes, guide the install (`gws` CLI) and stop; record `gws_sync: "pending-install"`. If no, record `gws_sync: "not-for-this-repo"` and never ask again.
+2. If `cli: true` and `config: false` → ASK which local folders are the deliverables and which Drive folder receives them, then hand off to `/gws-sync:gws-sync` to write `.gws-sync.json`. Record `gws_sync: "configured"`.
+
+### spec is a preference, not a migration
+
+Two spec homes is `INFO`, not `WARN`: state which one this project prefers (`.claude/spec/` unless the project says otherwise) and leave the files where they are. Only `missing_frontmatter > 0` is a `WARN`, because a spec without `status:` frontmatter is invisible to `spec-state` regardless of which directory it sits in. Never move spec files as part of "apply all".
 
 Three verdicts need an explanation the JSON cannot carry:
 
@@ -75,19 +131,24 @@ Print a fixed-width table, most severe first. Name the remediation on every non-
 
 [FAIL] llm-wiki    .llmwiki/.staging: 2 pending captures uncurated
                    -> /llm-wiki:ingest-finding  (gitignored; lore is unrecoverable if cleaned)
-[WARN] serena      project.yml name "oh-my-claudecode" != dir "my-claude-plugins"
-                   -> edit .serena/project.yml
-[WARN] .tmp        not covered by .gitignore
-                   -> mechanical fix available
-[SKIP] gws-sync    gws CLI not installed
+[WARN] rules       plugin-versioning.md has paths: scoping, but CLAUDE.md @imports it
+                   -> scoping is dead; ~2k tokens loaded every session. mechanical fix
+[WARN] mcp         7 servers registered twice (~/.claude.json wins, settings.json copy inert)
+                   -> context7 deepwiki exa firecrawl mcpdocs notion shadcn-ui
+[ASK ] gws-sync    does this project publish deliverables to Drive?  (unanswered)
+[ASK ] git         no origin remote — create one?                    (unanswered)
+[INFO] codex       approval=never sandbox=danger-full-access -> /codex:rescue edits unprompted
+[INFO] codex       AGENTS.md 28,506 / 65,536 B (43%) of the doc budget
+[INFO] spec        .claude/spec 8 + docs/superpowers/specs 6 — this project prefers .claude/spec
 [ OK ] llm-wiki    post-2.4.0 layout (insight + raw buckets)
 [ OK ] serena      onboarded (1 memory)
 ```
 
-State the scan is filesystem-only. Two things it deliberately does not check, to avoid duplicating their owners:
+State the scan is filesystem-only. Things it deliberately does not check, to avoid duplicating their owners:
 
 - wiki page staleness / identity duplication → `/llm-wiki:lint-wiki`
 - mem0 store contents and config posture → `/mem0-ops:doctor`
+- MCP servers left behind by deleted plugins, and which extensions go unused → the built-in `/doctor` (it reads usage history; this skill reads only the filesystem)
 
 ## Step 4 — Gate, then fix
 
@@ -101,12 +162,15 @@ Present ONE `AskUserQuestion`. Put "Apply all mechanical fixes (Recommended)" fi
 | `.tmp/` convention | `mkdir -p .tmp && : > .tmp/.gitkeep` + the `.gitignore` line |
 | hooksPath | `git config core.hooksPath .githooks` |
 | serena name drift | rewrite the `project_name:` line in `.serena/project.yml` |
+| rules scoping | in `CLAUDE.md`, change `@.claude/rules/<f>.md` to `` `.claude/rules/<f>.md` `` — restores `paths:` scoping, keeps the pointer readable |
 
 **Never fixed here** — delegate, and say so:
 
-`.staging` drain, wiki bootstrap/migrate, CLAUDE.md authoring, spec relocation, Serena onboarding, mem0 changes. Each needs LLM judgment or touches a store this skill does not own.
+`.staging` drain, wiki bootstrap/migrate, CLAUDE.md authoring, spec relocation, Serena onboarding, mem0 changes, MCP config collapse (it edits a user-scope file holding credentials). Each needs LLM judgment or touches a store this skill does not own.
 
 Deleting stale `.tmp/` files is destructive: list them, confirm separately, and never widen the glob beyond `.tmp/`.
+
+**Recording `ASK` answers.** Every `ASK` the user answers is written to `.claude/state/wiring.json` under `answers.<key>` with `value` and `answered_at` (UTC `YYYY-MM-DD`). Create the file if absent. Write it even when the rest of "apply all" is declined — a recorded "no" is the whole point of the class. Never write an answer the user did not give.
 
 ## Memory posture
 

--- a/plugins/project-init/skills/wiring/SKILL.md
+++ b/plugins/project-init/skills/wiring/SKILL.md
@@ -14,7 +14,7 @@ Sibling of `new`: `new` bootstraps an empty directory and hard-aborts on a non-e
 - **Detection is read-only.** `scripts/project_state.sh` never writes. Run it first, always.
 - **Nothing is fixed before approval.** Present the full report, then a single `AskUserQuestion` gate.
 - **Delegate, do not reimplement.** Every remediation that needs judgment routes to the skill that owns it. Only mechanical, reversible edits are applied here.
-- **Absent tooling is not a defect.** A missing optional CLI is never a `FAIL`. `gws-sync` without the `gws` binary is an unanswered question (`ASK`) or a recorded decision (`SKIP`), never a broken repo.
+- **Absent tooling is not a defect.** A missing optional CLI is never a `FAIL`. For `gws-sync` the exact verdict — `ASK`, `SKIP`, `INFO`, or a `WARN` when a live `.gws-sync.json` outlives its CLI — comes from the table in "gws-sync is a two-step ASK", never from the CLI's absence alone.
 - **A decision is not a defect.** Some axes have no correct answer the filesystem can know — whether this project wants a git remote, whether its deliverables belong on a shared Drive. Those report `ASK`, are put to the user once, and the answer is persisted so the next run stays quiet. An axis that barks the same un-answerable warning every run trains the user to ignore the ones that matter.
 
 ## Verdict classes

--- a/plugins/project-init/skills/wiring/SKILL.md
+++ b/plugins/project-init/skills/wiring/SKILL.md
@@ -42,7 +42,7 @@ Sibling of `new`: `new` bootstraps an empty directory and hard-aborts on a non-e
 }
 ```
 
-`project_state.sh` surfaces the file's `answers` object verbatim under `.answers`. Before raising any `ASK`, check whether its key is already answered; if so, report the recorded value as `OK` or `SKIP` and move on. Re-ask only when the user says so, or when an answer is older than a year.
+`project_state.sh` surfaces the file's `answers` object verbatim under `.answers`. Before raising any `ASK`, check whether its key holds a **terminal** value; if so, report it as `OK` or `SKIP` and move on. A value that records a step still pending (`gws_sync: "pending-install"`) is not terminal — re-ask once its precondition is met, or the answer file silently swallows the follow-up question. Re-ask otherwise only when the user says so, or when an answer is older than a year.
 
 ## Step 0 — Resolve PLUGIN_ROOT
 
@@ -81,15 +81,15 @@ Map the JSON to verdicts. Suppress any `ASK` whose key already appears in `.answ
 | llm-wiki | `.llmwiki` | `staging_pending > 0` | `state: absent`; `state: legacy`; `state: current` but `insight_layer: false` or `raw_source_buckets: false` | — | pending → `/llm-wiki:ingest-finding`; absent → `/llm-wiki:bootstrap-wiki`; legacy → `/llm-wiki:migrate-wiki` |
 | serena | `.serena` | — | `state: not-registered` / `registered`; `name_drift: true` | — | onboard via Serena MCP `onboarding`; drift → edit `.serena/project.yml` |
 | memory | `.memory` | `native_auto_memory_enabled: true` **and** `mem0_settings: true` | orphan `MEMORY.md`; `mem0_settings: true` but `federate_labels: false`; `mem0_project_mapped: false` | — | see "Memory posture" below |
-| mcp config | `.mcp` | — | `duplicates` non-empty | — | collapse to one file (see below) |
-| codex | `.codex` | — | — | **INFO** always when `config: true` | none — visibility only |
+| mcp config | `.mcp` | — | `duplicates` non-empty; `unreadable` non-empty | — | collapse to one file (see below) |
+| codex | `.codex` | — | `agents_md_bytes + global_agents_md_bytes` ≥ 80% of `project_doc_max_bytes` | **INFO** otherwise when `config: true` | over budget → trim `AGENTS.md`; else visibility only |
 | spec | `.spec` | — | `missing_frontmatter > 0` | **INFO** `claude_spec > 0` **and** `superpowers_spec > 0` | `/spec-state:state-tracker init` |
-| gws-sync | `.gws_sync` | — | — | **ASK** unless answered (`gws_sync`) — see below | `/gws-sync:gws-sync` |
+| gws-sync | `.gws_sync` | — | — | **ASK** unless answered with a terminal value (`gws_sync`) — see below | `/gws-sync:gws-sync` |
 | .tmp | `.tmp` | — | `dir: true` and `gitignored: false`; `stale_files > 0` | — | mechanical fix (Step 4) |
 | gitignore | `.gitignore` | `env: false` | any of `claude_state` / `serena` / `llmwiki_staging` false | — | mechanical fix (Step 4) |
 | code_signal | `.code_signal` | — | — | **INFO** | — |
 
-### The three efficacy axes
+### The four efficacy axes
 
 Existence checks answer "is it there?". These four answer "**does it take effect?**" — the failure mode where a file exists, looks configured, and is inert.
 
@@ -97,11 +97,13 @@ Existence checks answer "is it there?". These four answer "**does it take effect
 - **rules scoping.** A `.claude/rules/*.md` carrying `paths:` frontmatter is meant to load only when Claude touches matching files. `@import`ing that same file from `CLAUDE.md` expands it unconditionally at launch, so the scoping is dead and its tokens are paid every session. Fix: drop the `@` and wrap the path in backticks — import parsing skips code spans, so the line survives as a human pointer.
 - **mcp config.** When the same server name appears in both `~/.claude.json` and `~/.claude/settings.json`, Claude Code picks one entry whole and discards the other — fields are never merged. Two definitions that have drifted mean one file's edits have never once taken effect. Report the duplicate names and say plainly that editing the losing copy does nothing. Orphan registrations (a server left behind by a deleted plugin) need usage history to identify — that is the built-in `/doctor`'s job, not this skill's.
 
-### `codex` is INFO, never a verdict
+  `unreadable` is a separate `WARN`. A user-scope file that is not valid JSON cannot be compared, and the detector refuses to answer "no duplicates" when what it means is "could not look". Name the file and say the duplicate check did not run.
 
-`approval_policy: "never"` with `sandbox_mode: "danger-full-access"` means a `/codex:rescue` edits the working tree without asking. That is a legitimate dev-box choice, so it is not a defect — but it should never be a surprise. Print it. Same for `model_pinned`: pinning freezes the model that `codex-image` deliberately leaves unpinned to auto-track the latest, which is maintenance debt, not breakage.
+### `codex` is visibility, except the doc budget
 
-Also print the Codex doc budget when `AGENTS.md` exists: `agents_md_bytes + global_agents_md_bytes` against `project_doc_max_bytes`. Codex concatenates root-down and truncates at the cap — and the tail of `AGENTS.md` is usually `## Review guidelines`, the part the GitHub cloud reviewer needs. Warn past 80%.
+`approval_policy: "never"` with `sandbox_mode: "danger-full-access"` means a `/codex:rescue` edits the working tree without asking. That is a legitimate dev-box choice, so it is not a defect — but it should never be a surprise. Print it. The one part of this axis that *is* a verdict is the doc budget below. Same for `model_pinned`: pinning freezes the model that `codex-image` deliberately leaves unpinned to auto-track the latest, which is maintenance debt, not breakage.
+
+Also print the Codex doc budget when `AGENTS.md` exists: `agents_md_bytes + global_agents_md_bytes` against `project_doc_max_bytes`. Codex concatenates root-down and truncates at the cap — and the tail of `AGENTS.md` is usually `## Review guidelines`, the part the GitHub cloud reviewer loads into its system prompt. So the budget is a `WARN` at 80% and above, not an `INFO`: past the cap the guidance is silently gone, with no error anywhere. Below 80% it is `INFO`, visibility only.
 
 ### gws-sync is a two-step ASK
 
@@ -109,6 +111,8 @@ Never a defect — it is a question about what this project produces.
 
 1. If `cli: false` → ASK: "이 프로젝트 산출물을 Google Drive 에 올리나요?" If yes, guide the install (`gws` CLI) and stop; record `gws_sync: "pending-install"`. If no, record `gws_sync: "not-for-this-repo"` and never ask again.
 2. If `cli: true` and `config: false` → ASK which local folders are the deliverables and which Drive folder receives them, then hand off to `/gws-sync:gws-sync` to write `.gws-sync.json`. Record `gws_sync: "configured"`.
+
+**Only a terminal answer suppresses the ASK.** `not-for-this-repo` and `configured` are decisions; `pending-install` is a step that has not happened yet. Treating all three as "answered" means the user installs `gws`, re-runs `wiring`, and is never asked step 2 — the answer file has silently swallowed the question. Re-ask whenever the recorded value is `pending-install` and `cli: true`.
 
 ### spec is a preference, not a migration
 

--- a/plugins/project-init/skills/wiring/SKILL.md
+++ b/plugins/project-init/skills/wiring/SKILL.md
@@ -172,6 +172,8 @@ Deleting stale `.tmp/` files is destructive: list them, confirm separately, and 
 
 **Recording `ASK` answers.** Every `ASK` the user answers is written to `.claude/state/wiring.json` under `answers.<key>` with `value` and `answered_at` (UTC `YYYY-MM-DD`). Create the file if absent. Write it even when the rest of "apply all" is declined — a recorded "no" is the whole point of the class. Never write an answer the user did not give.
 
+**The answers file must be ignored before it is written.** Its values are machine-local (a Drive folder id, a decision that holds for this clone only), so run `git check-ignore -q .claude/state/wiring.json` first. If it does not pass, add `.claude/state/` to `.gitignore` as a precondition — not as part of "apply all", which the user may have declined. If the user declines that line too, do not create the file: report the answer as unrecorded and say why. Persisting a "no" is worth a `.gitignore` line; it is not worth committing someone's Drive folder id on their next `git add -A`. Outside a git repository the check does not apply.
+
 ## Memory posture
 
 This axis checks **posture consistency** — which writers are live and whether their authority relationship is declared. It does **not** check **content consistency**: whether mem0 and `.llmwiki/` hold contradicting versions of the same fact. That comparison spans a cloud API and a markdown tree, no tool in this toolchain performs it, and claiming otherwise would be a lie. Say so when reporting.

--- a/plugins/project-init/skills/wiring/SKILL.md
+++ b/plugins/project-init/skills/wiring/SKILL.md
@@ -14,7 +14,7 @@ Sibling of `new`: `new` bootstraps an empty directory and hard-aborts on a non-e
 - **Detection is read-only.** `scripts/project_state.sh` never writes. Run it first, always.
 - **Nothing is fixed before approval.** Present the full report, then a single `AskUserQuestion` gate.
 - **Delegate, do not reimplement.** Every remediation that needs judgment routes to the skill that owns it. Only mechanical, reversible edits are applied here.
-- **Absent tooling is not a defect.** An unconfigured optional integration (gws-sync without the `gws` CLI) reports `SKIP`, never `FAIL`.
+- **Absent tooling is not a defect.** A missing optional CLI is never a `FAIL`. `gws-sync` without the `gws` binary is an unanswered question (`ASK`) or a recorded decision (`SKIP`), never a broken repo.
 - **A decision is not a defect.** Some axes have no correct answer the filesystem can know — whether this project wants a git remote, whether its deliverables belong on a shared Drive. Those report `ASK`, are put to the user once, and the answer is persisted so the next run stays quiet. An axis that barks the same un-answerable warning every run trains the user to ignore the ones that matter.
 
 ## Verdict classes
@@ -42,7 +42,7 @@ Sibling of `new`: `new` bootstraps an empty directory and hard-aborts on a non-e
 }
 ```
 
-`project_state.sh` surfaces the file's `answers` object verbatim under `.answers`. Before raising any `ASK`, check whether its key holds a **terminal** value; if so, report it as `OK` or `SKIP` and move on. A value that records a step still pending (`gws_sync: "pending-install"`) is not terminal — re-ask once its precondition is met, or the answer file silently swallows the follow-up question. Otherwise re-ask only when the user explicitly asks to revisit the decision. There is no automatic expiry: "do you want a git remote?" does not become a new question a year later, and an axis that re-opens settled decisions on a timer is the same barking this class exists to stop.
+`project_state.sh` surfaces the file's `answers` object verbatim under `.answers`. Before raising any `ASK`, check whether its key holds a **terminal** value; if so, report it as `OK` or `SKIP` and move on. For `gws_sync` the answer alone does not settle it — the filesystem can have moved underneath, so its verdict comes from the table in "gws-sync is a two-step ASK". A value that records a step still pending (`gws_sync: "pending-install"`) is not terminal — re-ask once its precondition is met, or the answer file silently swallows the follow-up question. Otherwise re-ask only when the user explicitly asks to revisit the decision. There is no automatic expiry: "do you want a git remote?" does not become a new question a year later, and an axis that re-opens settled decisions on a timer is the same barking this class exists to stop.
 
 ## Step 0 — Resolve PLUGIN_ROOT
 
@@ -84,7 +84,7 @@ Map the JSON to verdicts. Suppress an `ASK` only when its key in `.answers` hold
 | mcp config | `.mcp` | — | `duplicates` non-empty; `unreadable` non-empty | — | collapse to one file (see below) |
 | codex | `.codex` | — | `agents_md_bytes + global_agents_md_bytes` ≥ 80% of `project_doc_max_bytes` | **INFO** otherwise when `config: true` | over budget → trim `AGENTS.md`; else visibility only |
 | spec | `.spec` | — | `missing_frontmatter > 0` | **INFO** `claude_spec > 0` **and** `superpowers_spec > 0` | `/spec-state:state-tracker init` |
-| gws-sync | `.gws_sync` | — | — | **ASK** unless answered with a terminal value (`gws_sync`) — see below | `/gws-sync:gws-sync` |
+| gws-sync | `.gws_sync`, `.answers.gws_sync` | — | `config: true` but `cli: false` | **ASK** / **OK** / **SKIP** / **INFO** per the table in "gws-sync is a two-step ASK" | `/gws-sync:gws-sync` |
 | .tmp | `.tmp` | — | `dir: true` and `gitignored: false`; `stale_files > 0` | — | mechanical fix (Step 4) |
 | gitignore | `.gitignore` | `env: false` | any of `claude_state` / `serena` / `llmwiki_staging` false | — | mechanical fix (Step 4) |
 | code_signal | `.code_signal` | — | — | **INFO** | — |
@@ -107,12 +107,23 @@ Also print the Codex doc budget when `AGENTS.md` exists: `agents_md_bytes + glob
 
 ### gws-sync is a two-step ASK
 
-Never a defect — it is a question about what this project produces.
+Never a defect — it is a question about what this project produces. The verdict depends on the filesystem (`.gws_sync.cli`, `.gws_sync.config`) *and* the recorded answer, never on the answer alone. This table is the single definition; Step 2 and Step 3.5 both defer to it.
 
-1. If `cli: false` → ASK: "이 프로젝트 산출물을 Google Drive 에 올리나요?" If yes, guide the install (`gws` CLI) and stop; record `gws_sync: "pending-install"`. If no, record `gws_sync: "not-for-this-repo"` and never ask again.
-2. If `cli: true` and `config: false` → ASK which local folders are the deliverables and which Drive folder receives them, then hand off to `/gws-sync:gws-sync` to write `.gws-sync.json`. Record `gws_sync: "configured"`.
+| `config` | recorded `gws_sync` | `cli` | Verdict | Ask? |
+|---|---|---|---|---|
+| `true` | any | `true` | `OK` — already adopted | no |
+| `true` | any | `false` | `WARN` — `.gws-sync.json` exists but the `gws` CLI is gone | no |
+| `false` | `not-for-this-repo` | any | `SKIP` | no |
+| `false` | `configured` | any | `ASK` — the config it claims is gone; confirm before rewriting | yes |
+| `false` | `pending-install` | `false` | `INFO` — waiting on the `gws` install | no |
+| `false` | `pending-install` | `true` | `ASK` step 2 | yes |
+| `false` | *(none)* | `false` | `ASK` step 1 | yes |
+| `false` | *(none)* | `true` | `ASK` step 2 | yes |
 
-**Only a terminal answer suppresses the ASK.** `not-for-this-repo` and `configured` are decisions; `pending-install` is a step that has not happened yet. Treating all three as "answered" means the user installs `gws`, re-runs `wiring`, and is never asked step 2 — the answer file has silently swallowed the question. Re-ask whenever the recorded value is `pending-install` and `cli: true`.
+1. **Step 1** ASK: "이 프로젝트 산출물을 Google Drive 에 올리나요?" If yes, guide the `gws` install and stop; record `gws_sync: "pending-install"`. If no, record `gws_sync: "not-for-this-repo"`.
+2. **Step 2** ASK which local folders are the deliverables and which Drive folder receives them, then hand off to `/gws-sync:gws-sync` to write `.gws-sync.json`. Record `gws_sync: "configured"`.
+
+Two ways this axis silently misbehaves, both closed by the table above. Treating `pending-install` as a decision means the user installs `gws`, re-runs `wiring`, and is never asked step 2 — the answer file swallows its own follow-up. Treating it as *unanswered* means asking the same question on every run before the install has happened. And a repo that already has `.gws-sync.json` must never be asked whether it wants Drive at all: a `not-for-this-repo` recorded on top of a live config puts the two in direct conflict.
 
 ### spec is a preference, not a migration
 
@@ -158,7 +169,7 @@ State the scan is filesystem-only. Things it deliberately does not check, to avo
 
 Every axis the report printed as `[ASK] … (unanswered)` is asked here, before Step 4. Without this step the class is decorative: the row renders, nobody is asked, `.claude/state/wiring.json` is never written, and the next run prints the same row forever.
 
-One `AskUserQuestion` per axis — `git_remote` and `gws_sync` are unrelated decisions and a `multiSelect` would conflate them. Skip an axis whose key already holds a terminal value. Record each answer per "Recording `ASK` answers" below, and honor the `.gitignore` precondition there.
+One `AskUserQuestion` per axis — `git_remote` and `gws_sync` are unrelated decisions and a `multiSelect` would conflate them. Ask an axis only when Step 2 marked it `ASK`; for `gws-sync` that verdict comes from the table in "gws-sync is a two-step ASK", which reads the filesystem as well as the recorded answer. Record each answer per "Recording `ASK` answers" below, and honor the `.gitignore` precondition there.
 
 A dismissed question leaves the key absent. An unanswered `ASK` is not a recorded "no" — inventing one would be writing an answer the user did not give.
 

--- a/plugins/project-init/skills/wiring/SKILL.md
+++ b/plugins/project-init/skills/wiring/SKILL.md
@@ -42,7 +42,7 @@ Sibling of `new`: `new` bootstraps an empty directory and hard-aborts on a non-e
 }
 ```
 
-`project_state.sh` surfaces the file's `answers` object verbatim under `.answers`. Before raising any `ASK`, check whether its key holds a **terminal** value; if so, report it as `OK` or `SKIP` and move on. A value that records a step still pending (`gws_sync: "pending-install"`) is not terminal — re-ask once its precondition is met, or the answer file silently swallows the follow-up question. Re-ask otherwise only when the user says so, or when an answer is older than a year.
+`project_state.sh` surfaces the file's `answers` object verbatim under `.answers`. Before raising any `ASK`, check whether its key holds a **terminal** value; if so, report it as `OK` or `SKIP` and move on. A value that records a step still pending (`gws_sync: "pending-install"`) is not terminal — re-ask once its precondition is met, or the answer file silently swallows the follow-up question. Otherwise re-ask only when the user explicitly asks to revisit the decision. There is no automatic expiry: "do you want a git remote?" does not become a new question a year later, and an axis that re-opens settled decisions on a timer is the same barking this class exists to stop.
 
 ## Step 0 — Resolve PLUGIN_ROOT
 
@@ -70,7 +70,7 @@ Do not re-derive any field with ad-hoc `test -f` calls — the script is the det
 
 ## Step 2 — Verdict per axis
 
-Map the JSON to verdicts. Suppress any `ASK` whose key already appears in `.answers`.
+Map the JSON to verdicts. Suppress an `ASK` only when its key in `.answers` holds a *terminal* value (see "Answers file").
 
 | Axis | JSON | FAIL when | WARN when | ASK / INFO when | Remediation |
 |---|---|---|---|---|---|
@@ -154,9 +154,19 @@ State the scan is filesystem-only. Things it deliberately does not check, to avo
 - mem0 store contents and config posture → `/mem0-ops:doctor`
 - MCP servers left behind by deleted plugins, and which extensions go unused → the built-in `/doctor` (it reads usage history; this skill reads only the filesystem)
 
+## Step 3.5 — Put the `ASK` axes to the user
+
+Every axis the report printed as `[ASK] … (unanswered)` is asked here, before Step 4. Without this step the class is decorative: the row renders, nobody is asked, `.claude/state/wiring.json` is never written, and the next run prints the same row forever.
+
+One `AskUserQuestion` per axis — `git_remote` and `gws_sync` are unrelated decisions and a `multiSelect` would conflate them. Skip an axis whose key already holds a terminal value. Record each answer per "Recording `ASK` answers" below, and honor the `.gitignore` precondition there.
+
+A dismissed question leaves the key absent. An unanswered `ASK` is not a recorded "no" — inventing one would be writing an answer the user did not give.
+
+Step 4's gate runs after this, and asks only about the mechanical fixes.
+
 ## Step 4 — Gate, then fix
 
-Present ONE `AskUserQuestion`. Put "Apply all mechanical fixes (Recommended)" first, "Let me pick" second, "Report only" last. If the user picks "Let me pick", follow with one `multiSelect` question, one option per fix group.
+Present ONE `AskUserQuestion` for the mechanical fixes (the `ASK` axes were already answered in Step 3.5). Put "Apply all mechanical fixes (Recommended)" first, "Let me pick" second, "Report only" last. If the user picks "Let me pick", follow with one `multiSelect` question, one option per fix group.
 
 **Mechanically fixable here** (reversible, no judgment):
 


### PR DESCRIPTION
## Why

Existence checks answer "is it there?". Every defect this session surfaced was a different question: **"does it take effect?"** — a file that exists, looks configured, and is inert.

| Found here | Why it hides |
|---|---|
| `.claude/rules/plugin-versioning.md` carries `paths:` scoping, but `CLAUDE.md` `@import`s it | `@import` expands unconditionally at launch, so the scoping is dead and ~2k tokens load every session |
| 7 MCP servers registered in both `~/.claude.json` and `~/.claude/settings.json` | Claude Code picks one entry **whole** and discards the other — fields are never merged. The losing `mcpdocs` copy has drifted, so its `slidev`/`runpod` llms.txt sources have never once loaded |
| `AGENTS.md` + `~/.codex/AGENTS.md` vs `project_doc_max_bytes` | Codex concatenates root-down and truncates at the cap; the tail of `AGENTS.md` is `## Review guidelines`, the section the GitHub cloud reviewer reads |
| `core.hooksPath` (already an axis) | per-clone git config, not tracked — a fresh clone has the hook scripts and no hook |

The `paths:` bug is real and was live in this repo. The fix is in this PR (`@` dropped, backticks added), and `project_state.sh` now reports `paths_defeated_by_import: []` — the tool recognizes the fix it prescribed.

## The ASK verdict class

`FAIL / WARN / ASK / INFO / SKIP / OK`.

A missing git remote and an unconfigured `gws-sync` are not defects — they are decisions nobody has made. They are asked **once** and the answer persists to `.claude/state/wiring.json`. An axis that barks the same un-answerable warning on every run trains the user to ignore the ones that matter, and then a real `FAIL` gets ignored with them.

Values are machine-local (a Drive folder id is not portable across clones), so the state file is gitignored — alongside `spec.json` and `cr-fix-*.json` — and `CLAUDE.md` carries only a pointer to the path, never the values. That mirrors `core-config`'s `prompt_inject.sh`, which points at `.llmwiki/insight/` every prompt and never inlines its content.

## Scope boundaries kept

- **Orphan MCP registrations are out of scope.** Identifying a server left behind by a deleted plugin needs usage history — the built-in `/doctor`'s signal, not the filesystem's. Duplicate registration *is* in scope: it is the intersection of two key sets, pure computation. The skill says which it can and cannot do.
- **`codex` is INFO, never a verdict.** `approval_policy: "never"` + `sandbox_mode: "danger-full-access"` means `/codex:rescue` edits the working tree unprompted. That is a legitimate dev-box choice. It should not be a surprise, so it prints; it is not a defect, so it never fails.
- **spec-home split demoted WARN -> INFO.** `.claude/spec/` is a preference, not a migration; `wiring` never moves spec files. Only a missing `status:` frontmatter stays a WARN, because such a spec is invisible to `spec-state` wherever it sits.
- **`.githooks/` absent stays silent.** The WARN fires only on `hooks_dir_present: true` **and** `hooks_path: null`. Plenty of repos don't use it.

## Verification

- 9/9 fixture tests: empty dir, non-git dir, legacy `.claude/wiki/`, `.gitkeep`-only wiki, this repo, `paths:` scoping before/after, MCP duplicate count, Codex budget read, `answers` round-trip.
- New axes degrade cleanly where the inputs don't exist: with `HOME` pointed at an empty dir, `mcp.duplicates: []`, `codex.config: false`, `rules_scoping: []`, `answers: {}`, exit 0.
- `idempotent-seed.sh diagnose` output shape unchanged.
- Skill `description` 925 chars (Codex cap 1024); `.githooks/pre-commit` passes both `--check` guards.
- `shellcheck` is not installed on this machine — shell linting remains unverified.

Versions: project-init `0.3.0 -> 0.4.0`, marketplace `metadata.version 1.88.0 -> 1.89.0`. Plugin count unchanged (24), Codex-eligible unchanged (22).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새 기능**
  - `/project-init:wiring` 진단을 11개→14개로 확장해 “효력 발생” 중심 점검과 MCP 중복 구성 여부를 포함합니다.
  - 사용자 결정(ASK) 결과를 `.claude/state/wiring.json`에 저장해 다음 실행에서 불필요한 재질문을 줄입니다.
  - Codex의 `AGENTS.md` 문서 예산(바이트/임계치) 상태를 함께 반영합니다.
- **문서**
  - Claude/Codex/Hermes 간 규칙 로딩 및 `@import` 스코핑 동작, 단계별 FAIL/WARN/ASK 흐름을 구체화했습니다.
- **Chores**
  - `project-init` 플러그인 메타데이터/버전을 최신으로 갱신했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->