### PR TITLE
fix(codex-image): block heredoc prompt shell-injection (#112)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Personal Claude Code plugin collection with 24 specialized plugins. Codex 0.135 + Hermes Agent native — generated `.agents/plugins/marketplace.json` + per-plugin `.codex-plugin/plugin.json` (`scripts/sync-codex-manifests.mjs`) and Hermes `plugin.yaml` + `__init__.py` adapters (`scripts/sync-hermes-manifests.mjs`).",
-    "version": "1.93.0"
+    "version": "1.94.0"
   },
   "plugins": [
     {
@@ -138,7 +138,7 @@
       "name": "codex-image",
       "source": "./plugins/codex-image",
       "description": "Generate or edit images from Claude Code by delegating to Codex CLI image generation (ChatGPT OAuth, no OpenAI API key). Claude-only bridge; excluded from Codex sync.",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "category": "ai-models"
     },
     {

--- a/plugins/codex-image/.claude-plugin/plugin.json
+++ b/plugins/codex-image/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "codex-image",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Generate or edit images from Claude Code by delegating to Codex CLI image generation (ChatGPT OAuth, no OpenAI API key)"
 }

--- a/plugins/codex-image/skills/codex-image/SKILL.md
+++ b/plugins/codex-image/skills/codex-image/SKILL.md
@@ -69,10 +69,17 @@ Pass instructions to Codex through stdin with `codex exec -`. Do not interpolate
 
 Use host-appropriate stdin syntax. Append `--skip-git-repo-check` to `codex exec` only when no git root was found. Insert `-m <model>`, `-c model_reasoning_effort="<effort>"`, and a non-default `-s <mode>` only when the matching `--model` / `--reasoning` / `--sandbox` argument was supplied; with none given, the command is exactly `codex exec - -C "<project-root>" -s workspace-write` as before.
 
+### Delimiter safety (required every invocation)
+
+The prompt is delivered as the body of a quoted here-document (bash) or here-string (PowerShell) — never interpolated into a shell argument. A *fixed* delimiter is unsafe: if the prompt's own text contains a line equal to the delimiter, the block closes early and the lines after it execute as shell commands. Guard the handoff:
+
+- **Bash — randomize the delimiter.** Pick a fresh token per invocation, e.g. `CODEX_PROMPT_EOF_<8+ random hex/alnum>`, and write that exact literal token in BOTH the opening `<<'TOKEN'` and the closing `TOKEN` line (substitute a concrete suffix for `<random>` in the template below). Then scan the exact prompt text: if any line equals the token, pick a new token and re-check before emitting the command. Keep the delimiter single-quoted so the body is never expanded. Do **not** put the token in a shell variable (`<<"$DELIM"` … `$DELIM`): bash does not parameter-expand the here-document delimiter word, so it would match the literal string `$DELIM` — a fixed, predictable value — and the randomization is lost. The token must be a concrete literal in both places.
+- **PowerShell — the here-string terminator `'@` is fixed** and cannot be randomized. Reject instead: if any line of the prompt begins with `'@`, ask the user to reword that line before generating.
+
 For bash-like shells:
 
 ```bash
-codex exec - [-m <model>] [-c model_reasoning_effort="<effort>"] -C "<project-root>" -s <sandbox, default workspace-write> <<'EOF'
+codex exec - [-m <model>] [-c model_reasoning_effort="<effort>"] -C "<project-root>" -s <sandbox, default workspace-write> <<'CODEX_PROMPT_EOF_<random>'
 Use the built-in image generation capability to create the requested image.
 
 Prompt:
@@ -93,7 +100,7 @@ Requirements:
 3. Never overwrite existing files.
 4. Print the saved file path(s), file size(s), and any tool/model limitation encountered.
 5. If image generation is unavailable in this Codex CLI session, say so directly and do not create placeholders.
-EOF
+CODEX_PROMPT_EOF_<random>
 ```
 
 For PowerShell, set the native-pipe encoding to UTF-8 first, otherwise PowerShell 5.1 transcodes the pipe to ASCII and corrupts non-ASCII text (e.g. Korean becomes `??`):


### PR DESCRIPTION
codex-image's Prompt Handoff spliced the user prompt into a fixed-`EOF` heredoc body. A prompt whose own text contains a line equal to `EOF` closed the heredoc early, executing the following prompt lines as shell commands (reproduced live with a canary).

## Fix
- Per-invocation **random literal delimiter** (`CODEX_PROMPT_EOF_<random>`) written verbatim in both the opening `<<'TOKEN'` and the closing line, plus a pre-check that regenerates the token if the prompt already contains a line equal to it. Single-quoted heredoc so the body is never expanded.
- Documented the load-bearing bash gotcha inline: a **shell-variable delimiter** (`<<"$DELIM"` … `$DELIM`) is NOT parameter-expanded, so it would match the literal `$DELIM` and give zero real randomization — the token must be a concrete literal in both positions. (The task-suggested variable form was rejected for exactly this reason.)
- PowerShell guard rejecting a prompt line that begins with the here-string terminator `'@`.

## Verification
- Injection repro pre/post (harmless canary, `cat` sink): PRE `INJECTED` (canary created), POST `SAFE` (no canary; `EOF` + `touch` lines pass through as inert text) — independently re-confirmed post-rebase.
- Normal multi-line prompt flows through the randomized-delimiter heredoc unchanged.

## allowed-tools verdict: not a bug
`Bash(codex *)` (space) and `Bash(codex:*)` (colon) are documented-equivalent trailing wildcards (https://code.claude.com/docs/en/permissions.md). `Bash(codex *)` matches `codex exec …`. Frontmatter left unchanged. (Report-only caveat: `allowed-tools` in skill frontmatter is parsed but not reliably enforced per claude-code #37683/#14956 — orthogonal to this fix.)

## Versions
codex-image 1.3.0→1.3.1. metadata 1.93.0→1.94.0 (re-declared vs origin/main post-#111). codex-image is Codex-EXCLUDED (Claude-only) — regen proves no drift elsewhere; both `--check` green.

Closes #112

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 이미지 생성 기능의 프롬프트 처리 방식이 강화되어, 프롬프트 내용에 특정 구분자가 포함되어도 명령이 조기에 종료되거나 오인 실행될 가능성을 줄였습니다.
  * 셸 환경별 안전한 프롬프트 입력 처리 지침이 보완되었습니다.

* **버전 업데이트**
  * 플러그인 버전이 1.3.1로 업데이트되었습니다.
  * 마켓플레이스 버전이 1.94.0으로 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->