### PR TITLE
feat(github-dev): state-envelope v0 run-record + post-merge per-step records

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Personal Claude Code plugin collection with 24 specialized plugins. Codex 0.135 + Hermes Agent native — generated `.agents/plugins/marketplace.json` + per-plugin `.codex-plugin/plugin.json` (`scripts/sync-codex-manifests.mjs`) and Hermes `plugin.yaml` + `__init__.py` adapters (`scripts/sync-hermes-manifests.mjs`).",
-    "version": "1.97.0"
+    "version": "1.98.0"
   },
   "plugins": [
     {
@@ -19,7 +19,7 @@
       "name": "github-dev",
       "source": "./plugins/github-dev",
       "description": "GitHub workflow: commit, PR, issue, worktree, unified CodeRabbit + ChatGPT-Codex cr-fix pipeline v2 (Step 5 pre-flight review detection across CR commit-status + comments + Codex reviews + Codex emoji 3-channel; autonomous Step 9 judgment replaces per-finding AskUserQuestion — LLM judges real/spurious + severity + fix-size and applies/defers/skips with logged reasoning; rate-limit sniffer now covers commit-status description + in-place comment edits; polling interval 60s → 8s; --auto-merge + --skip-minor + --cr-source retained), project tracking, release. All workflows are now skills (commit-and-push, create-issue-label, decompose-issue, update-progress, resolve-issue, release, cr-fix, post-merge) — no commands surface, so they run under Codex too. post-merge runs a mandatory built-in wiki-lore ingest step (absorbed llm-wiki:post-merge-wiki) plus an optional Step 4.5 ephemeral-artifact pruning gate (heuristic candidates → AskUserQuestion → git rm). 2.8.0 correctness repairs: CR-state fetch failures map to a real error channel (no longer masked as a clean 'none'), a null-repository GraphQL response fails loudly instead of a silent false-clean convergence, and an active `@coderabbitai rate limit` query resolves ambiguous passive rate-limit sniffs.",
-      "version": "2.8.0",
+      "version": "2.9.0",
       "category": "github"
     },
     {

--- a/.claude/rules/state-envelope.md
+++ b/.claude/rules/state-envelope.md
@@ -71,7 +71,10 @@ Init (once the run's key + anchor sha are known):
 ```bash
 REC=".claude/state/<pipeline>-<key>.json"
 mkdir -p .claude/state/archive
-[ -f "$REC" ] && mv "$REC" ".claude/state/archive/<pipeline>-<key>-$(date +%Y%m%d-%H%M%S)-$$.json"
+if [ -f "$REC" ]; then
+  mv "$REC" ".claude/state/archive/<pipeline>-<key>-$(date +%Y%m%d-%H%M%S)-$$.json" \
+    || { echo "state-envelope: archive rotation failed for $REC — aborting so the next write cannot clobber the only live copy" >&2; exit 1; }
+fi
 NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 jq -n --arg rid "<pipeline>-<key>" --arg sha "$ANCHOR_SHA" --arg now "$NOW" \
   '{schema:"state-envelope/v0", run_id:$rid, status:"in_progress", conclusion:null,

--- a/.claude/rules/state-envelope.md
+++ b/.claude/rules/state-envelope.md
@@ -86,6 +86,9 @@ Record one step as it closes (`reason` only on a skip):
 
 ```bash
 record_step() {  # <n> <done|skipped> [reason]
+  if [ "$2" = "skipped" ] && [ -z "${3:-}" ]; then
+    echo "state-envelope: a skipped step needs a reason" >&2; return 1
+  fi
   local tmp; tmp=$(mktemp)
   jq --argjson step "$1" --arg status "$2" --arg reason "${3:-}" \
      --arg now "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \

--- a/.claude/rules/state-envelope.md
+++ b/.claude/rules/state-envelope.md
@@ -1,0 +1,109 @@
+---
+paths: .claude/state/*.json
+---
+
+# State-Envelope Run Records (v0)
+
+Convention for the per-run state files a long multi-step skill writes to make its own
+progress machine-inspectable. v0 is a **documented convention plus per-skill `jq`** —
+there is deliberately **no shared library or script**. Each adopting skill inlines its
+own `jq` snippets; this file is only the schema they agree on.
+
+## Role
+
+Give multi-step pipeline skills a uniform run-record shape so a step that skipped
+**silently** is visible after the fact, and so a re-run can find and archive the prior
+attempt. Introduced narrow: the first and only v0 adopter is `github-dev:post-merge`
+(per-step records). Retrofitting other skills' state files onto this envelope is
+deliberately deferred to a later change.
+
+## Location & rotation
+
+- Live file: `.claude/state/<pipeline>-<key>.json` — e.g. `.claude/state/post-merge-114.json`,
+  mirroring the existing `.claude/state/cr-fix-<PR>.json` naming.
+- On a re-run for the same key, archive the prior live file to
+  `.claude/state/archive/<pipeline>-<key>-<timestamp>-$$.json` before writing a fresh
+  one (mirrors `cr-fix` Step 2 — the timestamp + `$$` suffix keeps a same-second or
+  parallel run from clobbering an archived copy).
+- `.claude/state/` is **gitignored and machine-local**. A run record is never staged,
+  committed, or added to a skill's `RUN_TOUCHED` staging set.
+
+## Schema
+
+```json
+{
+  "schema": "state-envelope/v0",
+  "run_id": "<pipeline>-<key>",
+  "status": "queued | in_progress | completed",
+  "conclusion": "<free string once terminal, else null>",
+  "started_at": "<UTC ISO-8601>",
+  "updated_at": "<UTC ISO-8601>",
+  "anchor_sha": "<the commit this run is anchored to, or null>",
+  "attempt": 1,
+  "session_id": "<host session id, or null>",
+  "steps": [
+    { "step": 1, "status": "done" },
+    { "step": 5, "status": "skipped", "reason": "no GitHub Project" }
+  ]
+}
+```
+
+- `status` moves `queued` / `in_progress` → `completed`; `conclusion` stays `null` until terminal.
+- `steps[]` carries one entry per top-level step as it closes: `{step, status: done|skipped, reason?}`.
+  `reason` is required on `skipped`, omitted on `done`. Sub-steps fold into their parent
+  top-level step's entry.
+
+## Orthogonality to spec-state
+
+A state-envelope run record is **not** `.claude/state/spec.json`. `spec.json` (owned by
+`spec-state:state-tracker`) is the cross-run aggregate of spec → issue → PR pipeline work.
+A run record is a **single skill run's own step log**. They are separate files with
+separate owners: a state-envelope record never reads or writes `spec.json`, and the
+spec aggregate never carries per-run step logs.
+
+## Per-skill jq (no shared library)
+
+An adopting skill inlines these three moves directly in its body — there is no sourced
+helper file. Reference adopter: `github-dev:post-merge`.
+
+Init (once the run's key + anchor sha are known):
+
+```bash
+REC=".claude/state/<pipeline>-<key>.json"
+mkdir -p .claude/state/archive
+[ -f "$REC" ] && mv "$REC" ".claude/state/archive/<pipeline>-<key>-$(date +%Y%m%d-%H%M%S)-$$.json"
+NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+jq -n --arg rid "<pipeline>-<key>" --arg sha "$ANCHOR_SHA" --arg now "$NOW" \
+  '{schema:"state-envelope/v0", run_id:$rid, status:"in_progress", conclusion:null,
+    started_at:$now, updated_at:$now, anchor_sha:($sha // null), attempt:1,
+    session_id:(env.CLAUDE_SESSION_ID // null), steps:[]}' > "$REC"
+```
+
+Record one step as it closes (`reason` only on a skip):
+
+```bash
+record_step() {  # <n> <done|skipped> [reason]
+  local tmp; tmp=$(mktemp)
+  jq --argjson step "$1" --arg status "$2" --arg reason "${3:-}" \
+     --arg now "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+     '.updated_at = $now
+      | .steps += [ {step: $step, status: $status}
+                    + (if $reason == "" then {} else {reason: $reason} end) ]' \
+     "$REC" > "$tmp" && mv "$tmp" "$REC"
+}
+```
+
+Finalize when the last step closes:
+
+```bash
+tmp=$(mktemp)
+jq --arg now "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  '.status = "completed" | .conclusion = "success" | .updated_at = $now' \
+  "$REC" > "$tmp" && mv "$tmp" "$REC"
+```
+
+## Don'ts
+
+- Never promote this into a shared library/script at v0 — a narrow per-skill convention is the point.
+- Never commit a run record — `.claude/state/` is gitignored; keep it out of any commit staging set.
+- Never overload `spec.json` with per-run step logs — that file is a different concern (see above).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -185,7 +185,19 @@
 `.claude/rules/*.md` is auto-loaded by Claude Code — no `@import` required, and Codex/Hermes cannot read the directory at all (their mirror is the "멀티런타임 통합" section above). A rule carrying `paths:` frontmatter loads only when Claude touches a matching file; `@import`ing that same rule expands it unconditionally at launch and kills the scoping, so the first pointer below is deliberately plain (backticks, not `@`).
 
 - `.claude/rules/plugin-versioning.md` — plugin version bump contract and cache-refresh workflow. Scoped via `paths:` to the manifest files, so it loads only when you touch them.
+- `.claude/rules/state-envelope.md` — the state-envelope v0 run-record convention (`.claude/state/<pipeline>-<key>.json` + archive rotation + per-skill jq, no shared library). Scoped via `paths:` to `.claude/state/*.json`. Its concept mirror for Codex/Hermes is the "State-envelope 실행 기록" section below.
 - See @.claude/rules/dual-integration.md for keeping the Claude Code, Codex, and Hermes surfaces in sync when editing guidance, hooks, or derived artifacts (unscoped, always loaded; its cross-runtime content is mirrored in the "멀티런타임 통합" section above, which is what Codex and Hermes actually read).
+
+## State-envelope 실행 기록 (run records, v0)
+
+> `.claude/rules/state-envelope.md` 의 Codex/Hermes 미러다 (그 두 런타임은 `.claude/rules/` 를 못 읽는다). Claude 는 위 `## Modular Rules` 포인터로 원본 규칙에 닿는다. 상세·jq 스니펫은 규칙 파일에 있다.
+
+여러 단계로 이어지는 파이프라인 스킬이 자기 진행 상태를 기계가 읽을 수 있게 남기는 per-run 상태 파일 규약이다. v0 는 **문서화된 규약 + per-skill `jq`** 일 뿐, **공유 라이브러리/스크립트를 두지 않는다**. 각 채택 스킬이 자기 본문에 jq 를 인라인한다.
+
+- **위치·회전**: live 파일은 `.claude/state/<pipeline>-<key>.json` (예: `post-merge-114.json`, 기존 `cr-fix-<PR>.json` 명명 미러). 같은 key 로 재실행하면 새로 쓰기 전에 이전 live 파일을 `.claude/state/archive/<pipeline>-<key>-<timestamp>-$$.json` 로 회전한다 (cr-fix Step 2 미러). `.claude/state/` 는 gitignore + 머신 로컬 — run record 는 절대 커밋하지 않고 스킬의 `RUN_TOUCHED` 스테이징 집합에도 넣지 않는다.
+- **스키마**: `{schema:"state-envelope/v0", run_id, status(queued|in_progress|completed), conclusion, started_at, updated_at, anchor_sha, attempt, session_id, steps[]}`. `steps[]` 는 top-level 단계가 닫힐 때마다 `{step, status: done|skipped, reason?}` 한 항목 (`reason` 은 skipped 에만).
+- **spec-state 와 직교(orthogonal)**: run record 는 `.claude/state/spec.json` 이 **아니다**. `spec.json` (owner: `spec-state:state-tracker`) 은 spec→issue→PR 파이프라인의 크로스런 집계이고, run record 는 스킬 단일 실행의 단계 로그다. 서로 다른 파일·다른 소유자이며 서로 읽거나 쓰지 않는다.
+- **v0 채택자**: `github-dev:post-merge` (Step 1-10 per-step 기록) 하나뿐이다. 다른 스킬 상태 파일의 retrofit 은 후속 변경으로 의도적으로 미룬다.
 
 ## Setup answers
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -217,9 +217,11 @@ jq -n --arg rid "<pipeline>-<key>" --arg sha "$ANCHOR_SHA" --arg now "$(date -u 
 각 단계가 닫힐 때 한 항목 append, 마지막에 finalize — shell 상태는 tool 호출 간 유지되지 않으므로 함수가 아니라 인라인 jq 로 (`reason` 은 skip 에만):
 
 ```bash
-# record one step (done):
-tmp=$(mktemp); jq --argjson step "$N" --arg now "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-  '.updated_at=$now | .steps += [{step:$step, status:"done"}]' "$REC" > "$tmp" && mv "$tmp" "$REC"
+# record one step — done, or skipped with a reason (reason only on skip):
+tmp=$(mktemp); jq --argjson step "$N" --arg status "done" --arg reason "" --arg now "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  '.updated_at=$now | .steps += [ {step:$step, status:$status} + (if $reason=="" then {} else {reason:$reason} end) ]' \
+  "$REC" > "$tmp" && mv "$tmp" "$REC"
+# skip a step: same call with  --arg status "skipped" --arg reason "why the precondition was absent"
 # finalize (terminal):
 tmp=$(mktemp); jq --arg now "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
   '.status="completed" | .conclusion="success" | .updated_at=$now' "$REC" > "$tmp" && mv "$tmp" "$REC"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -190,7 +190,7 @@
 
 ## State-envelope 실행 기록 (run records, v0)
 
-> `.claude/rules/state-envelope.md` 의 Codex/Hermes 미러다 (그 두 런타임은 `.claude/rules/` 를 못 읽는다). Claude 는 위 `## Modular Rules` 포인터로 원본 규칙에 닿는다. 상세·jq 스니펫은 규칙 파일에 있다.
+> `.claude/rules/state-envelope.md` 의 Codex/Hermes 미러다 (그 두 런타임은 `.claude/rules/` 를 못 읽는다). Claude 는 위 `## Modular Rules` 포인터로 원본 규칙에 닿고, Codex/Hermes 에게는 이 미러가 유일 소스이므로 실행 jq 를 아래에 그대로 싣는다 (규칙 파일로 미루지 않는다).
 
 여러 단계로 이어지는 파이프라인 스킬이 자기 진행 상태를 기계가 읽을 수 있게 남기는 per-run 상태 파일 규약이다. v0 는 **문서화된 규약 + per-skill `jq`** 일 뿐, **공유 라이브러리/스크립트를 두지 않는다**. 각 채택 스킬이 자기 본문에 jq 를 인라인한다.
 
@@ -198,6 +198,31 @@
 - **스키마**: `{schema:"state-envelope/v0", run_id, status(queued|in_progress|completed), conclusion, started_at, updated_at, anchor_sha, attempt, session_id, steps[]}`. `steps[]` 는 top-level 단계가 닫힐 때마다 `{step, status: done|skipped, reason?}` 한 항목 (`reason` 은 skipped 에만).
 - **spec-state 와 직교(orthogonal)**: run record 는 `.claude/state/spec.json` 이 **아니다**. `spec.json` (owner: `spec-state:state-tracker`) 은 spec→issue→PR 파이프라인의 크로스런 집계이고, run record 는 스킬 단일 실행의 단계 로그다. 서로 다른 파일·다른 소유자이며 서로 읽거나 쓰지 않는다.
 - **v0 채택자**: `github-dev:post-merge` (Step 1-10 per-step 기록) 하나뿐이다. 다른 스킬 상태 파일의 retrofit 은 후속 변경으로 의도적으로 미룬다.
+
+**실행 jq (Codex/Hermes 자립용 — Claude 도 동일 패턴).** 채택 스킬이 본문에 인라인한다 (공유 라이브러리 없음). Init 은 archive 회전 실패 시 이전 기록을 덮어쓰지 않도록 abort 한다:
+
+```bash
+REC=".claude/state/<pipeline>-<key>.json"; mkdir -p .claude/state/archive
+if [ -f "$REC" ]; then
+  mv "$REC" ".claude/state/archive/<pipeline>-<key>-$(date +%Y%m%d-%H%M%S)-$$.json" \
+    || { echo "state-envelope: archive rotation failed" >&2; exit 1; }
+fi
+jq -n --arg rid "<pipeline>-<key>" --arg sha "$ANCHOR_SHA" --arg now "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  '{schema:"state-envelope/v0", run_id:$rid, status:"in_progress", conclusion:null,
+    started_at:$now, updated_at:$now, anchor_sha:($sha // null), attempt:1,
+    session_id:(env.CLAUDE_SESSION_ID // null), steps:[]}' > "$REC"
+```
+
+각 단계가 닫힐 때 한 항목 append, 마지막에 finalize — shell 상태는 tool 호출 간 유지되지 않으므로 함수가 아니라 인라인 jq 로 (`reason` 은 skip 에만):
+
+```bash
+# record one step (done):
+tmp=$(mktemp); jq --argjson step "$N" --arg now "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  '.updated_at=$now | .steps += [{step:$step, status:"done"}]' "$REC" > "$tmp" && mv "$tmp" "$REC"
+# finalize (terminal):
+tmp=$(mktemp); jq --arg now "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  '.status="completed" | .conclusion="success" | .updated_at=$now' "$REC" > "$tmp" && mv "$tmp" "$REC"
+```
 
 ## Setup answers
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -217,11 +217,13 @@ jq -n --arg rid "<pipeline>-<key>" --arg sha "$ANCHOR_SHA" --arg now "$(date -u 
 각 단계가 닫힐 때 한 항목 append, 마지막에 finalize — shell 상태는 tool 호출 간 유지되지 않으므로 함수가 아니라 인라인 jq 로 (`reason` 은 skip 에만):
 
 ```bash
-# record one step — done, or skipped with a reason (reason only on skip):
-tmp=$(mktemp); jq --argjson step "$N" --arg status "done" --arg reason "" --arg now "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-  '.updated_at=$now | .steps += [ {step:$step, status:$status} + (if $reason=="" then {} else {reason:$reason} end) ]' \
-  "$REC" > "$tmp" && mv "$tmp" "$REC"
-# skip a step: same call with  --arg status "skipped" --arg reason "why the precondition was absent"
+# record a completed step:
+tmp=$(mktemp); jq --argjson step "$N" --arg now "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  '.updated_at=$now | .steps += [{step:$step, status:"done"}]' "$REC" > "$tmp" && mv "$tmp" "$REC"
+# record a skipped step — reason is REQUIRED; guard it so a skip is never written without one:
+[ -n "$reason" ] || { echo "state-envelope: a skipped step needs a reason" >&2; exit 1; }
+tmp=$(mktemp); jq --argjson step "$N" --arg reason "$reason" --arg now "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  '.updated_at=$now | .steps += [{step:$step, status:"skipped", reason:$reason}]' "$REC" > "$tmp" && mv "$tmp" "$REC"
 # finalize (terminal):
 tmp=$(mktemp); jq --arg now "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
   '.status="completed" | .conclusion="success" | .updated_at=$now' "$REC" > "$tmp" && mv "$tmp" "$REC"

--- a/plugins/github-dev/.claude-plugin/plugin.json
+++ b/plugins/github-dev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "github-dev",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "description": "GitHub workflow automation skills for Claude Code",
   "skills": [
     "./skills/cr-fix",

--- a/plugins/github-dev/.codex-plugin/plugin.json
+++ b/plugins/github-dev/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "github-dev",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "description": "GitHub workflow: commit, PR, issue, worktree, unified CodeRabbit + ChatGPT-Codex cr-fix pipeline v2 (Step 5 pre-flight review detection across CR commit-status + comments + Codex reviews + Codex emoji 3-channel; autonomous Step 9 judgment replaces per-finding AskUserQuestion — LLM judges real/spurious + severity + fix-size and applies/defers/skips with logged reasoning; rate-limit sniffer now covers commit-status description + in-place comment edits; polling interval 60s → 8s; --auto-merge + --skip-minor + --cr-source retained), project tracking, release. All workflows are now skills (commit-and-push, create-issue-label, decompose-issue, update-progress, resolve-issue, release, cr-fix, post-merge) — no commands surface, so they run under Codex too. post-merge runs a mandatory built-in wiki-lore ingest step (absorbed llm-wiki:post-merge-wiki) plus an optional Step 4.5 ephemeral-artifact pruning gate (heuristic candidates → AskUserQuestion → git rm). 2.8.0 correctness repairs: CR-state fetch failures map to a real error channel (no longer masked as a clean 'none'), a null-repository GraphQL response fails loudly instead of a silent false-clean convergence, and an active `@coderabbitai rate limit` query resolves ambiguous passive rate-limit sniffs.",
   "author": {
     "name": "YoungjaeDev"

--- a/plugins/github-dev/plugin.yaml
+++ b/plugins/github-dev/plugin.yaml
@@ -1,5 +1,5 @@
 name: github-dev
-version: "2.8.0"
+version: "2.9.0"
 description: "GitHub workflow: commit, PR, issue, worktree, unified CodeRabbit + ChatGPT-Codex cr-fix pipeline v2 (Step 5 pre-flight review detection across CR commit-status + comments + Codex reviews + Codex emoji 3-channel; autonomous Step 9 judgment replaces per-finding AskUserQuestion — LLM judges real/spurious + severity + fix-size and applies/defers/skips with logged reasoning; rate-limit sniffer now covers commit-status description + in-place comment edits; polling interval 60s → 8s; --auto-merge + --skip-minor + --cr-source retained), project tracking, release. All workflows are now skills (commit-and-push, create-issue-label, decompose-issue, update-progress, resolve-issue, release, cr-fix, post-merge) — no commands surface, so they run under Codex too. post-merge runs a mandatory built-in wiki-lore ingest step (absorbed llm-wiki:post-merge-wiki) plus an optional Step 4.5 ephemeral-artifact pruning gate (heuristic candidates → AskUserQuestion → git rm). 2.8.0 correctness repairs: CR-state fetch failures map to a real error channel (no longer masked as a clean 'none'), a null-repository GraphQL response fails loudly instead of a silent false-clean convergence, and an active `@coderabbitai rate limit` query resolves ambiguous passive rate-limit sniffs."
 author: "YoungjaeDev"
 kind: standalone

--- a/plugins/github-dev/skills/post-merge/SKILL.md
+++ b/plugins/github-dev/skills/post-merge/SKILL.md
@@ -82,6 +82,9 @@ jq -n --arg rid "post-merge-${PR_NUMBER}" --arg sha "$MERGE_SHA" --arg now "$NOW
 
 # record_step <n> <done|skipped> [reason] — append one entry, bump updated_at.
 record_step() {
+  if [ "$2" = "skipped" ] && [ -z "${3:-}" ]; then
+    echo "post-merge: a skipped step needs a reason" >&2; return 1
+  fi
   local tmp; tmp=$(mktemp)
   jq --argjson step "$1" --arg status "$2" --arg reason "${3:-}" \
      --arg now "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \

--- a/plugins/github-dev/skills/post-merge/SKILL.md
+++ b/plugins/github-dev/skills/post-merge/SKILL.md
@@ -303,12 +303,13 @@ done
 
 Skip the commit only when `git diff --cached --quiet` reports nothing staged after the `git add` — a staged-only check; `git status --porcelain` would also count pre-existing untracked files and wrongly attempt an empty-index commit.
 
-**Finalize the run record.** Record this closing step and mark the envelope terminal (see the Step 1 recording contract; re-`export REC` + re-declare `record_step` first since shell state does not persist). The record stays under gitignored `.claude/state/` — do **not** add it to `RUN_TOUCHED`:
+**Finalize the run record.** Record this closing step and mark the envelope terminal. Step 10 is a fresh shell, so re-set `PR_NUMBER` (the merged PR number) + `REC` first — `record_step` is not used here, the append + finalize are inlined. The record stays under gitignored `.claude/state/` — do **not** add it to `RUN_TOUCHED`:
 
 ```bash
-REC=".claude/state/post-merge-${PR_NUMBER}.json"
-# Step 10 runs in a fresh shell — record_step from Step 1 is out of scope here, so
-# append the closing step and finalize inline (no function dependency).
+# Step 10 runs in a fresh shell — neither PR_NUMBER nor record_step from Step 1 persist.
+# Re-set PR_NUMBER (the merged PR number) so REC points at the real record, not
+# .claude/state/post-merge-.json; the :? guard fails loud if it is empty. Append + finalize inline.
+REC=".claude/state/post-merge-${PR_NUMBER:?Step 10: re-set PR_NUMBER to the merged PR number before finalizing}.json"
 tmp=$(mktemp)
 jq --arg now "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
   '.steps += [{step: 10, status: "done"}]

--- a/plugins/github-dev/skills/post-merge/SKILL.md
+++ b/plugins/github-dev/skills/post-merge/SKILL.md
@@ -63,6 +63,34 @@ esac
 - Verify `state` is `MERGED`. This result is the **authoritative merge signal** (see Guidelines) — no later SHA comparison.
 - Capture `MERGE_SHA=$(gh pr view <PR_NUMBER> --json mergeCommit --jq '.mergeCommit.oid')` — this is **this PR's** merge commit, used to label the wiki log entry and read diff content. Step 8 derives the merged **file list** from `gh pr diff <N> --name-only` (PR-scoped, merge-method-agnostic, uncapped), not from `MERGE_SHA` (a `--no-ff` merge commit shows an empty combined diff; a multi-commit rebase merge's SHA only points at the last replayed commit).
 
+**Open the run record (state-envelope v0).** With `PR_NUMBER` + `MERGE_SHA` fixed, open a per-run record so every later step's outcome is machine-visible — a step that skipped **silently** was previously invisible. Convention + schema: `.claude/rules/state-envelope.md` (concept mirror in `AGENTS.md`). No shared library — this per-skill `jq` is the whole mechanism, and the file lives under gitignored `.claude/state/`, so it is machine-local and is **never** staged (never added to Step 10's `RUN_TOUCHED`).
+
+```bash
+REC=".claude/state/post-merge-${PR_NUMBER}.json"
+mkdir -p .claude/state/archive
+# Archive a prior same-PR record before overwriting (mirrors cr-fix Step 2).
+[ -f "$REC" ] && mv "$REC" ".claude/state/archive/post-merge-${PR_NUMBER}-$(date +%Y%m%d-%H%M%S)-$$.json"
+NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+jq -n --arg rid "post-merge-${PR_NUMBER}" --arg sha "$MERGE_SHA" --arg now "$NOW" \
+  '{schema:"state-envelope/v0", run_id:$rid, status:"in_progress", conclusion:null,
+    started_at:$now, updated_at:$now, anchor_sha:($sha // null), attempt:1,
+    session_id:(env.CLAUDE_SESSION_ID // null), steps:[]}' > "$REC"
+
+# record_step <n> <done|skipped> [reason] — append one entry, bump updated_at.
+record_step() {
+  local tmp; tmp=$(mktemp)
+  jq --argjson step "$1" --arg status "$2" --arg reason "${3:-}" \
+     --arg now "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+     '.updated_at = $now
+      | .steps += [ {step: $step, status: $status}
+                    + (if $reason == "" then {} else {reason: $reason} end) ]' \
+     "$REC" > "$tmp" && mv "$tmp" "$REC"
+}
+record_step 1 done
+```
+
+**Recording contract.** After each top-level Step 2-10 closes, append its outcome — `record_step <n> done`, or `record_step <n> skipped "<reason>"` when that step's skip-condition fires (Steps 5, 5.5, 5.7, 9, 9.5 skip silently today, and under Codex Step 7 records `skipped "Codex — Serena unavailable"`; the record is what makes each skip visible). Sub-steps (1.5, 4.5, 4.6, 6.5) fold into their parent top-level entry. **Shell state does not persist across separate tool calls** — `REC` is the deterministic path `.claude/state/post-merge-<PR>.json`, so in the bash block that closes a later step, re-`export REC=...` and re-declare `record_step` (or run the equivalent inline `jq`) before calling it. Step 10 finalizes the envelope to `status: completed`.
+
 ### 1.5. Surface unresolved review items (informational)
 
 A merge can land while `cr-fix` still left findings unresolved — items it autonomously **deferred** (real + high-severity + too invasive for autopilot), or a loop that exited on a cap/timeout rather than converging clean. That signal sits in `cr-fix`'s state file and nobody reads it. This step surfaces it **once, right after the merge is confirmed**. It is **informational — it never blocks cleanup**; like the Step 8 wiki checkpoint it ALWAYS prints exactly one terminal status line so a skip can't pass unnoticed.
@@ -260,7 +288,7 @@ If **any** tracked files were modified by this run — config (`CLAUDE.md`/`AGEN
 Stage **only the exact files this run created or modified** — collect them as you go through Steps 4.6-9.5 (each config file you edited, the `.claude/state/spec.json` + spec file from Step 5.7, README, `CHANGELOG.md` from Step 9.5, any Step 4.6 in-file deprecated-block `Edit`, Serena memory files, and the specific wiki pages `ingest-finding` created/updated). Build that explicit list as `RUN_TOUCHED` and add only those paths — **never `git add` a whole directory** (`.llmwiki/`, `.claude/spec/`, …): a pre-existing untracked draft (e.g. a user's `.llmwiki/wiki/draft.md`) would otherwise be swept into this commit, and Step 2 already decided to leave untracked files alone.
 
 ```bash
-# RUN_TOUCHED = the exact paths this run wrote, gathered across Steps 5.7-9.
+# RUN_TOUCHED = the exact paths this run wrote, gathered across Steps 4.6-9.5.
 # Existence-checked + added one at a time: `git add a b c` is atomic, so one
 # stale path would abort the whole add (and `|| true` would hide it), leaving
 # real changes unstaged.
@@ -271,11 +299,23 @@ done
 
 Skip the commit only when `git diff --cached --quiet` reports nothing staged after the `git add` — a staged-only check; `git status --porcelain` would also count pre-existing untracked files and wrongly attempt an empty-index commit.
 
+**Finalize the run record.** Record this closing step and mark the envelope terminal (see the Step 1 recording contract; re-`export REC` + re-declare `record_step` first since shell state does not persist). The record stays under gitignored `.claude/state/` — do **not** add it to `RUN_TOUCHED`:
+
+```bash
+REC=".claude/state/post-merge-${PR_NUMBER}.json"
+record_step 10 done
+tmp=$(mktemp)
+jq --arg now "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  '.status = "completed" | .conclusion = "success" | .updated_at = $now' \
+  "$REC" > "$tmp" && mv "$tmp" "$REC"
+```
+
 ## References
 
 - **No-stamp Core Principle + knowledge-routing boundary**: `references/core-principle.md`
 - **Config + Serena learning integration** (Pre-Audit, classification, history rotation, size audit, memory mapping): `references/learning-integration.md`
 - **Unresolved review surface** (Step 1.5 — cr-fix state-file defer list + `final_state`, open-thread proxy): reads `.claude/state/cr-fix-<PR>.json` / `.claude/state/archive/`; field schema in `plugins/github-dev/skills/cr-fix/assets/final-output.schema.json`.
+- **Run-record envelope** (Step 1 + Step 10 — per-step `.claude/state/post-merge-<PR>.json`, schema + archive rotation + per-skill jq): `.claude/rules/state-envelope.md` (concept mirror in `AGENTS.md`).
 - **Mandatory wiki ingest** (absorbed post-merge-wiki — candidate derivation, autonomy triage, ingest-finding delegation, routing dedup): `references/wiki-ingest.md`
 - **Ephemeral artifact pruning** (Step 4.5 — heuristics, exclusions, git rm/commit interaction): `references/ephemeral-heuristics.md`
 - Milestone / Type M-2 diagram mechanics: `skills/update-progress/SKILL.md`

--- a/plugins/github-dev/skills/post-merge/SKILL.md
+++ b/plugins/github-dev/skills/post-merge/SKILL.md
@@ -69,7 +69,11 @@ esac
 REC=".claude/state/post-merge-${PR_NUMBER}.json"
 mkdir -p .claude/state/archive
 # Archive a prior same-PR record before overwriting (mirrors cr-fix Step 2).
-[ -f "$REC" ] && mv "$REC" ".claude/state/archive/post-merge-${PR_NUMBER}-$(date +%Y%m%d-%H%M%S)-$$.json"
+# Fail closed: a failed archive must abort init, else the jq below clobbers the only live copy.
+if [ -f "$REC" ]; then
+  mv "$REC" ".claude/state/archive/post-merge-${PR_NUMBER}-$(date +%Y%m%d-%H%M%S)-$$.json" \
+    || { echo "post-merge: archiving the prior run record failed — aborting to avoid clobbering it" >&2; exit 1; }
+fi
 NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 jq -n --arg rid "post-merge-${PR_NUMBER}" --arg sha "$MERGE_SHA" --arg now "$NOW" \
   '{schema:"state-envelope/v0", run_id:$rid, status:"in_progress", conclusion:null,
@@ -303,10 +307,12 @@ Skip the commit only when `git diff --cached --quiet` reports nothing staged aft
 
 ```bash
 REC=".claude/state/post-merge-${PR_NUMBER}.json"
-record_step 10 done
+# Step 10 runs in a fresh shell — record_step from Step 1 is out of scope here, so
+# append the closing step and finalize inline (no function dependency).
 tmp=$(mktemp)
 jq --arg now "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-  '.status = "completed" | .conclusion = "success" | .updated_at = $now' \
+  '.steps += [{step: 10, status: "done"}]
+   | .status = "completed" | .conclusion = "success" | .updated_at = $now' \
   "$REC" > "$tmp" && mv "$tmp" "$REC"
 ```
 


### PR DESCRIPTION
## 요약

state-envelope v0 실행 기록(run-record) 규약을 **좁게** 도입한다 — 문서화된 규칙 + per-skill `jq` 뿐이고, **공유 라이브러리/스크립트는 만들지 않는다**. 유일한 그린필드 채택자는 `github-dev:post-merge` 의 per-step 기록이다. 다른 스킬 상태 파일의 retrofit 은 후속 변경으로 의도적으로 미룬다.

Closes #114

## 변경 내용

1. **`.claude/rules/state-envelope.md` (신규 규칙)**
   - 위치: `.claude/state/<pipeline>-<key>.json`, 재실행 시 `.claude/state/archive/<pipeline>-<key>-<timestamp>-$$.json` 로 회전 (기존 cr-fix Step 2 아카이브 패턴 미러).
   - `.claude/state/` 는 gitignore + 머신 로컬 — run record 는 절대 커밋하지 않고 `RUN_TOUCHED` 에도 넣지 않는다.
   - 스키마: `{schema, run_id, status(queued|in_progress|completed), conclusion, started_at, updated_at, anchor_sha, attempt, session_id, steps[]}`. `steps[]` = `{step, status: done|skipped, reason?}`.
   - `paths: .claude/state/*.json` 로 스코프 (plugin-versioning.md 선례: 규칙이 다스리는 아티팩트에 스코프).
   - init / `record_step` / finalize 세 개의 per-skill jq 스니펫 포함.

2. **AGENTS.md 미러**: Codex/Hermes 는 `.claude/rules/` 를 못 읽으므로 "State-envelope 실행 기록" 개념 미러 블록 + `## Modular Rules` 한 줄 포인터 추가 (PR-4 역전 모델 답습). `## Plugins (N)` 카운트/트리 섹션은 건드리지 않았다.

3. **post-merge SKILL.md (채택자)**: Step 1 에서 `.claude/state/post-merge-<PR>.json` 를 열고, Step 1-10 이 닫힐 때마다 `record_step <n> done|skipped [reason]` 로 항목을 하나씩 남긴다 — **silent 하게 건너뛴 단계가 이제 기록으로 드러난다** (silent-step-skip 하네스 갭 수정). Step 10 에서 envelope 를 `status: completed` 로 마감. 아울러 Step 10 의 `RUN_TOUCHED` step-range 주석 오차를 고쳤다 (`5.7-9` → `4.6-9.5`, 산문과 일치, opus #12 P3).

4. **버전·매니페스트**: github-dev `2.8.0 → 2.9.0` (plugin.json + marketplace entry), `metadata.version 1.97.0 → 1.98.0`, Codex + Hermes 매니페스트 재생성.

## 직교성 (spec-state)

state-envelope run record 는 `.claude/state/spec.json` 이 **아니다**. `spec.json` (owner: `spec-state:state-tracker`) 은 spec→issue→PR 파이프라인의 크로스런 집계이고, run record 는 스킬 단일 실행의 단계 로그다 — 서로 다른 파일, 다른 소유자, 상호 읽기/쓰기 없음. 규칙 본문에 명시했다.

## Counsel / triage 노트

- 범위: counsel(codex #8) 판단대로 규약 + 단일 채택자로 좁혀 착지. shared library 미도입.
- `record_step` 은 셸 함수지만 post-merge 는 AskUserQuestion 게이트로 멀티턴이라 셸 상태가 tool call 간 유지되지 않는다 — 이를 스킬 본문에 명시하고, `REC` 를 결정론적 경로(`.claude/state/post-merge-<PR>.json`)로 두어 각 단계 블록에서 재선언/인라인 실행하도록 했다.
- 의도적 보류: github-dev marketplace 설명 산문에 2.9.0 per-step 기능 문구를 덧붙이지 않았다 (surgical diff; 버전 넘버만 범프). 필요하면 후속으로 반영 가능.

## 검증

- `node scripts/sync-codex-manifests.mjs --check` → `up to date (23 manifests)`.
- `node scripts/sync-hermes-manifests.mjs --check` → `up to date (14 adapter files, 7 plugins)`.
- DRY: init + `record_step` (done 6 + skipped 4) + finalize 를 손으로 실행 → 유효 JSON, steps 10개, `done` 은 reason 없음 / `skipped` 은 reason 필수 불변식 통과, 모든 스키마 필드 존재.
- `git check-ignore` 로 `.claude/state/post-merge-114.json` gitignore 확인.
- `.githooks/pre-commit` 통과 (양쪽 `--check` + cr-fix 픽스처 70 passed / 0 failed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added **state-envelope v0** run-recording for the post-merge workflow, tracking per-step status, completion/conclusion, and required skip reasons, with automatic archival of prior records on reruns.

* **Documentation**
  * Published a new guide for the state-envelope v0 schema and lifecycle.
  * Updated modular rules and post-merge skill instructions to adopt the new run-record envelope.
  * Refined Step 10 guidance and references to the new convention.

* **Chores**
  * Bumped marketplace and GitHub Dev plugin versions to **2.9.0**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->