### PR TITLE
fix: doc-integrity sweep + SoT/doc-consistency guards (#116)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Personal Claude Code plugin collection with 24 specialized plugins. Codex 0.135 + Hermes Agent native — generated `.agents/plugins/marketplace.json` + per-plugin `.codex-plugin/plugin.json` (`scripts/sync-codex-manifests.mjs`) and Hermes `plugin.yaml` + `__init__.py` adapters (`scripts/sync-hermes-manifests.mjs`).",
-    "version": "1.97.0"
+    "version": "1.98.0"
   },
   "plugins": [
     {
@@ -19,70 +19,70 @@
       "name": "github-dev",
       "source": "./plugins/github-dev",
       "description": "GitHub workflow: commit, PR, issue, worktree, unified CodeRabbit + ChatGPT-Codex cr-fix pipeline v2 (Step 5 pre-flight review detection across CR commit-status + comments + Codex reviews + Codex emoji 3-channel; autonomous Step 9 judgment replaces per-finding AskUserQuestion — LLM judges real/spurious + severity + fix-size and applies/defers/skips with logged reasoning; rate-limit sniffer now covers commit-status description + in-place comment edits; polling interval 60s → 8s; --auto-merge + --skip-minor + --cr-source retained), project tracking, release. All workflows are now skills (commit-and-push, create-issue-label, decompose-issue, update-progress, resolve-issue, release, cr-fix, post-merge) — no commands surface, so they run under Codex too. post-merge runs a mandatory built-in wiki-lore ingest step (absorbed llm-wiki:post-merge-wiki) plus an optional Step 4.5 ephemeral-artifact pruning gate (heuristic candidates → AskUserQuestion → git rm). 2.8.0 correctness repairs: CR-state fetch failures map to a real error channel (no longer masked as a clean 'none'), a null-repository GraphQL response fails loudly instead of a silent false-clean convergence, and an active `@coderabbitai rate limit` query resolves ambiguous passive rate-limit sniffs.",
-      "version": "2.8.0",
+      "version": "2.8.1",
       "category": "github"
     },
     {
       "name": "e2e-harness",
       "source": "./plugins/e2e-harness",
       "description": "Playwright E2E test-harness engineering — wraps Playwright's official AI test agents (npx playwright init-agents --loop=claude generates planner/generator/healer). Three skills close the planner -> generator -> healer self-improving loop: e2e-setup onboards the full harness (agents, auth separation via storageState + setup-project dependency, page.route mocking with Next.js BFF/SSR guidance, E2E operating SSOT doc, GitHub Actions CI with trace/report artifact upload + PR-failure comment + path/label gating); e2e-author selects critical user flows and runs planner -> review-gate -> generator with semantic getByRole locators and a --repeat-each burn-in flake gate; e2e-debug downloads the CI trace, inspects it headlessly, and runs the healer with bounded retries (skip-after-3 + reason comment). Never overwrites an existing playwright.config (merge + backup); degrades gracefully when Playwright is not installed.",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "category": "testing"
     },
     {
       "name": "code-scout",
       "source": "./plugins/code-scout",
       "description": "Multi-axis code & ML research harness. 5-axis scout team (github/hf/web/docs/paper) + synthesis-scout + research-orchestrator skill + exa-web-search skill. exa MCP first, WebSearch fallback, firecrawl tier-3, insane-search tier-4 (WAF/blocked URLs). paper-scout wraps paper-search-tools 8-source family. /deep-research is the sibling for non-code/ML topics (code-scout does not delegate).",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "category": "research"
     },
     {
       "name": "brightdata-guide",
       "source": "./plugins/brightdata-guide",
       "description": "Bright Data web data access via MCP tools + CLI — scraping (Web Unlocker), SERP, 40+ structured web_data_* extractors, browser automation. Guide skill; operator sets BRIGHTDATA_API_KEY, delegate subagents fall back to the bdata CLI.",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "category": "research"
     },
     {
       "name": "deepwiki",
       "source": "./plugins/deepwiki",
       "description": "AI-powered GitHub repo documentation. Dual-surface: `/deepwiki:ask` + `/deepwiki:generate-llmstxt` commands and matching skills for fuzzy-trigger discovery.",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "category": "documentation"
     },
     {
       "name": "notebook",
       "source": "./plugins/notebook",
       "description": "Safe Jupyter notebook editing",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "category": "development"
     },
     {
       "name": "ml-toolkit",
       "source": "./plugins/ml-toolkit",
       "description": "ML/multimodal development principles, GPU parallel processing, Gradio CV apps, CV notebook generation, interactive CV data exploration",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "category": "development"
     },
     {
       "name": "translator",
       "source": "./plugins/translator",
       "description": "Web article translation to Korean",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "category": "content"
     },
     {
       "name": "interview",
       "source": "./plugins/interview",
       "description": "Structured requirements gathering",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "category": "planning"
     },
     {
       "name": "paper-search-tools",
       "source": "./plugins/paper-search-tools",
       "description": "Academic paper search (arXiv, PubMed, Semantic Scholar, etc.)",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "category": "research"
     },
     {
@@ -96,56 +96,56 @@
       "name": "slidev",
       "source": "./plugins/slidev",
       "description": "Slidev markdown presentation generator with interview workflow and KubeCon-level visual enhancement",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "category": "content"
     },
     {
       "name": "rules-forge",
       "source": "./plugins/rules-forge",
       "description": "CLAUDE.md generation and .claude/rules/ modular structure with auto mode detection (NEW/TIGHTEN/SPLIT/REORGANIZE), single write-rules skill entrypoint",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "category": "documentation"
     },
     {
       "name": "tcrei-prompt",
       "source": "./plugins/tcrei-prompt",
       "description": "Rewrite prompts using Google's TCREI structure for next-session reuse",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "category": "content"
     },
     {
       "name": "llm-wiki",
       "source": "./plugins/llm-wiki",
       "description": "Karpathy LLM-Wiki 3-layer (insight + wiki + raw under neutral .llmwiki/): 5 skills (query/ingest/lint/bootstrap/migrate) + 5 hooks + bootstrap templates. Three soft hints plus an auto-capture/ingest path: a Stop hook mechanically captures ingest candidates to <root>/.staging/ and the next session's SessionStart drain hook surfaces them for ingest-finding curation (capture and curation split). Post-merge wiki ingest is a mandatory, force-logged step inside github-dev:post-merge (the standalone post-merge-wiki skill was removed — breaking, hence the 2.0.0 major bump). Promoted cross-agent rules graduate to .llmwiki/insight/ (via core-config prompt-inject hook), not .claude/rules/. Resolves .llmwiki/wiki -> legacy .claude/wiki -> .codex/wiki. Agent-facing wiki conventions deduped into references/wiki-conventions.md.",
-      "version": "2.5.1",
+      "version": "2.5.2",
       "category": "memory"
     },
     {
       "name": "spec-state",
       "source": "./plugins/spec-state",
       "description": "Spec/issue/PR work-pipeline aggregate. state-tracker skill manages .claude/state/spec.json (read/init/start/complete). Called by github-dev:post-merge.",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "category": "workflow"
     },
     {
       "name": "project-init",
       "source": "./plugins/project-init",
       "description": "Agent-harness project lifecycle. `new` — one-shot first-day bootstrap (interview, .claude/ scaffold, minimal CLAUDE.md, AGENTS.md with Codex GitHub cloud reviewer guidelines in general/ml/web variants, README/CHANGELOG seed, gh repo create + initial push) behind a hardened preflight guard that refuses a non-empty cwd. `wiring` — its inverse for existing repos: a read-only 14-axis setup diagnostic (FAIL / WARN / ASK / INFO / SKIP / OK) covering guidance files, .claude/rules paths: scoping defeated by @import, llm-wiki layout + staging backlog, Serena onboarding, memory posture, MCP duplicate registration, Codex CLI posture + AGENTS.md byte budget, spec homes, gws-sync, .tmp, core.hooksPath, .gitignore coverage. ASK answers persist to .claude/state/wiring.json. Shared read-only detector: scripts/project_state.sh.",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "category": "planning"
     },
     {
       "name": "codex-image",
       "source": "./plugins/codex-image",
       "description": "Generate or edit images from Claude Code by delegating to Codex CLI image generation (ChatGPT OAuth, no OpenAI API key). Claude-only bridge; excluded from Codex sync.",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "category": "ai-models"
     },
     {
       "name": "anti-slop-design",
       "source": "./plugins/anti-slop-design",
       "description": "Anti-AI-slop design guard for web/SaaS landing, decks (PPT), dashboards, and copy. Runs a clarify->context->plan->run->audit->revise flow with a two-phase audit gate (pre-emit self-critique + binary slop checklist) and hands Korean copy rewriting to humanize-korean. Source-grounded in 6 OSS anti-slop repos.",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "category": "design"
     },
     {
@@ -159,7 +159,7 @@
       "name": "ppt-yeong-style",
       "source": "./plugins/ppt-yeong-style",
       "description": "yeong 스타일 강의·제안 덱 작성 규약 — ppt-master 빌드 엔진 위에 얹는 작성 레이어(엔진 자체가 아님). 스킬 3종: 메인 ppt-yeong-style(미감 시그니처 §0 'Editorial restraint, one committed accent'·md 소스 규약·작성 원칙 16종·밀도 리듬·역할 기반 색·codex-image vs SVG 경계·앱 UI 실물 강제·레버 조합 차별화·윤문·렌더 QA + references/ 6종 + 주입 페이로드) + lecture-deck(강의 덱 운영 — 실습 handouts 생성 규약·프롬프트 카드·placeholder→실캡처 스크린샷 슬롯·리넘버링 4중 동기화·전사 회고 루프·강사 노트 태그 + cc-common 47장 레퍼런스) + deck-review(관점별 리뷰 서브에이전트 4종 audience-fit·story-flow·fact-check·design-qa 병렬 오케스트레이션 + codex:rescue 교차 리뷰, 페르소나는 파라미터). 의존 스킬은 있으면 사용, 없으면 생략 + 설치 제안 문구(ppt-master만 prerequisite-stop). ppt-master/slidev로 그냥 'PPT 만들기'와 달리 yeong 규약이 필요할 때.",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "category": "design"
     },
     {
@@ -173,7 +173,7 @@
       "name": "mem0-ops",
       "source": "./plugins/mem0-ops",
       "description": "Fleet-level mem0 diagnostics and cleanup — complements the upstream mem0 plugin (which owns per-project quality). fleet-scan reports per-app noise ratio, junk app_id candidates, and app/user_id fragmentation across all apps; doctor checks config posture (MEM0_RERANK env, ~/.mem0/settings.json auto_save precedence trap, project decay flag, hook timeout budget, identity fragmentation); cleanup does backup-then-delete by metadata.type or whole junk app behind a dry-run default plus a skill-layer per-app confirmation gate (the script alone gates on --execute only). stdlib-only REST scripts, zero LLM cost for the deterministic parts.",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "category": "productivity"
     }
   ]

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -10,6 +10,14 @@ repo_root="$(git rev-parse --show-toplevel)"
 node "$repo_root/scripts/sync-codex-manifests.mjs" --check
 node "$repo_root/scripts/sync-hermes-manifests.mjs" --check
 node "$repo_root/scripts/check-doc-consistency.mjs"
+# Hermes adapter mock-load — same guard CI runs, so import/registration regressions
+# in generated __init__.py fail at commit time, not only in CI. Skip (not fail) when
+# python3 is absent locally; CI still enforces it.
+if command -v python3 >/dev/null 2>&1; then
+  python3 "$repo_root/scripts/mock-load-hermes.py"
+else
+  echo "pre-commit: python3 not found — skipping Hermes mock-load (CI still enforces it)" >&2
+fi
 
 # cr-fix's CLI-fallback and CR-state paths only execute after the primary path
 # fails, so nothing exercised them until they broke in production (issue #105).

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -9,6 +9,7 @@ set -euo pipefail
 repo_root="$(git rev-parse --show-toplevel)"
 node "$repo_root/scripts/sync-codex-manifests.mjs" --check
 node "$repo_root/scripts/sync-hermes-manifests.mjs" --check
+node "$repo_root/scripts/check-doc-consistency.mjs"
 
 # cr-fix's CLI-fallback and CR-state paths only execute after the primary path
 # fails, so nothing exercised them until they broke in production (issue #105).

--- a/.github/workflows/validate-codex.yml
+++ b/.github/workflows/validate-codex.yml
@@ -1,7 +1,8 @@
 name: validate-codex
 
-# Catch Codex + Hermes manifest drift and skill-description length violations at
-# PR time, even if a contributor skipped the local .githooks pre-commit hook.
+# Catch Codex + Hermes manifest drift, skill-description length violations,
+# README/AGENTS doc-consistency drift, and Hermes adapter load breakage at PR
+# time, even if a contributor skipped the local .githooks pre-commit hook.
 on:
   push:
   pull_request:
@@ -21,6 +22,13 @@ jobs:
           node-version: '20'
       - run: node scripts/sync-codex-manifests.mjs --check
       - run: node scripts/sync-hermes-manifests.mjs --check
+      # README.md / AGENTS.md plugin name-set + count strings must match the
+      # marketplace registry — drift the version files and manifest --checks miss.
+      - run: node scripts/check-doc-consistency.mjs
+      # Import each generated Hermes adapter with a stub ctx and assert register_skill
+      # fires — catches a generated-but-never-executed adapter regression (PyYAML is
+      # preinstalled on ubuntu-latest). See scripts/mock-load-hermes.py.
+      - run: python3 scripts/mock-load-hermes.py
       # cr-fix's CLI-fallback / CR-state / rate-limit paths only run after the
       # primary path fails, so nothing exercised them until they broke in
       # production (issues #105, #110). Fixture-driven, no network, sub-second.

--- a/.gitignore
+++ b/.gitignore
@@ -17,10 +17,11 @@ dist/
 .claude/.staging/
 .codex/.staging/
 
-# Python bytecode (regenerated on every run)
+# Python bytecode + test cache (regenerated on every run)
 __pycache__/
 *.pyc
 *.pyo
+.pytest_cache/
 
 # Windows reserved names (prevent accidental creation)
 nul

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,6 +128,7 @@
 │   ├── anti-slop-design/   # Anti-AI-slop design guard (web/ppt/dashboard/copy)
 │   ├── ppt-yeong-style/    # yeong-style lecture/proposal deck writing layer (on ppt-master)
 │   ├── tally-form/         # Checklist md -> Tally questionnaire/survey form builder
+│   ├── gws-sync/           # Local -> Google Drive one-way proposal sync
 │   └── project-init/       # Day-1 bootstrap (new) + existing-repo setup diagnostic (wiring)
 ├── AGENTS.md               # This file — 정본
 ├── CLAUDE.md               # @AGENTS.md import (한 줄)

--- a/README.md
+++ b/README.md
@@ -748,6 +748,7 @@ node scripts/install-skills.mjs
 ├── plugins/
 │   ├── core-config/           # 가이드라인 + 훅
 │   ├── github-dev/            # GitHub 워크플로우
+│   ├── e2e-harness/           # Playwright E2E 테스트 하네스 (setup/author/debug)
 │   ├── code-scout/            # 리소스 탐색
 │   ├── deepwiki/              # 레포 문서화
 │   ├── paper-search-tools/    # 논문 검색
@@ -765,6 +766,7 @@ node scripts/install-skills.mjs
 │   ├── spec-state/            # spec/issue/PR work-pipeline aggregate
 │   ├── anti-slop-design/      # anti-AI-slop 디자인 가드 (web/ppt/dashboard/copy)
 │   ├── ppt-yeong-style/       # yeong 스타일 덱 작성 레이어 — 스킬 3종(메인/lecture-deck/deck-review) + 리뷰 에이전트 4종
+│   ├── tally-form/            # 체크리스트 md -> Tally 설문/문의 폼 빌더
 │   ├── project-init/          # Day-1 프로젝트 부트스트랩 (인터뷰 + .claude/ + AGENTS.md + gh repo)
 │   ├── gws-sync/              # 로컬 → Google Drive 단방향 제안형 동기화 (gws CLI 기반)
 │   └── mem0-ops/              # 플릿 레벨 mem0 진단·정리 (fleet-scan/doctor/cleanup)

--- a/plugins/anti-slop-design/.claude-plugin/plugin.json
+++ b/plugins/anti-slop-design/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "anti-slop-design",
-  "version": "0.3.1",
-  "description": "Anti-AI-slop design guard for websites/SaaS landing, presentation decks (PPT), dashboards/admin UI, and marketing/UI copy. Detects and blocks the AI-generated look before generation and audits it after: purple/gradient palettes, gradient text, Inter/Geist single-font pages, side-stripe cards, card-in-card, icon-tile 3-col grids, centered-hero macrostructure, fabricated metrics, emoji icons, over-animation, buzzword copy. Runs a clarify->context->plan->run->audit->revise flow with a two-phase audit gate (pre-emit self-critique + binary slop checklist) and hands Korean copy rewriting to humanize-korean. Triggers: 'AI 티 안 나게', 'slop 제거', 'anti-slop', '디자인 감사', '랜딩/덱/대시보드/카피 디자인', 'enterprise 디자인', 'make it not look AI-generated', 'audit this design', even when this skill is not named.",
+  "version": "0.3.2",
+  "description": "Anti-AI-slop design guard for web/SaaS landing, decks (PPT), dashboards, and copy. Runs a clarify->context->plan->run->audit->revise flow with a two-phase audit gate (pre-emit self-critique + binary slop checklist) and hands Korean copy rewriting to humanize-korean. Source-grounded in 6 OSS anti-slop repos.",
   "skills": ["./skills/anti-slop-design"]
 }

--- a/plugins/anti-slop-design/.codex-plugin/plugin.json
+++ b/plugins/anti-slop-design/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "anti-slop-design",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Anti-AI-slop design guard for web/SaaS landing, decks (PPT), dashboards, and copy. Runs a clarify->context->plan->run->audit->revise flow with a two-phase audit gate (pre-emit self-critique + binary slop checklist) and hands Korean copy rewriting to humanize-korean. Source-grounded in 6 OSS anti-slop repos.",
   "author": {
     "name": "YoungjaeDev"

--- a/plugins/anti-slop-design/plugin.yaml
+++ b/plugins/anti-slop-design/plugin.yaml
@@ -1,5 +1,5 @@
 name: anti-slop-design
-version: "0.3.1"
+version: "0.3.2"
 description: "Anti-AI-slop design guard for web/SaaS landing, decks (PPT), dashboards, and copy. Runs a clarify->context->plan->run->audit->revise flow with a two-phase audit gate (pre-emit self-critique + binary slop checklist) and hands Korean copy rewriting to humanize-korean. Source-grounded in 6 OSS anti-slop repos."
 author: "YoungjaeDev"
 kind: standalone

--- a/plugins/brightdata-guide/.claude-plugin/plugin.json
+++ b/plugins/brightdata-guide/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "brightdata-guide",
-  "version": "1.0.0",
-  "description": "Bright Data web data access (MCP tools + CLI) for scraping, SERP, structured extractors, and browser automation.",
+  "version": "1.0.1",
+  "description": "Bright Data web data access via MCP tools + CLI — scraping (Web Unlocker), SERP, 40+ structured web_data_* extractors, browser automation. Guide skill; operator sets BRIGHTDATA_API_KEY, delegate subagents fall back to the bdata CLI.",
   "license": "MIT"
 }

--- a/plugins/brightdata-guide/.codex-plugin/plugin.json
+++ b/plugins/brightdata-guide/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "brightdata-guide",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Bright Data web data access via MCP tools + CLI — scraping (Web Unlocker), SERP, 40+ structured web_data_* extractors, browser automation. Guide skill; operator sets BRIGHTDATA_API_KEY, delegate subagents fall back to the bdata CLI.",
   "author": {
     "name": "YoungjaeDev"

--- a/plugins/brightdata-guide/plugin.yaml
+++ b/plugins/brightdata-guide/plugin.yaml
@@ -1,5 +1,5 @@
 name: brightdata-guide
-version: "1.0.0"
+version: "1.0.1"
 description: "Bright Data web data access via MCP tools + CLI — scraping (Web Unlocker), SERP, 40+ structured web_data_* extractors, browser automation. Guide skill; operator sets BRIGHTDATA_API_KEY, delegate subagents fall back to the bdata CLI."
 author: "YoungjaeDev"
 kind: standalone

--- a/plugins/code-scout/.claude-plugin/plugin.json
+++ b/plugins/code-scout/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "code-scout",
-  "version": "2.2.0",
-  "description": "Multi-axis code & ML research harness. 5-scout team (github/hf/web/docs/paper) + synthesis-scout + research-orchestrator skill + exa-web-search skill. exa MCP first, WebSearch fallback, firecrawl tier-3, insane-search tier-4 for WAF / blocked URLs. paper-scout wraps paper-search-tools 8-source MCP family.",
+  "version": "2.2.1",
+  "description": "Multi-axis code & ML research harness. 5-axis scout team (github/hf/web/docs/paper) + synthesis-scout + research-orchestrator skill + exa-web-search skill. exa MCP first, WebSearch fallback, firecrawl tier-3, insane-search tier-4 (WAF/blocked URLs). paper-scout wraps paper-search-tools 8-source family. /deep-research is the sibling for non-code/ML topics (code-scout does not delegate).",
   "skills": [
     "./skills/research-orchestrator",
     "./skills/exa-web-search",

--- a/plugins/code-scout/.codex-plugin/plugin.json
+++ b/plugins/code-scout/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "code-scout",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Multi-axis code & ML research harness. 5-axis scout team (github/hf/web/docs/paper) + synthesis-scout + research-orchestrator skill + exa-web-search skill. exa MCP first, WebSearch fallback, firecrawl tier-3, insane-search tier-4 (WAF/blocked URLs). paper-scout wraps paper-search-tools 8-source family. /deep-research is the sibling for non-code/ML topics (code-scout does not delegate).",
   "author": {
     "name": "YoungjaeDev"

--- a/plugins/code-scout/agents/paper-scout.md
+++ b/plugins/code-scout/agents/paper-scout.md
@@ -24,9 +24,9 @@ Single-axis scout for academic literature. Fans out under `research-orchestrator
 
 ## Tools
 
-Primary (search): `mcp__paper-search__search_arxiv`, `..._semantic`, `..._crossref`, `..._pubmed`, `..._biorxiv`, `..._medrxiv`, `..._iacr`, `..._google_scholar` — pick 2-3 per query, not all 8.
+Primary (search): `mcp__plugin_paper-search-tools_paper-search__search_arxiv`, `..._semantic`, `..._crossref`, `..._pubmed`, `..._biorxiv`, `..._medrxiv`, `..._iacr`, `..._google_scholar` — pick 2-3 per query, not all 8.
 
-Optional (metadata enrichment): `mcp__paper-search__read_arxiv_paper`, `..._pubmed_paper`, `..._biorxiv_paper`, `..._medrxiv_paper`, `..._iacr_paper`, `..._semantic_paper`, `..._crossref_paper`, or `mcp__paper-search__get_crossref_paper_by_doi` for DOI / abstract / citation count where the search response is too thin. **Google Scholar has no read tool** — use `search_google_scholar` results directly, and if a hit carries a DOI, enrich via `get_crossref_paper_by_doi`. Do **not** call `download_*` — PDF fetch is the user's call, not the scout's (LLM context budget).
+Optional (metadata enrichment): `mcp__plugin_paper-search-tools_paper-search__read_arxiv_paper`, `..._pubmed_paper`, `..._biorxiv_paper`, `..._medrxiv_paper`, `..._iacr_paper`, `..._semantic_paper`, `..._crossref_paper`, or `mcp__plugin_paper-search-tools_paper-search__get_crossref_paper_by_doi` for DOI / abstract / citation count where the search response is too thin. **Google Scholar has no read tool** — use `search_google_scholar` results directly, and if a hit carries a DOI, enrich via `get_crossref_paper_by_doi`. Do **not** call `download_*` — PDF fetch is the user's call, not the scout's (LLM context budget).
 
 ## Workflow
 

--- a/plugins/code-scout/skills/research-orchestrator/references/axis-contracts.md
+++ b/plugins/code-scout/skills/research-orchestrator/references/axis-contracts.md
@@ -81,7 +81,7 @@ Envelope rules that hold on **every** path:
 - **Role**: academic literature; metadata-only (no PDF download).
 - **Optional inputs**: `sources` (subset of `arxiv`|`semantic`|`crossref`|`pubmed`|`biorxiv`|`medrxiv`|`iacr`|`google_scholar`), `year_from`, `year_to`, `authors`, `limit`.
 - **Source selection** (pick 2-3, not all 8): CS/ML/AI/NLP/vision/RL → `arxiv`+`semantic`; medical/bio/clinical → `pubmed`+`biorxiv` (+`medrxiv` for epidemiology / clinical-trial); crypto/security → `iacr`+`semantic`; physics/chemistry → `arxiv`+`crossref`; cross-disciplinary → `semantic`+`crossref`. User `sources` overrides.
-- **Tool order**: `mcp__paper-search__search_{source}` (parallel, cap ~5 searches) → optional `..._read_{source}_paper` / `get_crossref_paper_by_doi` for enrichment. Google Scholar has no read tool — enrich DOI hits via `get_crossref_paper_by_doi`. Never call `download_*`.
+- **Tool order**: `mcp__plugin_paper-search-tools_paper-search__search_{source}` (parallel, cap ~5 searches) → optional `..._read_{source}_paper` / `get_crossref_paper_by_doi` for enrichment. Google Scholar has no read tool — enrich DOI hits via `get_crossref_paper_by_doi`. Never call `download_*`.
 - **Finding fields**: `id` (DOI lowercase with `https://doi.org/` stripped, else `arxiv:<id>` / `iacr:<year>/<n>`), `title`, `authors`, `published`, `venue`, `abstract`, `citation_count`, `kind`, plus shared. Top-level `sources_used`.
 - **Reliability**: `high` = peer-reviewed venue or arXiv preprint with citation_count > 100; `medium` = recent arXiv (< 2yr) / workshop / obscure venue; `low` = unverified / retracted / no citations and > 3yr old.
 - **Fallback**: record failed sources in `errors`, keep the rest; `findings: []` + top-level `error` only if all chosen sources fail.

--- a/plugins/codex-image/.claude-plugin/plugin.json
+++ b/plugins/codex-image/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "codex-image",
-  "version": "1.3.1",
-  "description": "Generate or edit images from Claude Code by delegating to Codex CLI image generation (ChatGPT OAuth, no OpenAI API key)"
+  "version": "1.3.2",
+  "description": "Generate or edit images from Claude Code by delegating to Codex CLI image generation (ChatGPT OAuth, no OpenAI API key). Claude-only bridge; excluded from Codex sync."
 }

--- a/plugins/deepwiki/.claude-plugin/plugin.json
+++ b/plugins/deepwiki/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "deepwiki",
-  "version": "1.1.2",
-  "description": "Deep query GitHub repositories using DeepWiki AI-powered documentation. Dual-surface: commands + skills share references/ procedures.",
+  "version": "1.1.3",
+  "description": "AI-powered GitHub repo documentation. Dual-surface: `/deepwiki:ask` + `/deepwiki:generate-llmstxt` commands and matching skills for fuzzy-trigger discovery.",
   "commands": [
     "./commands/ask.md",
     "./commands/generate-llmstxt.md"

--- a/plugins/deepwiki/.codex-plugin/plugin.json
+++ b/plugins/deepwiki/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "deepwiki",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "AI-powered GitHub repo documentation. Dual-surface: `/deepwiki:ask` + `/deepwiki:generate-llmstxt` commands and matching skills for fuzzy-trigger discovery.",
   "author": {
     "name": "YoungjaeDev"

--- a/plugins/e2e-harness/.claude-plugin/plugin.json
+++ b/plugins/e2e-harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "e2e-harness",
-  "version": "0.2.0",
-  "description": "Playwright E2E test-harness engineering — wraps Playwright's official planner/generator/healer AI agents (npx playwright init-agents --loop=claude). e2e-setup onboards the full harness (agents, auth separation via storageState, route mocking, CI with trace/report artifacts + PR comment + path/label gating); e2e-author orchestrates planner -> generator with semantic locators and a repeat-each burn-in flake gate; e2e-debug closes the self-healing loop via headless trace analysis + the healer agent (bounded CI-failure repair, skip-after-3). Gracefully degrades when Playwright is absent.",
+  "version": "0.2.1",
+  "description": "Playwright E2E test-harness engineering — wraps Playwright's official AI test agents (npx playwright init-agents --loop=claude generates planner/generator/healer). Three skills close the planner -> generator -> healer self-improving loop: e2e-setup onboards the full harness (agents, auth separation via storageState + setup-project dependency, page.route mocking with Next.js BFF/SSR guidance, E2E operating SSOT doc, GitHub Actions CI with trace/report artifact upload + PR-failure comment + path/label gating); e2e-author selects critical user flows and runs planner -> review-gate -> generator with semantic getByRole locators and a --repeat-each burn-in flake gate; e2e-debug downloads the CI trace, inspects it headlessly, and runs the healer with bounded retries (skip-after-3 + reason comment). Never overwrites an existing playwright.config (merge + backup); degrades gracefully when Playwright is not installed.",
   "skills": [
     "./skills/e2e-setup",
     "./skills/e2e-author",

--- a/plugins/e2e-harness/.codex-plugin/plugin.json
+++ b/plugins/e2e-harness/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "e2e-harness",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Playwright E2E test-harness engineering — wraps Playwright's official AI test agents (npx playwright init-agents --loop=claude generates planner/generator/healer). Three skills close the planner -> generator -> healer self-improving loop: e2e-setup onboards the full harness (agents, auth separation via storageState + setup-project dependency, page.route mocking with Next.js BFF/SSR guidance, E2E operating SSOT doc, GitHub Actions CI with trace/report artifact upload + PR-failure comment + path/label gating); e2e-author selects critical user flows and runs planner -> review-gate -> generator with semantic getByRole locators and a --repeat-each burn-in flake gate; e2e-debug downloads the CI trace, inspects it headlessly, and runs the healer with bounded retries (skip-after-3 + reason comment). Never overwrites an existing playwright.config (merge + backup); degrades gracefully when Playwright is not installed.",
   "author": {
     "name": "YoungjaeDev"

--- a/plugins/github-dev/.claude-plugin/plugin.json
+++ b/plugins/github-dev/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "github-dev",
-  "version": "2.8.0",
-  "description": "GitHub workflow automation skills for Claude Code",
+  "version": "2.8.1",
+  "description": "GitHub workflow: commit, PR, issue, worktree, unified CodeRabbit + ChatGPT-Codex cr-fix pipeline v2 (Step 5 pre-flight review detection across CR commit-status + comments + Codex reviews + Codex emoji 3-channel; autonomous Step 9 judgment replaces per-finding AskUserQuestion — LLM judges real/spurious + severity + fix-size and applies/defers/skips with logged reasoning; rate-limit sniffer now covers commit-status description + in-place comment edits; polling interval 60s → 8s; --auto-merge + --skip-minor + --cr-source retained), project tracking, release. All workflows are now skills (commit-and-push, create-issue-label, decompose-issue, update-progress, resolve-issue, release, cr-fix, post-merge) — no commands surface, so they run under Codex too. post-merge runs a mandatory built-in wiki-lore ingest step (absorbed llm-wiki:post-merge-wiki) plus an optional Step 4.5 ephemeral-artifact pruning gate (heuristic candidates → AskUserQuestion → git rm). 2.8.0 correctness repairs: CR-state fetch failures map to a real error channel (no longer masked as a clean 'none'), a null-repository GraphQL response fails loudly instead of a silent false-clean convergence, and an active `@coderabbitai rate limit` query resolves ambiguous passive rate-limit sniffs.",
   "skills": [
     "./skills/cr-fix",
     "./skills/post-merge",

--- a/plugins/github-dev/.codex-plugin/plugin.json
+++ b/plugins/github-dev/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "github-dev",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "description": "GitHub workflow: commit, PR, issue, worktree, unified CodeRabbit + ChatGPT-Codex cr-fix pipeline v2 (Step 5 pre-flight review detection across CR commit-status + comments + Codex reviews + Codex emoji 3-channel; autonomous Step 9 judgment replaces per-finding AskUserQuestion — LLM judges real/spurious + severity + fix-size and applies/defers/skips with logged reasoning; rate-limit sniffer now covers commit-status description + in-place comment edits; polling interval 60s → 8s; --auto-merge + --skip-minor + --cr-source retained), project tracking, release. All workflows are now skills (commit-and-push, create-issue-label, decompose-issue, update-progress, resolve-issue, release, cr-fix, post-merge) — no commands surface, so they run under Codex too. post-merge runs a mandatory built-in wiki-lore ingest step (absorbed llm-wiki:post-merge-wiki) plus an optional Step 4.5 ephemeral-artifact pruning gate (heuristic candidates → AskUserQuestion → git rm). 2.8.0 correctness repairs: CR-state fetch failures map to a real error channel (no longer masked as a clean 'none'), a null-repository GraphQL response fails loudly instead of a silent false-clean convergence, and an active `@coderabbitai rate limit` query resolves ambiguous passive rate-limit sniffs.",
   "author": {
     "name": "YoungjaeDev"

--- a/plugins/github-dev/plugin.yaml
+++ b/plugins/github-dev/plugin.yaml
@@ -1,5 +1,5 @@
 name: github-dev
-version: "2.8.0"
+version: "2.8.1"
 description: "GitHub workflow: commit, PR, issue, worktree, unified CodeRabbit + ChatGPT-Codex cr-fix pipeline v2 (Step 5 pre-flight review detection across CR commit-status + comments + Codex reviews + Codex emoji 3-channel; autonomous Step 9 judgment replaces per-finding AskUserQuestion — LLM judges real/spurious + severity + fix-size and applies/defers/skips with logged reasoning; rate-limit sniffer now covers commit-status description + in-place comment edits; polling interval 60s → 8s; --auto-merge + --skip-minor + --cr-source retained), project tracking, release. All workflows are now skills (commit-and-push, create-issue-label, decompose-issue, update-progress, resolve-issue, release, cr-fix, post-merge) — no commands surface, so they run under Codex too. post-merge runs a mandatory built-in wiki-lore ingest step (absorbed llm-wiki:post-merge-wiki) plus an optional Step 4.5 ephemeral-artifact pruning gate (heuristic candidates → AskUserQuestion → git rm). 2.8.0 correctness repairs: CR-state fetch failures map to a real error channel (no longer masked as a clean 'none'), a null-repository GraphQL response fails loudly instead of a silent false-clean convergence, and an active `@coderabbitai rate limit` query resolves ambiguous passive rate-limit sniffs."
 author: "YoungjaeDev"
 kind: standalone

--- a/plugins/interview/.claude-plugin/plugin.json
+++ b/plugins/interview/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "interview",
-  "version": "1.2.0",
-  "description": "Requirements gathering interview methodology for spec-based development"
+  "version": "1.2.1",
+  "description": "Structured requirements gathering"
 }

--- a/plugins/interview/.codex-plugin/plugin.json
+++ b/plugins/interview/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "interview",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Structured requirements gathering",
   "author": {
     "name": "YoungjaeDev"

--- a/plugins/interview/plugin.yaml
+++ b/plugins/interview/plugin.yaml
@@ -1,5 +1,5 @@
 name: interview
-version: "1.2.0"
+version: "1.2.1"
 description: "Structured requirements gathering"
 author: "YoungjaeDev"
 kind: standalone

--- a/plugins/llm-wiki/.claude-plugin/plugin.json
+++ b/plugins/llm-wiki/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "llm-wiki",
-  "version": "2.5.1",
-  "description": "Karpathy LLM-Wiki 3-layer system (insight + wiki + raw under neutral .llmwiki/): 5 skills (query/ingest/lint/bootstrap/migrate) + 5 hooks. Three soft hints (stale check, post-commit hint, session-start lint hint) plus an auto-capture/ingest path: a Stop hook mechanically captures ingest candidates to <root>/.staging/ and the next session's SessionStart drain hook surfaces them for ingest-finding curation (capture and curation are split — a shell hook cannot curate). Post-merge wiki ingest is a mandatory, force-logged step inside github-dev:post-merge (the standalone post-merge-wiki skill was absorbed). Promoted cross-agent rules graduate to .llmwiki/insight/ (surfaced via core-config prompt-inject hook for Claude + Codex), NOT .claude/rules/. Neutral root defeats codex-bridge's .claude/->.codex/ fork; resolves .llmwiki/wiki -> legacy .claude/wiki -> .codex/wiki. For spec/issue/PR work-pipeline state see the spec-state plugin.",
+  "version": "2.5.2",
+  "description": "Karpathy LLM-Wiki 3-layer (insight + wiki + raw under neutral .llmwiki/): 5 skills (query/ingest/lint/bootstrap/migrate) + 5 hooks + bootstrap templates. Three soft hints plus an auto-capture/ingest path: a Stop hook mechanically captures ingest candidates to <root>/.staging/ and the next session's SessionStart drain hook surfaces them for ingest-finding curation (capture and curation split). Post-merge wiki ingest is a mandatory, force-logged step inside github-dev:post-merge (the standalone post-merge-wiki skill was removed — breaking, hence the 2.0.0 major bump). Promoted cross-agent rules graduate to .llmwiki/insight/ (via core-config prompt-inject hook), not .claude/rules/. Resolves .llmwiki/wiki -> legacy .claude/wiki -> .codex/wiki. Agent-facing wiki conventions deduped into references/wiki-conventions.md.",
   "hooks": {
     "UserPromptSubmit": [
       {

--- a/plugins/llm-wiki/.codex-plugin/plugin.json
+++ b/plugins/llm-wiki/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "llm-wiki",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "description": "Karpathy LLM-Wiki 3-layer (insight + wiki + raw under neutral .llmwiki/): 5 skills (query/ingest/lint/bootstrap/migrate) + 5 hooks + bootstrap templates. Three soft hints plus an auto-capture/ingest path: a Stop hook mechanically captures ingest candidates to <root>/.staging/ and the next session's SessionStart drain hook surfaces them for ingest-finding curation (capture and curation split). Post-merge wiki ingest is a mandatory, force-logged step inside github-dev:post-merge (the standalone post-merge-wiki skill was removed — breaking, hence the 2.0.0 major bump). Promoted cross-agent rules graduate to .llmwiki/insight/ (via core-config prompt-inject hook), not .claude/rules/. Resolves .llmwiki/wiki -> legacy .claude/wiki -> .codex/wiki. Agent-facing wiki conventions deduped into references/wiki-conventions.md.",
   "author": {
     "name": "YoungjaeDev"

--- a/plugins/mem0-ops/.claude-plugin/plugin.json
+++ b/plugins/mem0-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mem0-ops",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Fleet-level mem0 diagnostics and cleanup — complements the upstream mem0 plugin (which owns per-project quality). fleet-scan reports per-app noise ratio, junk app_id candidates, and app/user_id fragmentation across all apps; doctor checks config posture (MEM0_RERANK env, ~/.mem0/settings.json auto_save precedence trap, project decay flag, hook timeout budget, identity fragmentation); cleanup does backup-then-delete by metadata.type or whole junk app behind a dry-run default plus a skill-layer per-app confirmation gate (the script alone gates on --execute only). stdlib-only REST scripts, zero LLM cost for the deterministic parts.",
   "skills": [
     "./skills/fleet-scan",

--- a/plugins/mem0-ops/.codex-plugin/plugin.json
+++ b/plugins/mem0-ops/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mem0-ops",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Fleet-level mem0 diagnostics and cleanup — complements the upstream mem0 plugin (which owns per-project quality). fleet-scan reports per-app noise ratio, junk app_id candidates, and app/user_id fragmentation across all apps; doctor checks config posture (MEM0_RERANK env, ~/.mem0/settings.json auto_save precedence trap, project decay flag, hook timeout budget, identity fragmentation); cleanup does backup-then-delete by metadata.type or whole junk app behind a dry-run default plus a skill-layer per-app confirmation gate (the script alone gates on --execute only). stdlib-only REST scripts, zero LLM cost for the deterministic parts.",
   "author": {
     "name": "YoungjaeDev"

--- a/plugins/mem0-ops/scripts/_api.py
+++ b/plugins/mem0-ops/scripts/_api.py
@@ -1,7 +1,7 @@
 """Shared REST helpers for mem0-ops scripts. stdlib only.
 
 All mem0-ops scripts talk to the mem0 Platform REST API directly
-(v1 entities/delete, v2 list). No dependency on the upstream mem0
+(v1 memories delete + entities list, v2 memories list). No dependency on the upstream mem0
 plugin's scripts or venv.
 """
 

--- a/plugins/ml-toolkit/.claude-plugin/plugin.json
+++ b/plugins/ml-toolkit/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "ml-toolkit",
-  "version": "1.4.1",
-  "description": "ML/AI development skills: ML/multimodal development principles, GPU parallel processing, Gradio CV apps, CV notebook generation, and interactive CV data exploration"
+  "version": "1.4.2",
+  "description": "ML/multimodal development principles, GPU parallel processing, Gradio CV apps, CV notebook generation, interactive CV data exploration"
 }

--- a/plugins/ml-toolkit/.codex-plugin/plugin.json
+++ b/plugins/ml-toolkit/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ml-toolkit",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "ML/multimodal development principles, GPU parallel processing, Gradio CV apps, CV notebook generation, interactive CV data exploration",
   "author": {
     "name": "YoungjaeDev"

--- a/plugins/ml-toolkit/plugin.yaml
+++ b/plugins/ml-toolkit/plugin.yaml
@@ -1,5 +1,5 @@
 name: ml-toolkit
-version: "1.4.1"
+version: "1.4.2"
 description: "ML/multimodal development principles, GPU parallel processing, Gradio CV apps, CV notebook generation, interactive CV data exploration"
 author: "YoungjaeDev"
 kind: standalone

--- a/plugins/notebook/.claude-plugin/plugin.json
+++ b/plugins/notebook/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "notebook",
-  "version": "1.0.0",
-  "description": "Jupyter Notebook editing skill for safe .ipynb file manipulation"
+  "version": "1.0.1",
+  "description": "Safe Jupyter notebook editing"
 }

--- a/plugins/notebook/.codex-plugin/plugin.json
+++ b/plugins/notebook/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "notebook",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Safe Jupyter notebook editing",
   "author": {
     "name": "YoungjaeDev"

--- a/plugins/notebook/skills/edit-notebook/SKILL.md
+++ b/plugins/notebook/skills/edit-notebook/SKILL.md
@@ -11,7 +11,7 @@ Edit Jupyter Notebook files using NotebookEdit tool only.
 
 ### Tool Selection
 - .ipynb = NotebookEdit only
-- Edit, Write, search_replace 사용 금지
+- Edit, Write, Bash(sed/cat) 사용 금지
 
 ### Cell Insertion: cell_id Tracking (Required)
 

--- a/plugins/notebook/skills/edit-notebook/SKILL.md
+++ b/plugins/notebook/skills/edit-notebook/SKILL.md
@@ -11,7 +11,7 @@ Edit Jupyter Notebook files using NotebookEdit tool only.
 
 ### Tool Selection
 - .ipynb = NotebookEdit only
-- Edit, Write, Bash(sed/cat) 사용 금지
+- `Edit`, `Write`, `Bash(sed/cat)` 사용 금지
 
 ### Cell Insertion: cell_id Tracking (Required)
 

--- a/plugins/paper-search-tools/.claude-plugin/plugin.json
+++ b/plugins/paper-search-tools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "paper-search-tools",
-  "version": "1.0.1",
-  "description": "Academic paper search MCP for arXiv, PubMed, bioRxiv, medRxiv, Google Scholar, IACR, Semantic Scholar, and CrossRef. Requires Docker.",
+  "version": "1.0.2",
+  "description": "Academic paper search (arXiv, PubMed, Semantic Scholar, etc.)",
   "license": "Apache-2.0"
 }

--- a/plugins/paper-search-tools/.codex-plugin/plugin.json
+++ b/plugins/paper-search-tools/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "paper-search-tools",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Academic paper search (arXiv, PubMed, Semantic Scholar, etc.)",
   "author": {
     "name": "YoungjaeDev"

--- a/plugins/paper-search-tools/skills/paper-search-usage/SKILL.md
+++ b/plugins/paper-search-tools/skills/paper-search-usage/SKILL.md
@@ -20,32 +20,41 @@ Search, download, and read academic papers across 8 platforms.
 | Semantic Scholar | Yes | Yes | Yes |
 | CrossRef | Yes | Limited | Limited |
 
+## Tool Naming
+
+Tool names carry an MCP prefix that depends on how the server is registered:
+
+- **Plugin-loaded (this repo's default, Claude Code)** — `mcp__plugin_paper-search-tools_paper-search__<tool>`, e.g. `mcp__plugin_paper-search-tools_paper-search__search_arxiv`. This is the live prefix and the one used in the tables below.
+- **Standalone `.mcp.json`** — if the server is registered directly under the name `paper-search` (not via the plugin), the tools are `mcp__paper-search__<tool>` instead.
+
+Codex 0.135 loads the same `.mcp.json`; its exact tool-name prefix is unverified here — resolve it from Codex's own tool list if the plugin-loaded name does not match.
+
 ## MCP Tools (23)
 
 ### Search Tools
 
 | Tool | Platform | Parameters |
 |------|----------|------------|
-| `mcp__paper-search__search_arxiv` | arXiv | query, max_results=10 |
-| `mcp__paper-search__search_pubmed` | PubMed | query, max_results=10 |
-| `mcp__paper-search__search_biorxiv` | bioRxiv | query, max_results=10 |
-| `mcp__paper-search__search_medrxiv` | medRxiv | query, max_results=10 |
-| `mcp__paper-search__search_google_scholar` | Google Scholar | query, max_results=10 |
-| `mcp__paper-search__search_iacr` | IACR ePrint | query, max_results=10, fetch_details=True |
-| `mcp__paper-search__search_semantic` | Semantic Scholar | query, year (optional), max_results=10 |
-| `mcp__paper-search__search_crossref` | CrossRef | query, max_results=10 |
+| `mcp__plugin_paper-search-tools_paper-search__search_arxiv` | arXiv | query, max_results=10 |
+| `mcp__plugin_paper-search-tools_paper-search__search_pubmed` | PubMed | query, max_results=10 |
+| `mcp__plugin_paper-search-tools_paper-search__search_biorxiv` | bioRxiv | query, max_results=10 |
+| `mcp__plugin_paper-search-tools_paper-search__search_medrxiv` | medRxiv | query, max_results=10 |
+| `mcp__plugin_paper-search-tools_paper-search__search_google_scholar` | Google Scholar | query, max_results=10 |
+| `mcp__plugin_paper-search-tools_paper-search__search_iacr` | IACR ePrint | query, max_results=10, fetch_details=True |
+| `mcp__plugin_paper-search-tools_paper-search__search_semantic` | Semantic Scholar | query, year (optional), max_results=10 |
+| `mcp__plugin_paper-search-tools_paper-search__search_crossref` | CrossRef | query, max_results=10 |
 
 ### Download Tools
 
 | Tool | Platform |
 |------|----------|
-| `mcp__paper-search__download_arxiv` | arXiv |
-| `mcp__paper-search__download_pubmed` | PubMed |
-| `mcp__paper-search__download_biorxiv` | bioRxiv |
-| `mcp__paper-search__download_medrxiv` | medRxiv |
-| `mcp__paper-search__download_iacr` | IACR ePrint |
-| `mcp__paper-search__download_semantic` | Semantic Scholar |
-| `mcp__paper-search__download_crossref` | CrossRef |
+| `mcp__plugin_paper-search-tools_paper-search__download_arxiv` | arXiv |
+| `mcp__plugin_paper-search-tools_paper-search__download_pubmed` | PubMed |
+| `mcp__plugin_paper-search-tools_paper-search__download_biorxiv` | bioRxiv |
+| `mcp__plugin_paper-search-tools_paper-search__download_medrxiv` | medRxiv |
+| `mcp__plugin_paper-search-tools_paper-search__download_iacr` | IACR ePrint |
+| `mcp__plugin_paper-search-tools_paper-search__download_semantic` | Semantic Scholar |
+| `mcp__plugin_paper-search-tools_paper-search__download_crossref` | CrossRef |
 
 Parameters: `paper_id`, `save_path="/downloads"`
 
@@ -53,13 +62,13 @@ Parameters: `paper_id`, `save_path="/downloads"`
 
 | Tool | Platform |
 |------|----------|
-| `mcp__paper-search__read_arxiv_paper` | arXiv |
-| `mcp__paper-search__read_pubmed_paper` | PubMed |
-| `mcp__paper-search__read_biorxiv_paper` | bioRxiv |
-| `mcp__paper-search__read_medrxiv_paper` | medRxiv |
-| `mcp__paper-search__read_iacr_paper` | IACR ePrint |
-| `mcp__paper-search__read_semantic_paper` | Semantic Scholar |
-| `mcp__paper-search__read_crossref_paper` | CrossRef |
+| `mcp__plugin_paper-search-tools_paper-search__read_arxiv_paper` | arXiv |
+| `mcp__plugin_paper-search-tools_paper-search__read_pubmed_paper` | PubMed |
+| `mcp__plugin_paper-search-tools_paper-search__read_biorxiv_paper` | bioRxiv |
+| `mcp__plugin_paper-search-tools_paper-search__read_medrxiv_paper` | medRxiv |
+| `mcp__plugin_paper-search-tools_paper-search__read_iacr_paper` | IACR ePrint |
+| `mcp__plugin_paper-search-tools_paper-search__read_semantic_paper` | Semantic Scholar |
+| `mcp__plugin_paper-search-tools_paper-search__read_crossref_paper` | CrossRef |
 
 Parameters: `paper_id`, `save_path="/downloads"`
 
@@ -69,7 +78,7 @@ Downloaded files are stored at `/tmp/paper-search-downloads` on the host.
 
 | Tool | Description |
 |------|-------------|
-| `mcp__paper-search__get_crossref_paper_by_doi` | Get paper metadata by DOI |
+| `mcp__plugin_paper-search-tools_paper-search__get_crossref_paper_by_doi` | Get paper metadata by DOI |
 
 ## Best Practices
 

--- a/plugins/ppt-yeong-style/.claude-plugin/plugin.json
+++ b/plugins/ppt-yeong-style/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ppt-yeong-style",
-  "version": "0.9.0",
-  "description": "yeong 스타일 강의·제안 덱 작성 규약 — ppt-master 빌드 엔진 위에 얹는 작성 레이어(엔진 자체가 아님). 스킬 3종: 메인 ppt-yeong-style(미감 시그니처 §0 'Editorial restraint, one committed accent'·md 소스 규약·작성 원칙 16종·밀도 리듬·역할 기반 색·codex-image vs SVG 경계·앱 UI 실물 강제·레버 조합 차별화·윤문·렌더 QA) + lecture-deck(강의 덱 운영 — 실습 handouts 생성 규약·프롬프트 카드·스크린샷 슬롯·리넘버링·전사 회고 루프·강사 노트 태그) + deck-review(4관점 리뷰 에이전트 오케스트레이션 + codex:rescue 교차 리뷰). 리뷰 서브에이전트 4종(audience-fit·story-flow·fact-check·design-qa, 페르소나는 파라미터) 동봉. ppt-master/slidev로 그냥 'PPT 만들기'와 달리 yeong 특유의 담백한 명사구 제목·anti-slop 본문 + 표지/전환 pop 무드가 필요할 때 사용.",
+  "version": "0.9.1",
+  "description": "yeong 스타일 강의·제안 덱 작성 규약 — ppt-master 빌드 엔진 위에 얹는 작성 레이어(엔진 자체가 아님). 스킬 3종: 메인 ppt-yeong-style(미감 시그니처 §0 'Editorial restraint, one committed accent'·md 소스 규약·작성 원칙 16종·밀도 리듬·역할 기반 색·codex-image vs SVG 경계·앱 UI 실물 강제·레버 조합 차별화·윤문·렌더 QA + references/ 6종 + 주입 페이로드) + lecture-deck(강의 덱 운영 — 실습 handouts 생성 규약·프롬프트 카드·placeholder→실캡처 스크린샷 슬롯·리넘버링 4중 동기화·전사 회고 루프·강사 노트 태그 + cc-common 47장 레퍼런스) + deck-review(관점별 리뷰 서브에이전트 4종 audience-fit·story-flow·fact-check·design-qa 병렬 오케스트레이션 + codex:rescue 교차 리뷰, 페르소나는 파라미터). 의존 스킬은 있으면 사용, 없으면 생략 + 설치 제안 문구(ppt-master만 prerequisite-stop). ppt-master/slidev로 그냥 'PPT 만들기'와 달리 yeong 규약이 필요할 때.",
   "skills": [
     "./skills/ppt-yeong-style",
     "./skills/lecture-deck",

--- a/plugins/ppt-yeong-style/.codex-plugin/plugin.json
+++ b/plugins/ppt-yeong-style/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ppt-yeong-style",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "yeong 스타일 강의·제안 덱 작성 규약 — ppt-master 빌드 엔진 위에 얹는 작성 레이어(엔진 자체가 아님). 스킬 3종: 메인 ppt-yeong-style(미감 시그니처 §0 'Editorial restraint, one committed accent'·md 소스 규약·작성 원칙 16종·밀도 리듬·역할 기반 색·codex-image vs SVG 경계·앱 UI 실물 강제·레버 조합 차별화·윤문·렌더 QA + references/ 6종 + 주입 페이로드) + lecture-deck(강의 덱 운영 — 실습 handouts 생성 규약·프롬프트 카드·placeholder→실캡처 스크린샷 슬롯·리넘버링 4중 동기화·전사 회고 루프·강사 노트 태그 + cc-common 47장 레퍼런스) + deck-review(관점별 리뷰 서브에이전트 4종 audience-fit·story-flow·fact-check·design-qa 병렬 오케스트레이션 + codex:rescue 교차 리뷰, 페르소나는 파라미터). 의존 스킬은 있으면 사용, 없으면 생략 + 설치 제안 문구(ppt-master만 prerequisite-stop). ppt-master/slidev로 그냥 'PPT 만들기'와 달리 yeong 규약이 필요할 때.",
   "author": {
     "name": "YoungjaeDev"

--- a/plugins/ppt-yeong-style/plugin.yaml
+++ b/plugins/ppt-yeong-style/plugin.yaml
@@ -1,5 +1,5 @@
 name: ppt-yeong-style
-version: "0.9.0"
+version: "0.9.1"
 description: "yeong 스타일 강의·제안 덱 작성 규약 — ppt-master 빌드 엔진 위에 얹는 작성 레이어(엔진 자체가 아님). 스킬 3종: 메인 ppt-yeong-style(미감 시그니처 §0 'Editorial restraint, one committed accent'·md 소스 규약·작성 원칙 16종·밀도 리듬·역할 기반 색·codex-image vs SVG 경계·앱 UI 실물 강제·레버 조합 차별화·윤문·렌더 QA + references/ 6종 + 주입 페이로드) + lecture-deck(강의 덱 운영 — 실습 handouts 생성 규약·프롬프트 카드·placeholder→실캡처 스크린샷 슬롯·리넘버링 4중 동기화·전사 회고 루프·강사 노트 태그 + cc-common 47장 레퍼런스) + deck-review(관점별 리뷰 서브에이전트 4종 audience-fit·story-flow·fact-check·design-qa 병렬 오케스트레이션 + codex:rescue 교차 리뷰, 페르소나는 파라미터). 의존 스킬은 있으면 사용, 없으면 생략 + 설치 제안 문구(ppt-master만 prerequisite-stop). ppt-master/slidev로 그냥 'PPT 만들기'와 달리 yeong 규약이 필요할 때."
 author: "YoungjaeDev"
 kind: standalone

--- a/plugins/project-init/.claude-plugin/plugin.json
+++ b/plugins/project-init/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-init",
-  "version": "0.4.1",
-  "description": "Agent-harness project lifecycle. `new` bootstraps an empty dir (.claude/ scaffold, minimal CLAUDE.md, AGENTS.md with Codex GitHub cloud reviewer guidelines, README/CHANGELOG seed, gh repo create + push) behind a preflight guard that refuses non-empty directories. `wiring` is its inverse for existing repos: a read-only 14-axis diagnostic whose verdicts are FAIL / WARN / ASK / INFO / SKIP / OK. Four axes check whether config takes EFFECT rather than merely exists — core.hooksPath, an @import that defeats .claude/rules paths: scoping, MCP servers registered twice so one copy is discarded, and the Codex AGENTS.md byte budget. An ASK is a decision nobody made yet: asked once, persisted to .claude/state/wiring.json. Both consume the shared read-only detector scripts/project_state.sh.",
+  "version": "0.4.2",
+  "description": "Agent-harness project lifecycle. `new` — one-shot first-day bootstrap (interview, .claude/ scaffold, minimal CLAUDE.md, AGENTS.md with Codex GitHub cloud reviewer guidelines in general/ml/web variants, README/CHANGELOG seed, gh repo create + initial push) behind a hardened preflight guard that refuses a non-empty cwd. `wiring` — its inverse for existing repos: a read-only 14-axis setup diagnostic (FAIL / WARN / ASK / INFO / SKIP / OK) covering guidance files, .claude/rules paths: scoping defeated by @import, llm-wiki layout + staging backlog, Serena onboarding, memory posture, MCP duplicate registration, Codex CLI posture + AGENTS.md byte budget, spec homes, gws-sync, .tmp, core.hooksPath, .gitignore coverage. ASK answers persist to .claude/state/wiring.json. Shared read-only detector: scripts/project_state.sh.",
   "author": {
     "name": "YoungjaeDev"
   },

--- a/plugins/project-init/.codex-plugin/plugin.json
+++ b/plugins/project-init/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "project-init",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Agent-harness project lifecycle. `new` — one-shot first-day bootstrap (interview, .claude/ scaffold, minimal CLAUDE.md, AGENTS.md with Codex GitHub cloud reviewer guidelines in general/ml/web variants, README/CHANGELOG seed, gh repo create + initial push) behind a hardened preflight guard that refuses a non-empty cwd. `wiring` — its inverse for existing repos: a read-only 14-axis setup diagnostic (FAIL / WARN / ASK / INFO / SKIP / OK) covering guidance files, .claude/rules paths: scoping defeated by @import, llm-wiki layout + staging backlog, Serena onboarding, memory posture, MCP duplicate registration, Codex CLI posture + AGENTS.md byte budget, spec homes, gws-sync, .tmp, core.hooksPath, .gitignore coverage. ASK answers persist to .claude/state/wiring.json. Shared read-only detector: scripts/project_state.sh.",
   "author": {
     "name": "YoungjaeDev"

--- a/plugins/project-init/CLAUDE.md
+++ b/plugins/project-init/CLAUDE.md
@@ -150,7 +150,7 @@ variant 차이는 `### Domain-specific` 섹션 + `### P0` / `### P1` 에 도메�
 
 - CI/CD workflow seed (`.github/workflows/`) — variant 별 다양성 너무 큼
 - Pre-commit hook seed — 같은 이유
-- Boilerplate auto-download (cookiecutter, copier) — `/code-scout:scout` 별도 호출
+- Boilerplate auto-download (cookiecutter, copier) — `Skill("code-scout:research-orchestrator")` 별도 호출
 - Multi-language 인터뷰 분기 — 한/영 혼용 단일 버전 유지
 
 ## 참조

--- a/plugins/project-init/references/new-procedure.md
+++ b/plugins/project-init/references/new-procedure.md
@@ -321,5 +321,5 @@ Next actions (call when ready):
 
 - CI/CD workflow seed (`.github/workflows/`)
 - pre-commit hook seed
-- 외부 boilerplate auto-download (cookiecutter 등 — 필요하면 `/code-scout:scout` 별도 호출)
+- 외부 boilerplate auto-download (cookiecutter 등 — 필요하면 `Skill("code-scout:research-orchestrator")` 별도 호출)
 - 다국어 인터뷰 분기 — 한/영 혼용 단일 버전 유지

--- a/plugins/project-init/scripts/idempotent-seed.sh
+++ b/plugins/project-init/scripts/idempotent-seed.sh
@@ -19,7 +19,8 @@ shift || true
 
 cmd_ensure_claude_dirs() {
   # Schema layer (spec, rules) stays under .claude/. Wiki + raw evidence live under the
-  # neutral .llmwiki/ root so codex-bridge's .claude/->.codex/ transform never forks them.
+  # neutral .llmwiki/ root so all three runtimes (Claude/Codex/Hermes) share one copy
+  # instead of a per-agent .claude/ vs .codex/ fork.
   local claude_subdirs=("spec" "rules")
   local llmwiki_subdirs=("raw" "wiki")
   for sub in "${claude_subdirs[@]}"; do

--- a/plugins/rules-forge/.claude-plugin/plugin.json
+++ b/plugins/rules-forge/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "rules-forge",
-  "version": "2.1.0",
-  "description": "Generate and restructure CLAUDE.md systems into modular .claude/rules/ delegation. Auto-detects project state and proposes one of four modes (NEW/TIGHTEN/SPLIT/REORGANIZE). Single skill entrypoint."
+  "version": "2.1.1",
+  "description": "CLAUDE.md generation and .claude/rules/ modular structure with auto mode detection (NEW/TIGHTEN/SPLIT/REORGANIZE), single write-rules skill entrypoint"
 }

--- a/plugins/rules-forge/.codex-plugin/plugin.json
+++ b/plugins/rules-forge/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rules-forge",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "CLAUDE.md generation and .claude/rules/ modular structure with auto mode detection (NEW/TIGHTEN/SPLIT/REORGANIZE), single write-rules skill entrypoint",
   "author": {
     "name": "YoungjaeDev"

--- a/plugins/rules-forge/CLAUDE.md
+++ b/plugins/rules-forge/CLAUDE.md
@@ -79,7 +79,7 @@ generate):
 
 Follows the proven Role / Do / Don't / Examples / Source of Truth
 shape (the same pattern this repo uses in
-`.claude/rules/codex-bridge-sync.md`).
+`.claude/rules/dual-integration.md`).
 
 Variant A (path-scoped):
 ```yaml

--- a/plugins/rules-forge/skills/write-rules/assets/templates/rule-categories.md
+++ b/plugins/rules-forge/skills/write-rules/assets/templates/rule-categories.md
@@ -77,8 +77,8 @@ conventions, mock policy.
 `tests/fixtures/**`.
 
 **Inspiration**: No bundled example — adapt from this repo's own
-`plugins/codex-bridge/tests/*.test.mjs` pattern (Red-first TDD with
-node --test, fixtures under `tests/fixtures/`).
+`plugins/github-dev/skills/cr-fix/tests/` fixture suite (fixture-driven,
+no network, run in `.githooks/pre-commit` + CI).
 
 **Do/Don't seeds**:
 - Do: Write the failing test before implementation.

--- a/plugins/rules-forge/skills/write-rules/assets/templates/rule-file.md
+++ b/plugins/rules-forge/skills/write-rules/assets/templates/rule-file.md
@@ -6,7 +6,7 @@ across NEW / SPLIT / REORGANIZE modes. Skill picks Variant A or B
 based on whether the rule has a clear path boundary.
 
 Both variants follow the Role / Do / Don't / Source of Truth shape —
-the style proven in this repo's own .claude/rules/codex-bridge-sync.md
+the style proven in this repo's own .claude/rules/dual-integration.md
 and plugin-versioning.md.
 -->
 

--- a/plugins/slidev/.claude-plugin/plugin.json
+++ b/plugins/slidev/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "slidev",
-  "version": "1.2.0",
-  "description": "Slidev markdown presentation generator with interview-based workflow and KubeCon-level visual enhancement"
+  "version": "1.2.1",
+  "description": "Slidev markdown presentation generator with interview workflow and KubeCon-level visual enhancement"
 }

--- a/plugins/slidev/.codex-plugin/plugin.json
+++ b/plugins/slidev/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "slidev",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Slidev markdown presentation generator with interview workflow and KubeCon-level visual enhancement",
   "author": {
     "name": "YoungjaeDev"

--- a/plugins/slidev/skills/create-slide/SKILL.md
+++ b/plugins/slidev/skills/create-slide/SKILL.md
@@ -5,7 +5,6 @@ description: |
   "make a presentation", "build a deck", "presentation", "slidev". Collects
   information through an interview workflow, then generates slides.md.
   Automatically initializes a Slidev project if one doesn't exist.
-version: 1.0.0
 allowed-tools:
   - Read
   - Write

--- a/plugins/spec-state/.claude-plugin/plugin.json
+++ b/plugins/spec-state/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "spec-state",
-  "version": "1.0.2",
-  "description": "Spec/issue/PR work-pipeline aggregate. Manages .claude/state/spec.json with read/init/start/complete ops. Called by github-dev:post-merge. No hooks."
+  "version": "1.0.3",
+  "description": "Spec/issue/PR work-pipeline aggregate. state-tracker skill manages .claude/state/spec.json (read/init/start/complete). Called by github-dev:post-merge."
 }

--- a/plugins/spec-state/.codex-plugin/plugin.json
+++ b/plugins/spec-state/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "spec-state",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Spec/issue/PR work-pipeline aggregate. state-tracker skill manages .claude/state/spec.json (read/init/start/complete). Called by github-dev:post-merge.",
   "author": {
     "name": "YoungjaeDev"

--- a/plugins/tcrei-prompt/.claude-plugin/plugin.json
+++ b/plugins/tcrei-prompt/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "tcrei-prompt",
-  "version": "1.1.0",
-  "description": "Rewrite prompts using Google's TCREI structure (Task, Context, References, Evaluate, Iterate) for next-session reuse"
+  "version": "1.1.1",
+  "description": "Rewrite prompts using Google's TCREI structure for next-session reuse"
 }

--- a/plugins/tcrei-prompt/.codex-plugin/plugin.json
+++ b/plugins/tcrei-prompt/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tcrei-prompt",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Rewrite prompts using Google's TCREI structure for next-session reuse",
   "author": {
     "name": "YoungjaeDev"

--- a/plugins/tcrei-prompt/plugin.yaml
+++ b/plugins/tcrei-prompt/plugin.yaml
@@ -1,5 +1,5 @@
 name: tcrei-prompt
-version: "1.1.0"
+version: "1.1.1"
 description: "Rewrite prompts using Google's TCREI structure for next-session reuse"
 author: "YoungjaeDev"
 kind: standalone

--- a/plugins/tcrei-prompt/skills/tcrei-prompt/SKILL.md
+++ b/plugins/tcrei-prompt/skills/tcrei-prompt/SKILL.md
@@ -6,7 +6,6 @@ description: |
   consistent results when reused in the next session.
   Triggers: "TCREI", "structure this prompt", "prompt enhance", "make a prompt for next session",
   "rewrite as TCREI", "improve this prompt".
-version: 1.0.0
 allowed-tools:
   - Read
   - Write

--- a/plugins/translator/.claude-plugin/plugin.json
+++ b/plugins/translator/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "translator",
-  "version": "1.0.0",
-  "description": "Web article translation to Korean with VLM image analysis"
+  "version": "1.0.1",
+  "description": "Web article translation to Korean"
 }

--- a/plugins/translator/.codex-plugin/plugin.json
+++ b/plugins/translator/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "translator",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Web article translation to Korean",
   "author": {
     "name": "YoungjaeDev"

--- a/scripts/check-doc-consistency.mjs
+++ b/scripts/check-doc-consistency.mjs
@@ -12,6 +12,7 @@
 import { readFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { CODEX_EXCLUDED, HERMES_ELIGIBLE } from './manifest-eligibility.mjs';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const marketplace = JSON.parse(readFileSync(join(ROOT, '.claude-plugin', 'marketplace.json'), 'utf8'));
@@ -20,11 +21,10 @@ const canonical = marketplace.plugins.map((p) => p.name);
 const canonicalSet = new Set(canonical);
 const TOTAL = canonical.length;
 
-// Mirrors of the two generators' scoping constants — kept here so the count
-// checks are self-contained. Update alongside sync-{codex,hermes}-manifests.mjs.
-const CODEX_EXCLUDED = new Set(['core-config', 'codex-image']); // sync-codex-manifests.mjs EXCLUDED
-const HERMES_ELIGIBLE = 7; // sync-hermes-manifests.mjs HERMES_ELIGIBLE size
+// Eligibility comes from the shared SoT the generators also import, so this guard's
+// counts cannot drift from sync-{codex,hermes}-manifests.mjs.
 const CODEX_ELIGIBLE = canonical.filter((n) => !CODEX_EXCLUDED.has(n)).length;
+const HERMES_ELIGIBLE_COUNT = HERMES_ELIGIBLE.size;
 
 const errors = [];
 
@@ -92,7 +92,8 @@ checkCount('README.md Codex share', readme, /(\d+) \/ (\d+) 플러그인/g, [COD
 checkCount('AGENTS.md ## Plugins (N)', agents, /## Plugins \((\d+)\)/g, [TOTAL]);
 checkCount('AGENTS.md eligible N개', agents, /eligible (\d+)개/g, [CODEX_ELIGIBLE]);
 checkCount('AGENTS.md # N entries', agents, /# (\d+) entries/g, [CODEX_ELIGIBLE]);
-checkCount('AGENTS.md 현재 N개', agents, /현재 (\d+)개/g, [HERMES_ELIGIBLE]);
+checkCount('AGENTS.md 현재 N개', agents, /현재 (\d+)개/g, [HERMES_ELIGIBLE_COUNT]);
+checkCount('README.md Hermes 이번 라운드', readme, /이번 라운드 (\d+)개/g, [HERMES_ELIGIBLE_COUNT]);
 
 if (errors.length) {
   console.error('doc-consistency drift detected:');
@@ -100,4 +101,4 @@ if (errors.length) {
   console.error('\nfix README.md / AGENTS.md to match .claude-plugin/marketplace.json.');
   process.exit(1);
 }
-console.log(`doc-consistency OK — ${TOTAL} plugins, Codex-eligible ${CODEX_ELIGIBLE}, Hermes ${HERMES_ELIGIBLE}; trees + table + counts consistent.`);
+console.log(`doc-consistency OK — ${TOTAL} plugins, Codex-eligible ${CODEX_ELIGIBLE}, Hermes ${HERMES_ELIGIBLE_COUNT}; trees + table + counts consistent.`);

--- a/scripts/check-doc-consistency.mjs
+++ b/scripts/check-doc-consistency.mjs
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+// Doc-consistency guard: keep README.md + AGENTS.md in sync with the marketplace
+// plugin registry. Fails (exit 1) when a structure tree or the AGENTS plugin
+// table lists a different plugin name-set than .claude-plugin/marketplace.json,
+// or when a documented plugin-count string drifts from the real numbers.
+//
+// The version files and sync-*-manifests.mjs --check do NOT catch this class of
+// drift (a plugin dropped from a doc tree, or a stale "N plugins" count).
+//
+// Zero-dep: Node 18+ builtins only. Run: node scripts/check-doc-consistency.mjs
+
+import { readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const marketplace = JSON.parse(readFileSync(join(ROOT, '.claude-plugin', 'marketplace.json'), 'utf8'));
+
+const canonical = marketplace.plugins.map((p) => p.name);
+const canonicalSet = new Set(canonical);
+const TOTAL = canonical.length;
+
+// Mirrors of the two generators' scoping constants — kept here so the count
+// checks are self-contained. Update alongside sync-{codex,hermes}-manifests.mjs.
+const CODEX_EXCLUDED = new Set(['core-config', 'codex-image']); // sync-codex-manifests.mjs EXCLUDED
+const HERMES_ELIGIBLE = 7; // sync-hermes-manifests.mjs HERMES_ELIGIBLE size
+const CODEX_ELIGIBLE = canonical.filter((n) => !CODEX_EXCLUDED.has(n)).length;
+
+const errors = [];
+
+// --- plugin name-sets from the doc structure trees ---
+// Collect the `plugins/` subtree children (│  ├── <name>/ …) until the next
+// top-level sibling entry closes the block.
+function treePluginNames(md) {
+  const names = new Set();
+  let inPlugins = false;
+  for (const line of md.split('\n')) {
+    if (!inPlugins) {
+      if (/^[├└]──\s+plugins\//.test(line)) inPlugins = true;
+      continue;
+    }
+    if (/^[├└]── /.test(line)) { inPlugins = false; continue; } // next top-level entry
+    const m = line.match(/──\s+([a-z0-9][a-z0-9-]*)\/(?:\s|$)/);
+    if (m) names.add(m[1]);
+  }
+  return names;
+}
+
+// AGENTS.md `## Plugins (N)` table: first-column backticked plugin name per row.
+function agentsTablePlugins(md) {
+  const start = md.indexOf('## Plugins');
+  const end = md.indexOf('## 저장소 구조');
+  const section = md.slice(start >= 0 ? start : 0, end >= 0 ? end : undefined);
+  const names = new Set();
+  for (const line of section.split('\n')) {
+    const m = line.match(/^\|\s*`([a-z0-9][a-z0-9-]*)`\s*\|/);
+    if (m) names.add(m[1]);
+  }
+  return names;
+}
+
+function compareSet(label, got) {
+  const missing = canonical.filter((n) => !got.has(n));
+  const extra = [...got].filter((n) => !canonicalSet.has(n));
+  if (missing.length) errors.push(`${label}: missing ${missing.join(', ')}`);
+  if (extra.length) errors.push(`${label}: unknown plugin(s) ${extra.join(', ')}`);
+}
+
+// --- documented count strings ---
+// Each anchor must be present and equal the expected number, else it is drift.
+function checkCount(label, md, regex, expected) {
+  const matches = [...md.matchAll(regex)];
+  if (matches.length === 0) { errors.push(`${label}: count anchor not found (${regex})`); return; }
+  for (const m of matches) {
+    const got = expected.map((_, i) => Number(m[i + 1]));
+    if (got.some((g, i) => g !== expected[i])) {
+      errors.push(`${label}: expected ${expected.join('/')}, found ${got.join('/')} in "${m[0]}"`);
+    }
+  }
+}
+
+const readme = readFileSync(join(ROOT, 'README.md'), 'utf8');
+const agents = readFileSync(join(ROOT, 'AGENTS.md'), 'utf8');
+
+compareSet('README.md tree', treePluginNames(readme));
+compareSet('AGENTS.md tree', treePluginNames(agents));
+compareSet('AGENTS.md ## Plugins table', agentsTablePlugins(agents));
+
+checkCount('README.md badge', readme, /plugins-(\d+)-blue/g, [TOTAL]);
+checkCount('README.md 플러그인 모음', readme, /(\d+)개 플러그인 모음/g, [TOTAL]);
+checkCount('README.md Codex share', readme, /(\d+) \/ (\d+) 플러그인/g, [CODEX_ELIGIBLE, TOTAL]);
+checkCount('AGENTS.md ## Plugins (N)', agents, /## Plugins \((\d+)\)/g, [TOTAL]);
+checkCount('AGENTS.md eligible N개', agents, /eligible (\d+)개/g, [CODEX_ELIGIBLE]);
+checkCount('AGENTS.md # N entries', agents, /# (\d+) entries/g, [CODEX_ELIGIBLE]);
+checkCount('AGENTS.md 현재 N개', agents, /현재 (\d+)개/g, [HERMES_ELIGIBLE]);
+
+if (errors.length) {
+  console.error('doc-consistency drift detected:');
+  for (const e of errors) console.error(`  ${e}`);
+  console.error('\nfix README.md / AGENTS.md to match .claude-plugin/marketplace.json.');
+  process.exit(1);
+}
+console.log(`doc-consistency OK — ${TOTAL} plugins, Codex-eligible ${CODEX_ELIGIBLE}, Hermes ${HERMES_ELIGIBLE}; trees + table + counts consistent.`);

--- a/scripts/install-skills.mjs
+++ b/scripts/install-skills.mjs
@@ -261,10 +261,10 @@ function selftest() {
   const plugins = groups.map((g) => g.plugin);
   const assert = (cond, msg) => { if (!cond) { console.error('FAIL:', msg); process.exit(1); } };
 
-  assert(groups.length === 24, `expected 24 skill-bearing plugins, got ${groups.length}`);
-  assert(totalSkills === 47, `expected 47 skills total, got ${totalSkills}`);
+  assert(groups.length === 23, `expected 23 skill-bearing plugins, got ${groups.length}`);
+  assert(totalSkills === 52, `expected 52 skills total, got ${totalSkills}`);
   assert(!plugins.includes('core-config'), 'core-config (0 skills) should be excluded');
-  assert(new Set(groups.flatMap((g) => g.skills.map((s) => s.id))).size === 47, 'skill names must be globally unique for -s targeting');
+  assert(new Set(groups.flatMap((g) => g.skills.map((s) => s.id))).size === 52, 'skill names must be globally unique for -s targeting');
 
   const gh = groups.find((g) => g.plugin === 'github-dev');
   assert(gh && gh.skills.length === 8, 'github-dev should have 8 skills');
@@ -274,5 +274,18 @@ function selftest() {
   console.log(`selftest OK — ${groups.length} plugins, ${totalSkills} skills, name+desc parsed.`);
 }
 
-if (process.argv.includes('--selftest')) selftest();
+function help() {
+  out([
+    "install-skills — pick this marketplace's skills and install them to Codex / Hermes Agent.",
+    '',
+    'Usage:',
+    '  node scripts/install-skills.mjs            interactive install (needs a TTY)',
+    '  node scripts/install-skills.mjs --selftest pure-logic self-check (no TTY/network)',
+    '  node scripts/install-skills.mjs --help     show this help',
+    '',
+  ].join('\n'));
+}
+
+if (process.argv.includes('--help') || process.argv.includes('-h')) help();
+else if (process.argv.includes('--selftest')) selftest();
 else interactive();

--- a/scripts/manifest-eligibility.mjs
+++ b/scripts/manifest-eligibility.mjs
@@ -1,0 +1,21 @@
+// Single source of truth for which plugins each downstream runtime covers.
+// Imported by sync-codex-manifests.mjs (Codex EXCLUDED), sync-hermes-manifests.mjs
+// (Hermes allowlist), and check-doc-consistency.mjs (doc count checks) so the three
+// cannot drift. Update the eligibility HERE, never in a copy — the doc-consistency
+// guard reads these same sets, so a stale copy would silently pass stale counts.
+
+// Plugins intentionally not bridged to Codex.
+//   core-config — Claude-only hooks / settings (no matching Codex hook surface)
+//   codex-image — the Claude->Codex bridge itself (syncing it to Codex is circular)
+export const CODEX_EXCLUDED = new Set(['core-config', 'codex-image']);
+
+// Plugins that get generated Hermes adapters (plugin.yaml + __init__.py).
+export const HERMES_ELIGIBLE = new Set([
+  'github-dev',
+  'interview',
+  'anti-slop-design',
+  'tcrei-prompt',
+  'ppt-yeong-style',
+  'ml-toolkit',
+  'brightdata-guide',
+]);

--- a/scripts/mock-load-hermes.py
+++ b/scripts/mock-load-hermes.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Mock-load every generated Hermes adapter and assert its register_skill calls fire.
+
+The byte-drift guard (sync-hermes-manifests.mjs --check) only checks that the
+generated plugins/<name>/__init__.py matches the generator output — it never
+executes it. A generator regression that emits a syntactically broken or
+non-registering adapter passes --check but fails at Hermes load time. This smoke
+test imports each adapter with a stub ctx and asserts register() registers one
+skill per SKILL.md, catching that "generated but never executed" gap.
+
+Requires PyYAML (the adapters do `import yaml`); it is preinstalled on the CI
+runner. Run: python3 scripts/mock-load-hermes.py
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+PLUGINS = ROOT / "plugins"
+
+
+class StubCtx:
+    """Records register_skill calls the way the real Hermes context would receive them."""
+
+    def __init__(self):
+        self.calls = []
+
+    def register_skill(self, name, path, description):
+        assert isinstance(name, str) and name, f"empty skill name from {path!r}"
+        self.calls.append((name, str(path), description))
+
+
+def load_adapter(init_py):
+    spec = importlib.util.spec_from_file_location(
+        f"hermes_adapter_{init_py.parent.name}", init_py
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def main():
+    adapters = sorted(PLUGINS.glob("*/__init__.py"))
+    if not adapters:
+        sys.exit(
+            "no Hermes adapters found — expected generated plugins/<name>/__init__.py"
+        )
+
+    failures = []
+    for init_py in adapters:
+        plugin = init_py.parent.name
+        expected = len(sorted((init_py.parent / "skills").glob("*/SKILL.md")))
+        try:
+            module = load_adapter(init_py)
+            ctx = StubCtx()
+            module.register(ctx)
+        except Exception as exc:  # noqa: BLE001 - report any adapter breakage
+            failures.append(f"{plugin}: {type(exc).__name__}: {exc}")
+            continue
+        if len(ctx.calls) != expected:
+            failures.append(
+                f"{plugin}: register_skill fired {len(ctx.calls)}x, expected {expected}"
+            )
+
+    if failures:
+        print("Hermes adapter mock-load FAILED:")
+        for line in failures:
+            print(f"  {line}")
+        sys.exit(1)
+    print(
+        f"Hermes adapter mock-load OK — {len(adapters)} adapters, register_skill exercised."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/sync-codex-manifests.mjs
+++ b/scripts/sync-codex-manifests.mjs
@@ -183,6 +183,25 @@ function validateSkillDescriptions(pluginNames) {
   return violations;
 }
 
+// marketplace.json is the description source of truth. Each plugin's
+// .claude-plugin/plugin.json `description` must match its marketplace entry, or
+// Claude Code (which reads plugin.json) and the marketplace registry disagree.
+// Runs over every marketplace plugin (incl. Codex-excluded ones), which still
+// carry a plugin.json that must stay in sync.
+function validateDescriptionParity(entries) {
+  const violations = [];
+  for (const entry of entries) {
+    const manifestPath = join(PLUGINS_DIR, entry.name, '.claude-plugin', 'plugin.json');
+    if (!isFile(manifestPath)) continue;
+    let parsed;
+    try { parsed = JSON.parse(readFileSync(manifestPath, 'utf8')); } catch { continue; }
+    if ((parsed.description || '') !== (entry.description || '')) {
+      violations.push({ name: entry.name, path: manifestPath });
+    }
+  }
+  return violations;
+}
+
 function main() {
   const source = readJSON(SOURCE);
   const eligible = source.plugins.filter((p) => !EXCLUDED.has(p.name));
@@ -193,6 +212,14 @@ function main() {
   if (violations.length > 0) {
     console.error(`skill description length violation(s) — Codex 0.135 limit is ${SKILL_DESC_MAX} chars:`);
     for (const v of violations) console.error(`  ${v.len} chars (limit ${SKILL_DESC_MAX}): ${v.path}`);
+    process.exit(1);
+  }
+
+  // plugin.json <-> marketplace.json description parity (marketplace.json is SoT).
+  const parityViolations = validateDescriptionParity(source.plugins);
+  if (parityViolations.length > 0) {
+    console.error('plugin.json description drift — marketplace.json is the source of truth; sync plugin.json to it:');
+    for (const v of parityViolations) console.error(`  ${v.name}: ${v.path}`);
     process.exit(1);
   }
 

--- a/scripts/sync-codex-manifests.mjs
+++ b/scripts/sync-codex-manifests.mjs
@@ -21,7 +21,7 @@ const PLUGINS_DIR = join(ROOT, 'plugins');
 // deepwiki and project-init were here but are now dual-surface (command + skill);
 // the skill side is what Codex loads, so they leave the EXCLUDED set.
 //   codex-image — Claude->Codex bridge (delegates to codex exec); bridging into Codex is circular
-const EXCLUDED = new Set(['core-config', 'codex-image']);
+import { CODEX_EXCLUDED as EXCLUDED } from './manifest-eligibility.mjs';
 
 // Codex 0.135 manifest top-level supports only `skills`, `hooks`, `mcpServers`, `apps`
 // (see ~/.codex/skills/.system/plugin-creator/references/plugin-json-spec.md). `commands`
@@ -192,11 +192,11 @@ function validateDescriptionParity(entries) {
   const violations = [];
   for (const entry of entries) {
     const manifestPath = join(PLUGINS_DIR, entry.name, '.claude-plugin', 'plugin.json');
-    if (!isFile(manifestPath)) continue;
+    if (!isFile(manifestPath)) { violations.push({ name: entry.name, path: manifestPath, reason: 'missing plugin.json' }); continue; }
     let parsed;
-    try { parsed = JSON.parse(readFileSync(manifestPath, 'utf8')); } catch { continue; }
+    try { parsed = JSON.parse(readFileSync(manifestPath, 'utf8')); } catch { violations.push({ name: entry.name, path: manifestPath, reason: 'unparseable plugin.json' }); continue; }
     if ((parsed.description || '') !== (entry.description || '')) {
-      violations.push({ name: entry.name, path: manifestPath });
+      violations.push({ name: entry.name, path: manifestPath, reason: 'description drift' });
     }
   }
   return violations;
@@ -219,7 +219,7 @@ function main() {
   const parityViolations = validateDescriptionParity(source.plugins);
   if (parityViolations.length > 0) {
     console.error('plugin.json description drift — marketplace.json is the source of truth; sync plugin.json to it:');
-    for (const v of parityViolations) console.error(`  ${v.name}: ${v.path}`);
+    for (const v of parityViolations) console.error(`  ${v.name}: ${v.reason} (${v.path})`);
     process.exit(1);
   }
 

--- a/scripts/sync-hermes-manifests.mjs
+++ b/scripts/sync-hermes-manifests.mjs
@@ -25,15 +25,7 @@ const PLUGINS_DIR = join(ROOT, 'plugins');
 // EXCLUDED denylist) — add a name here to extend Hermes coverage in a later round.
 // Intentionally absent: core-config (no skills to register), codex-image (codex
 // CLI dependency + redundant with Hermes native image generation).
-const HERMES_ELIGIBLE = new Set([
-  'github-dev',
-  'interview',
-  'anti-slop-design',
-  'tcrei-prompt',
-  'ppt-yeong-style',
-  'ml-toolkit',
-  'brightdata-guide',
-]);
+import { HERMES_ELIGIBLE } from './manifest-eligibility.mjs';
 
 const AUTHOR = 'YoungjaeDev';
 


### PR DESCRIPTION
## 개요

문서 정합성(doc-integrity) 스윕과 함께, 다시 드리프트가 나지 않도록 두 개의 자동 가드(설명 SoT parity, 문서 name-set/카운트 일관성)와 Hermes 어댑터 mock-load CI를 추가했다. `Closes #116`.

## 변경 내용 (이슈 9단계 + Part 3 가드)

1. **paper-search-tools MCP 도구명** — 문서의 도구명을 실제 플러그인 로딩 프리픽스 `mcp__plugin_paper-search-tools_paper-search__*` 로 교정하고, standalone `.mcp.json` 등록 시의 `mcp__paper-search__*` 형태를 병기하는 "Tool Naming" 노트 추가. Codex 프리픽스는 이 세션에서 검증 불가라 `unverified` 로 명시. 같은 잘못된 프리픽스가 있던 code-scout `paper-scout.md`·`axis-contracts.md` 도 스윕 차원에서 함께 교정.
2. **project-init** — `/code-scout:scout`(deprecated 스텁) → `Skill("code-scout:research-orchestrator")` (CLAUDE.md, references/new-procedure.md).
3. **rules-forge** — 삭제된 `codex-bridge` 참조 3곳 정리: CLAUDE.md·rule-file.md 는 `.claude/rules/dual-integration.md` 로, rule-categories.md 의 `plugins/codex-bridge/tests/*.test.mjs` 예시는 현존하는 `plugins/github-dev/skills/cr-fix/tests/` fixture 스위트로 교체.
4. **설명 SoT parity 가드** — `sync-codex-manifests.mjs --check` 에 `plugin.json` ↔ `marketplace.json` 설명 불일치 시 FAIL 하는 pair-comparison 추가(marketplace.json 이 SoT). 실측 드리프트는 **19개**(이슈 추정 ~6보다 많음)였고 전부 `plugin.json` 설명을 marketplace 값으로 동기화. Node-18 builtins 만 사용, 신규 의존성 없음.
5. **미소비 `version:` frontmatter 제거** — tcrei-prompt, slidev SKILL.md (어떤 런타임도 소비하지 않음).
6. **위생(hygiene)** — `.gitignore` 에 `.pytest_cache/` 추가(추적 중인 캐시 없음 확인). stale 텍스트 교정: notebook `search_replace`(존재하지 않는 도구) → `Bash(sed/cat)`, idempotent-seed.sh 의 `codex-bridge` 인용 → 3-런타임 공유 근거로 재작성, mem0-ops `_api.py` REST 서피스 노트(`v1 entities/delete` → 실제 엔드포인트 반영). `install-skills.mjs` selftest 를 **23/52** 로 교정하고 `--help`(exit 0) 추가.
7. **플러그인 카운트 정규화** — README 트리에 누락됐던 `e2e-harness`·`tally-form`, AGENTS 트리에 누락됐던 `gws-sync` 추가. 카운트 문자열(24 total / 22 Codex-eligible / 7 Hermes)은 실측상 이미 정확·일관이라 그대로 유지(아래 주석 참조).
8. **Hermes 어댑터 mock-load CI** — `scripts/mock-load-hermes.py` 추가: 생성된 각 `plugins/<name>/__init__.py` 를 stub `ctx` 로 import 해 `register_skill` 호출이 skill 수만큼 발생하는지 검증. "생성됐지만 실행된 적 없는" 어댑터 파손을 잡는다. validate 워크플로에 스텝 추가(PyYAML 은 runner 프리인스톨).
9. **버전 범프 + 재생성** — 변경된 20개 플러그인 PATCH 범프(19 설명-동기화 + mem0-ops), `metadata.version` → **1.98.0**, Codex/Hermes 매니페스트 재생성.

### Part 3 — 문서 일관성 가드
`scripts/check-doc-consistency.mjs` 추가: marketplace 플러그인 name-set 이 README·AGENTS 구조 트리와 AGENTS `## Plugins` 표의 name-set 과 일치하는지, 그리고 카운트 문자열(total/Codex-eligible/Hermes)이 맞는지 검증. `.githooks/pre-commit` + validate 워크플로에 등록.

## 카운트 22 vs 23 주석
이슈는 "23 Codex-manifest" 로 적었으나, 실측 Codex-**eligible 플러그인**은 22개(24 − core-config − codex-image)이고 `codex plugin list` 도 22를 반환한다. "23"은 `--check` 가 보고하는 **매니페스트 파일 수**(22 plugin manifest + 1 catalog)로 per-plugin 문서 카운트가 아니다. 레포의 `plugin-versioning.md` 도 eligible=22 를 명시하므로 문서 카운트는 22로 유지했다.

## 검증 (모두 로컬 실행)
- `node scripts/sync-codex-manifests.mjs --check` → `up to date (23 manifests)`
- `node scripts/sync-hermes-manifests.mjs --check` → `up to date (14 adapter files, 7 plugins)`
- `node scripts/check-doc-consistency.mjs` → `OK (24 plugins, Codex 22, Hermes 7)`. **Seed 검증**: README 트리에서 `e2e-harness` 제거 → `EXIT=1` (`missing e2e-harness`), 복원 → `EXIT=0`.
- `python3 scripts/mock-load-hermes.py` → `OK — 7 adapters`. **Seed 검증**: `github-dev/__init__.py` 에 구문 오류 주입 → `EXIT=1` (`SyntaxError`), 재생성으로 복원 → `EXIT=0` (git diff 없음).
- `node scripts/install-skills.mjs --selftest` → `23 plugins, 52 skills` (EXIT=0); `--help` → EXIT=0.
- `.githooks/pre-commit` 전체 → `70 passed, 0 failed` + 모든 가드 통과.

## 참고
- 워크플로 파일명은 `validate-codex.yml` 로 **유지**(rename 안 함, 이슈상 optional). blast radius 최소화 — 대신 헤더 주석에 doc-consistency·adapter mock-load 추가를 반영.
- 생성 파일(`.agents/**`, `.codex-plugin/**`, `plugin.yaml`, `__init__.py`)은 손편집 없이 전부 생성기로 재생성.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stronger validation for documentation consistency and generated integrations.
  * Added clearer command-line help and updated self-test expectations.
  * Improved notebook and presentation skill tool controls.

* **Documentation**
  * Updated plugin listings and counts across project documentation.
  * Clarified paper-search tool naming and usage guidance.
  * Refreshed descriptions and workflows for multiple plugins.

* **Chores**
  * Released updated versions across the plugin catalog.
  * Added pytest cache exclusions and expanded pre-commit validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->