### PR TITLE
fix(github-dev): cr-fix path-trust works on BSD/macOS userland (#152)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Personal Claude Code plugin collection with 24 specialized plugins. Codex 0.135 + Hermes Agent native — generated `.agents/plugins/marketplace.json` + per-plugin `.codex-plugin/plugin.json` (`scripts/sync-codex-manifests.mjs`) and Hermes `plugin.yaml` + `__init__.py` adapters (`scripts/sync-hermes-manifests.mjs`).",
-    "version": "2.5.5"
+    "version": "2.5.6"
   },
   "plugins": [
     {
@@ -19,7 +19,7 @@
       "name": "github-dev",
       "source": "./plugins/github-dev",
       "description": "GitHub workflow: commit, PR, issue, worktree, unified CodeRabbit + ChatGPT-Codex cr-fix pipeline v2 (Step 5 pre-flight review detection across CR commit-status + comments + Codex reviews + Codex emoji 3-channel; autonomous Step 9 judgment replaces per-finding AskUserQuestion — LLM judges real/spurious + severity + fix-size and applies/defers/skips with logged reasoning; rate-limit sniffer now covers commit-status description + in-place comment edits; polling interval 60s → 8s; --auto-merge + --skip-minor + --cr-source retained), project tracking, release. All workflows are now skills (commit-and-push, create-issue-label, decompose-issue, update-progress, resolve-issue, release, cr-fix, post-merge) — no commands surface, so they run under Codex too. post-merge runs a mandatory built-in wiki-lore ingest step (absorbed llm-wiki:post-merge-wiki) plus an optional Step 4.5 ephemeral-artifact pruning gate (heuristic candidates → AskUserQuestion → git rm). 2.8.0 correctness repairs: CR-state fetch failures map to a real error channel (no longer masked as a clean 'none'), a null-repository GraphQL response fails loudly instead of a silent false-clean convergence, and an active `@coderabbitai rate limit` query resolves ambiguous passive rate-limit sniffs.",
-      "version": "2.10.0",
+      "version": "2.10.1",
       "category": "github"
     },
     {

--- a/plugins/github-dev/.claude-plugin/plugin.json
+++ b/plugins/github-dev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "github-dev",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "description": "GitHub workflow: commit, PR, issue, worktree, unified CodeRabbit + ChatGPT-Codex cr-fix pipeline v2 (Step 5 pre-flight review detection across CR commit-status + comments + Codex reviews + Codex emoji 3-channel; autonomous Step 9 judgment replaces per-finding AskUserQuestion — LLM judges real/spurious + severity + fix-size and applies/defers/skips with logged reasoning; rate-limit sniffer now covers commit-status description + in-place comment edits; polling interval 60s → 8s; --auto-merge + --skip-minor + --cr-source retained), project tracking, release. All workflows are now skills (commit-and-push, create-issue-label, decompose-issue, update-progress, resolve-issue, release, cr-fix, post-merge) — no commands surface, so they run under Codex too. post-merge runs a mandatory built-in wiki-lore ingest step (absorbed llm-wiki:post-merge-wiki) plus an optional Step 4.5 ephemeral-artifact pruning gate (heuristic candidates → AskUserQuestion → git rm). 2.8.0 correctness repairs: CR-state fetch failures map to a real error channel (no longer masked as a clean 'none'), a null-repository GraphQL response fails loudly instead of a silent false-clean convergence, and an active `@coderabbitai rate limit` query resolves ambiguous passive rate-limit sniffs.",
   "skills": [
     "./skills/cr-fix",

--- a/plugins/github-dev/.codex-plugin/plugin.json
+++ b/plugins/github-dev/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "github-dev",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "description": "GitHub workflow: commit, PR, issue, worktree, unified CodeRabbit + ChatGPT-Codex cr-fix pipeline v2 (Step 5 pre-flight review detection across CR commit-status + comments + Codex reviews + Codex emoji 3-channel; autonomous Step 9 judgment replaces per-finding AskUserQuestion — LLM judges real/spurious + severity + fix-size and applies/defers/skips with logged reasoning; rate-limit sniffer now covers commit-status description + in-place comment edits; polling interval 60s → 8s; --auto-merge + --skip-minor + --cr-source retained), project tracking, release. All workflows are now skills (commit-and-push, create-issue-label, decompose-issue, update-progress, resolve-issue, release, cr-fix, post-merge) — no commands surface, so they run under Codex too. post-merge runs a mandatory built-in wiki-lore ingest step (absorbed llm-wiki:post-merge-wiki) plus an optional Step 4.5 ephemeral-artifact pruning gate (heuristic candidates → AskUserQuestion → git rm). 2.8.0 correctness repairs: CR-state fetch failures map to a real error channel (no longer masked as a clean 'none'), a null-repository GraphQL response fails loudly instead of a silent false-clean convergence, and an active `@coderabbitai rate limit` query resolves ambiguous passive rate-limit sniffs.",
   "author": {
     "name": "YoungjaeDev"

--- a/plugins/github-dev/plugin.yaml
+++ b/plugins/github-dev/plugin.yaml
@@ -1,5 +1,5 @@
 name: github-dev
-version: "2.10.0"
+version: "2.10.1"
 description: "GitHub workflow: commit, PR, issue, worktree, unified CodeRabbit + ChatGPT-Codex cr-fix pipeline v2 (Step 5 pre-flight review detection across CR commit-status + comments + Codex reviews + Codex emoji 3-channel; autonomous Step 9 judgment replaces per-finding AskUserQuestion — LLM judges real/spurious + severity + fix-size and applies/defers/skips with logged reasoning; rate-limit sniffer now covers commit-status description + in-place comment edits; polling interval 60s → 8s; --auto-merge + --skip-minor + --cr-source retained), project tracking, release. All workflows are now skills (commit-and-push, create-issue-label, decompose-issue, update-progress, resolve-issue, release, cr-fix, post-merge) — no commands surface, so they run under Codex too. post-merge runs a mandatory built-in wiki-lore ingest step (absorbed llm-wiki:post-merge-wiki) plus an optional Step 4.5 ephemeral-artifact pruning gate (heuristic candidates → AskUserQuestion → git rm). 2.8.0 correctness repairs: CR-state fetch failures map to a real error channel (no longer masked as a clean 'none'), a null-repository GraphQL response fails loudly instead of a silent false-clean convergence, and an active `@coderabbitai rate limit` query resolves ambiguous passive rate-limit sniffs."
 author: "YoungjaeDev"
 kind: standalone

--- a/plugins/github-dev/skills/cr-fix/scripts/path-trust.sh
+++ b/plugins/github-dev/skills/cr-fix/scripts/path-trust.sh
@@ -16,8 +16,17 @@ case "$P" in
   *../*|*/..|..) echo "untrusted-path: .. segment: $P" >&2; exit 1;;
 esac
 
-abs=$(realpath -m -- "$REPO_ROOT/$P")
-repo_abs=$(realpath -- "$REPO_ROOT")
+# `realpath -m` is GNU-only (BSD/macOS realpath rejects it), and bare `realpath`
+# is no substitute: both GNU and BSD error on a path that does not exist yet,
+# which cr-fix needs to validate for files a fix is about to create. `cd` + `pwd -P`
+# is POSIX and resolves symlinks the same way, so the containment check below keeps
+# its meaning on macOS, Linux, and Git Bash alike. `..` segments are already
+# rejected above, so only the parent needs resolving.
+parent=$(cd "$(dirname -- "$REPO_ROOT/$P")" 2>/dev/null && pwd -P) \
+  || { echo "untrusted-path: unresolvable parent: $P" >&2; exit 1; }
+abs="$parent/$(basename -- "$P")"
+repo_abs=$(cd "$REPO_ROOT" 2>/dev/null && pwd -P) \
+  || { echo "untrusted-path: unresolvable repo root: $REPO_ROOT" >&2; exit 1; }
 case "$abs" in
   "$repo_abs"/*|"$repo_abs") ;;
   *) echo "untrusted-path: resolves outside repo: $P → $abs" >&2; exit 1;;

--- a/plugins/github-dev/skills/cr-fix/scripts/path-trust.sh
+++ b/plugins/github-dev/skills/cr-fix/scripts/path-trust.sh
@@ -18,13 +18,34 @@ esac
 
 # `realpath -m` is GNU-only (BSD/macOS realpath rejects it), and bare `realpath`
 # is no substitute: both GNU and BSD error on a path that does not exist yet,
-# which cr-fix needs to validate for files a fix is about to create. `cd` + `pwd -P`
-# is POSIX and resolves symlinks the same way, so the containment check below keeps
-# its meaning on macOS, Linux, and Git Bash alike. `..` segments are already
-# rejected above, so only the parent needs resolving.
-parent=$(cd "$(dirname -- "$REPO_ROOT/$P")" 2>/dev/null && pwd -P) \
-  || { echo "untrusted-path: unresolvable parent: $P" >&2; exit 1; }
-abs="$parent/$(basename -- "$P")"
+# which cr-fix needs to validate for files a fix is about to create.
+#
+# Resolving only the parent is NOT enough: if the final component is itself a
+# symlink pointing outside the repo, the reconstructed path still looks in-repo
+# and the containment check below passes, letting a downstream Edit write outside
+# the trust boundary. So follow a final-component symlink chain too, re-resolving
+# the parent each hop. `cd` + `pwd -P` + `readlink` are portable across macOS,
+# Linux, and Git Bash. `..` segments are already rejected above.
+resolve_path() {
+  _p="$1" _n=0
+  while :; do
+    _d=$(dirname -- "$_p"); _b=$(basename -- "$_p")
+    _d=$(cd "$_d" 2>/dev/null && pwd -P) || return 1
+    _p="$_d/$_b"
+    [ -L "$_p" ] || break
+    _n=$((_n + 1))
+    [ "$_n" -gt 40 ] && return 1   # symlink loop / excessive nesting
+    _link=$(readlink -- "$_p") || return 1
+    case "$_link" in
+      /*) _p="$_link" ;;
+      *)  _p="$_d/$_link" ;;
+    esac
+  done
+  printf '%s\n' "$_p"
+}
+
+abs=$(resolve_path "$REPO_ROOT/$P") \
+  || { echo "untrusted-path: unresolvable path: $P" >&2; exit 1; }
 repo_abs=$(cd "$REPO_ROOT" 2>/dev/null && pwd -P) \
   || { echo "untrusted-path: unresolvable repo root: $REPO_ROOT" >&2; exit 1; }
 case "$abs" in

--- a/plugins/github-dev/skills/cr-fix/tests/run-tests.sh
+++ b/plugins/github-dev/skills/cr-fix/tests/run-tests.sh
@@ -594,11 +594,18 @@ echo "path-trust.sh"
 # and the gate's `|| { skip; continue; }` branch turned that into "every finding
 # is untrusted", converging the loop to a false `final_state=clean` (issue #152).
 PT="$SCRIPTS/path-trust.sh"
-PT_ROOT=$(mktemp -d); trap 'rm -rf "$PT_ROOT"' EXIT
-mkdir -p "$PT_ROOT/sub/nested" "$PT_ROOT/../pt-outside-$$"
-: > "$PT_ROOT/README.md"; : > "$PT_ROOT/sub/nested/deep.txt"
+PT_ROOT=$(mktemp -d); PT_OUT=$(mktemp -d)
+trap 'rm -rf "$PT_ROOT" "$PT_OUT"' EXIT
+mkdir -p "$PT_ROOT/sub/nested"
+: > "$PT_ROOT/README.md"; : > "$PT_ROOT/sub/nested/deep.txt"; : > "$PT_OUT/secret.txt"
 
-pt() { bash "$PT" "$PT_ROOT" "$1" >/dev/null 2>&1; printf '%s' "$?"; }
+# `env -i PATH=/usr/bin:/bin` on purpose: a GNU-rich runner (or Claude Code's
+# grep->ugrep shell function) otherwise masks exactly the BSD portability breaks
+# these cases exist to catch.
+pt() {
+  env -i PATH=/usr/bin:/bin bash "$PT" "$PT_ROOT" "$1" >/dev/null 2>&1
+  printf '%s' "$?"
+}
 
 is "in-repo file at root"            "$(pt 'README.md')"            0
 is "in-repo nested file"             "$(pt 'sub/nested/deep.txt')"  0
@@ -610,10 +617,20 @@ is "parent escape rejected"          "$(pt '../escape.md')"         1
 is "mid-path .. rejected"            "$(pt 'sub/../../escape.md')"  1
 is "absolute path rejected"          "$(pt '/etc/passwd')"          1
 is "home-relative rejected"          "$(pt '~/secrets')"            1
-# A symlink pointing outside the repo must not smuggle a write past the gate.
-ln -s "$PT_ROOT/../pt-outside-$$" "$PT_ROOT/link-out" 2>/dev/null \
-  && is "symlink escaping repo rejected" "$(pt 'link-out/x.md')" 1 \
-  || ok "symlink escaping repo rejected (skipped: ln -s unavailable)"
+# Symlinks must not smuggle a write past the gate. Two distinct shapes: a symlinked
+# DIRECTORY component (caught by parent resolution) and a symlinked FINAL component
+# (needs the link chain followed — resolving only the parent leaves `abs` looking
+# in-repo while the write lands outside). An explicit if/else, not `&& ... || ok`,
+# so a real regression fails the suite instead of being reported as skipped.
+if ln -s "$PT_OUT" "$PT_ROOT/link-dir" 2>/dev/null \
+   && ln -s "$PT_OUT/secret.txt" "$PT_ROOT/link-file.md" 2>/dev/null \
+   && ln -s "sub/nested/deep.txt" "$PT_ROOT/link-inside.md" 2>/dev/null; then
+  is "symlinked dir component escaping repo rejected"   "$(pt 'link-dir/x.md')"    1
+  is "symlinked final component escaping repo rejected" "$(pt 'link-file.md')"     1
+  is "symlink staying inside repo allowed"              "$(pt 'link-inside.md')"   0
+else
+  ok "symlink escape cases (skipped: ln -s unavailable)"
+fi
 # Nonexistent intermediate dir has no resolvable parent — reject, do not crash.
 is "unresolvable parent rejected"    "$(pt 'no/such/dir/f.md')"     1
 

--- a/plugins/github-dev/skills/cr-fix/tests/run-tests.sh
+++ b/plugins/github-dev/skills/cr-fix/tests/run-tests.sh
@@ -587,5 +587,36 @@ gcap2=$(bash -euo pipefail -c '
 is "grace-cap codex_wait: pre-flight remaining wins" "$gcap2" 500
 
 echo
+echo "path-trust.sh"
+
+# The Step 9c gate runs this per finding. It used GNU-only `realpath -m`, so on
+# BSD/macOS it aborted under `set -e` for EVERY path — including valid ones —
+# and the gate's `|| { skip; continue; }` branch turned that into "every finding
+# is untrusted", converging the loop to a false `final_state=clean` (issue #152).
+PT="$SCRIPTS/path-trust.sh"
+PT_ROOT=$(mktemp -d); trap 'rm -rf "$PT_ROOT"' EXIT
+mkdir -p "$PT_ROOT/sub/nested" "$PT_ROOT/../pt-outside-$$"
+: > "$PT_ROOT/README.md"; : > "$PT_ROOT/sub/nested/deep.txt"
+
+pt() { bash "$PT" "$PT_ROOT" "$1" >/dev/null 2>&1; printf '%s' "$?"; }
+
+is "in-repo file at root"            "$(pt 'README.md')"            0
+is "in-repo nested file"             "$(pt 'sub/nested/deep.txt')"  0
+# The whole reason `-m` was there: a fix may create a file that does not exist yet.
+is "not-yet-created file in repo"    "$(pt 'sub/brand-new.md')"     0
+is "not-yet-created nested dir file" "$(pt 'sub/nested/new.txt')"   0
+# Containment must still hold.
+is "parent escape rejected"          "$(pt '../escape.md')"         1
+is "mid-path .. rejected"            "$(pt 'sub/../../escape.md')"  1
+is "absolute path rejected"          "$(pt '/etc/passwd')"          1
+is "home-relative rejected"          "$(pt '~/secrets')"            1
+# A symlink pointing outside the repo must not smuggle a write past the gate.
+ln -s "$PT_ROOT/../pt-outside-$$" "$PT_ROOT/link-out" 2>/dev/null \
+  && is "symlink escaping repo rejected" "$(pt 'link-out/x.md')" 1 \
+  || ok "symlink escaping repo rejected (skipped: ln -s unavailable)"
+# Nonexistent intermediate dir has no resolvable parent — reject, do not crash.
+is "unresolvable parent rejected"    "$(pt 'no/such/dir/f.md')"     1
+
+echo
 printf '%d passed, %d failed\n' "$pass" "$fail"
 [ "$fail" -eq 0 ]


### PR DESCRIPTION
Closes #152

## Problem

`path-trust.sh:19` used GNU-only `realpath -m`. BSD/macOS realpath rejects the flag, so under `set -euo pipefail` the script exited 1 for **every** path — valid in-repo ones included.

```
$ bash plugins/github-dev/skills/cr-fix/scripts/path-trust.sh "$PWD" AGENTS.md
realpath: illegal option -- m   # rc=1
```

The Step 9c gate reads a non-zero exit as "untrusted path" and `continue`s, so every finding was skipped **without being read**. `applied_this_cycle` / `deferred_this_cycle` stayed 0, so Step 13 declared `final_state=clean` — the one state that is auto-merge eligible. A false-clean review was indistinguishable from a real one, and `--auto-merge` could merge a PR with unresolved CRITICAL findings.

`resolve-issue` Step 10.5 drives cr-fix ON by default, so this hit the normal path with no flag.

## Fix

`cd` + `pwd -P` on the resolved parent, then re-append the basename.

Bare `realpath` would not work: GNU and BSD both error on a path that does not exist yet, and cr-fix must validate paths for files a fix is about to *create* — which is exactly why `-m` was there. `cd` + `pwd -P` is POSIX, resolves symlinks identically, and keeps containment meaningful on macOS, Linux, and Git Bash alike.

## Tests

First coverage for `path-trust.sh` (it had none, which is why CI never caught this). 10 cases: in-repo root/nested, not-yet-created file and nested-dir file, parent escape, mid-path `..`, absolute, home-relative, symlink escaping the repo, unresolvable parent.

**Verified RED** against the old code — it fails all four should-pass cases while the reject cases still pass, the exact "everything rejected" signature:

```
FAIL in-repo file at root          expected: 0  actual: 1
FAIL in-repo nested file           expected: 0  actual: 1
FAIL not-yet-created file in repo  expected: 0  actual: 1
FAIL not-yet-created nested dir    expected: 0  actual: 1
80 passed, 4 failed
```

After the fix: **84 passed, 0 failed** (baseline 74 + 10 new).

## Verification

- `bash plugins/github-dev/skills/cr-fix/tests/run-tests.sh` → 84/0
- All four drift guards pass (`sync-codex-manifests`, `sync-hermes-manifests`, `check-doc-consistency`, `check-skill-tool-portability`)
- Verified under `env -i PATH=/usr/bin:/bin` — Claude Code routes `grep` through a ugrep shell function, so an interactive shell masks BSD-userland breaks; hooks and Codex/Hermes do not inherit that shim
- `github-dev` 2.10.0 → 2.10.1, `metadata.version` 2.5.5 → 2.5.6 (re-checked against `origin/main` for the concurrent-bump trap); Codex manifest + Hermes adapter regenerated

## Context

First of two PRs from a macOS/BSD compatibility sweep. This one lands alone and first: until cr-fix's path-trust gate works, the review on any follow-up PR silently skips every finding. The remaining fixes (llm-wiki `grep -oP` cluster, `date -d` fallback, `.gitattributes` for Windows CRLF, pre-commit node/PyYAML guards) follow in a second issue that depends on this.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved path validation to be portable across macOS, BSD, and other environments.
  * Correctly handles in-repository paths (including entries that don’t exist yet).
  * Strengthened safeguards against path traversal, absolute paths, home-relative paths, and symlink-based escapes.

* **Tests**
  * Added an isolated test suite covering trusted vs. rejected path scenarios, including unresolved parent directories and platform-specific symlink availability.

* **Chores**
  * Bumped plugin catalog metadata and the GitHub development plugin version to **2.10.1**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
