### PR TITLE
feat(plaud-note-taking): add PLAUD note review plugin

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -279,6 +279,18 @@
         "authentication": "ON_INSTALL"
       },
       "category": "productivity"
+    },
+    {
+      "name": "plaud-note-taking",
+      "source": {
+        "source": "local",
+        "path": "./plugins/plaud-note-taking"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "productivity"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,8 +4,8 @@
     "name": "YoungjaeDev"
   },
   "metadata": {
-    "description": "Personal Claude Code plugin collection with 24 specialized plugins. Codex 0.135 + Hermes Agent native — generated `.agents/plugins/marketplace.json` + per-plugin `.codex-plugin/plugin.json` (`scripts/sync-codex-manifests.mjs`) and Hermes `plugin.yaml` + `__init__.py` adapters (`scripts/sync-hermes-manifests.mjs`).",
-    "version": "2.5.9"
+    "description": "Personal Claude Code plugin collection with 25 specialized plugins. Codex 0.135 + Hermes Agent native — generated `.agents/plugins/marketplace.json` + per-plugin `.codex-plugin/plugin.json` (`scripts/sync-codex-manifests.mjs`) and Hermes `plugin.yaml` + `__init__.py` adapters (`scripts/sync-hermes-manifests.mjs`).",
+    "version": "2.6.0"
   },
   "plugins": [
     {
@@ -174,6 +174,13 @@
       "source": "./plugins/mem0-ops",
       "description": "Fleet-level mem0 diagnostics and cleanup — complements the upstream mem0 plugin (which owns per-project quality). fleet-scan reports per-app noise ratio, junk app_id candidates, and app/user_id fragmentation across all apps; doctor checks config posture (MEM0_RERANK env, ~/.mem0/settings.json auto_save precedence trap, project decay flag, hook timeout budget, identity fragmentation); cleanup does backup-then-delete by metadata.type or whole junk app behind a dry-run default plus a skill-layer per-app confirmation gate (the script alone gates on --execute only). stdlib-only REST scripts, zero LLM cost for the deterministic parts.",
       "version": "0.1.2",
+      "category": "productivity"
+    },
+    {
+      "name": "plaud-note-taking",
+      "source": "./plugins/plaud-note-taking",
+      "description": "Review and correct PLAUD voice-recorder notes (Whisper transcript + separate LLM summary). Fixes STT misrecognition (Korean+English code-switching, proper nouns, numbers) against a project term dictionary, grill-me interviews to resolve ambiguities, and writes a transcript-grounded *.corrected.md back to .llmwiki/raw/transcripts without touching the originals.",
+      "version": "0.1.0",
       "category": "productivity"
     }
   ]

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -24,7 +24,8 @@
       "./plugins/codex-image",
       "./plugins/brightdata-guide",
       "./plugins/gws-sync",
-      "./plugins/mem0-ops"
+      "./plugins/mem0-ops",
+      "./plugins/plaud-note-taking"
     ]
   }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@
 
 플러그인 트리 하나를 Claude Code, Codex 0.135(`scripts/sync-codex-manifests.mjs`), Hermes Agent(`scripts/sync-hermes-manifests.mjs`)가 함께 읽습니다 — one source, three runtimes.
 
-## Plugins (24)
+## Plugins (25)
 
 ### Core
 | Plugin | Description |
@@ -85,6 +85,7 @@
 | Plugin | Description |
 |--------|-------------|
 | `gws-sync` | 로컬 → Google Drive 단방향 제안형 동기화 (gws CLI 기반). 매핑 설정(`.gws-sync.json`) → Drive 트리 탐색 → 신규·변경 diff 리포트 → 업로드 위치 AskUserQuestion 승인 → 업로드(기존 파일 content update로 ID·공유링크 보존). 삭제는 제안만. gws 미설치 시 설치 안내 후 중단. googleworkspace/cli 스킬 95종 카탈로그 동봉 |
+| `plaud-note-taking` | PLAUD 음성 녹음 노트 검토·정정. PLAUD는 녹음당 **Whisper 전사록 + 별도 LLM 요약** 두 산출물을 내며, 이 스킬은 **요약이 아니라 전사록을 기준**으로 STT 오인식(한·영 코드스위칭·고유명사·수치)을 프로젝트 용어 사전(`terminology.md`)에 맞춰 정정한다. 애매한 담당자·기한·수치·화자 귀속과 "요약이 지어낸 결정"은 `interview:interview-methodology` relentless(grill-me) 위임으로 캐물어 확정하고, 원본은 손대지 않고 `.llmwiki/raw/transcripts/`에 `*.corrected.md`를 쓴다. 입력은 손으로 올린 `*.transcript.txt`(+`*.note.txt`) |
 
 ### Memory & Lore
 | Plugin | Description |
@@ -129,6 +130,7 @@
 │   ├── ppt-yeong-style/    # yeong-style lecture/proposal deck writing layer (on ppt-master)
 │   ├── tally-form/         # Checklist md -> Tally questionnaire/survey form builder
 │   ├── gws-sync/           # Local -> Google Drive one-way proposal sync
+│   ├── plaud-note-taking/  # PLAUD note (Whisper transcript + LLM summary) STT + terminology correction
 │   └── project-init/       # Day-1 bootstrap (new) + existing-repo setup diagnostic (wiring)
 ├── AGENTS.md               # This file — 정본
 ├── CLAUDE.md               # @AGENTS.md import (한 줄)
@@ -183,7 +185,7 @@
 | Hermes | `clarify` |
 
 - 새 스킬 본문이 `AskUserQuestion` 을 쓰면 파일럿의 "Cross-runtime interactive input" 블록(위 3런타임 매핑)을 같이 넣거나, 이관을 미룰 경우 `scripts/check-skill-tool-portability.mjs` 의 baseline 에 등록한다. `scripts/check-skill-tool-portability.mjs --check` 가 `.githooks/pre-commit` + `.github/workflows/validate-codex.yml` 에서 이를 강제한다 — 파일럿은 표준 매핑을, baseline 은 등록 사실을, 그 외 새 경로는 실패로 잡는다.
-- **Follow-up debt (#123):** 현재 파일럿은 `interview:interview-methodology` 와 `github-dev:decompose-issue` 2개뿐이다. 나머지 18개 스킬(baseline)은 아직 body 에서 `AskUserQuestion` 을 실제로 하드코딩하고 있으며, 표준 매핑으로의 이관은 후속 플릿 작업으로 의도적으로 미룬다. Hermes 호환표 행이나 frontmatter `allowed-tools:` 에만 `AskUserQuestion` 이 있고 실제 대화 게이트가 없는 스킬은 debt 가 아니라 가드가 제외한다. baseline 에서 파일럿으로 옮기며 점진 이관한다.
+- **Follow-up debt (#123):** 현재 파일럿은 `interview:interview-methodology` 와 `github-dev:decompose-issue` 2개뿐이다. 나머지 19개 스킬(baseline)은 아직 body 에서 `AskUserQuestion` 을 실제로 하드코딩하고 있으며, 표준 매핑으로의 이관은 후속 플릿 작업으로 의도적으로 미룬다. Hermes 호환표 행이나 frontmatter `allowed-tools:` 에만 `AskUserQuestion` 이 있고 실제 대화 게이트가 없는 스킬은 debt 가 아니라 가드가 제외한다. baseline 에서 파일럿으로 옮기며 점진 이관한다.
 
 ## 플러그인 변경 규칙
 
@@ -259,7 +261,7 @@ node scripts/sync-codex-manifests.mjs --check   # CI drift guard
 ```
 
 - Claude 와 Codex 0.135 가 **동일한** `plugins/<name>/` 트리를 직접 읽습니다. 별도 mirror / body transform 없음 (구 `codex-bridge` 플러그인은 1.40.0 에서 제거). Skill 본문은 in-place 로 읽히므로 transform 이 없고, frontmatter 유효성만 남습니다.
-- 생성물은 `.agents/plugins/marketplace.json` + 플러그인별 `.codex-plugin/plugin.json`, eligible 23개 대상. `.agents/` 와 `plugins/<name>/.codex-plugin/` 하위 파일은 손으로 편집하지 마세요 — `scripts/sync-codex-manifests.mjs` 가 진실의 원천입니다.
+- 생성물은 `.agents/plugins/marketplace.json` + 플러그인별 `.codex-plugin/plugin.json`, eligible 24개 대상. `.agents/` 와 `plugins/<name>/.codex-plugin/` 하위 파일은 손으로 편집하지 마세요 — `scripts/sync-codex-manifests.mjs` 가 진실의 원천입니다.
 - 새 플러그인 추가 / 기존 플러그인의 `version` / `description` / `category` 변경 시 반드시 `node scripts/sync-codex-manifests.mjs` 를 실행해 매니페스트를 재생성하세요. `--check` 는 플러그인 제거 후 남은 orphan 매니페스트도 감지합니다.
 - Skill `description` frontmatter 는 1024자 미만으로 유지하세요. Codex 0.135 는 1024자 초과 description 을 가진 skill 을 **silent 하게 skip** 합니다 (Claude Code 는 제한이 없어 위반이 안 보임). `--check` 가 drift 외에 description 길이도 검증하고, 공유 `.githooks/pre-commit` 이 매 커밋마다 실행합니다 — clone 당 한 번 `git config core.hooksPath .githooks` 로 활성화하세요. 전체 trigger 목록 / per-tool rationale 는 description 이 아니라 skill 본문에 두세요.
 - Skill `description` frontmatter 에 콜론+공백(`: `) 이 들어가면 반드시 따옴표로 감싸세요 (또는 `>-` block scalar). 안 하면 YAML frontmatter 가 nested mapping 으로 파싱돼 `mapping values are not allowed here` 로 실패하고 skill 이 양쪽 런타임에서 silent 하게 로드 안 됩니다. `plugin.json` / `marketplace.json` 은 JSON 이라 무관; lenient 매니페스트 생성기와 `--check` 는 못 잡습니다.
@@ -297,7 +299,7 @@ node scripts/sync-hermes-manifests.mjs --check
 
 ```bash
 codex plugin marketplace add ~/.claude/plugins/marketplaces/my-claude-plugins
-codex plugin list --marketplace my-claude-plugins   # 23 entries
+codex plugin list --marketplace my-claude-plugins   # 24 entries
 codex plugin marketplace remove my-claude-plugins   # 검증 후 정리
 ```
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
 
 # my-claude-plugins
 
-Claude Code를 위한 24개 플러그인 모음 - GitHub 워크플로우부터 AI 이미지 생성까지. Codex 0.135 와 Hermes Agent 도 동일한 소스 트리를 네이티브로 로드합니다 (shared source).
+Claude Code를 위한 25개 플러그인 모음 - GitHub 워크플로우부터 AI 이미지 생성까지. Codex 0.135 와 Hermes Agent 도 동일한 소스 트리를 네이티브로 로드합니다 (shared source).
 
-[![Plugins](https://img.shields.io/badge/plugins-24-blue.svg)](https://github.com/YoungjaeDev/my-claude-plugins)
+[![Plugins](https://img.shields.io/badge/plugins-25-blue.svg)](https://github.com/YoungjaeDev/my-claude-plugins)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-compatible-purple.svg)](https://docs.anthropic.com/claude-code)
 
@@ -107,6 +107,7 @@ rm -rf ~/.claude/plugins/cache/my-claude-plugins/
 | **Design** | `anti-slop-design` | 웹/SaaS 랜딩, 덱(PPT), 대시보드, 카피 anti-AI-slop 가드. clarify→context→plan→run→audit→revise + 2단계 audit gate; 한국어 카피는 `humanize-korean` 위임. 6개 OSS repo 기반 |
 | | `ppt-yeong-style` | yeong 스타일 강의·제안 덱 작성 규약. `ppt-master` 엔진 위 작성 레이어 — 스킬 3종(메인 작성 규약 + `lecture-deck` 강의 덱 운영 + `deck-review` 리뷰 오케스트레이션) + 리뷰 서브에이전트 4종(audience-fit·story-flow·fact-check·design-qa). md 규약·원칙 16종·밀도 리듬·역할 기반 색·앱 UI 실물 강제·전사 회고 루프·스크린샷 슬롯·리넘버링. 진입점 SKILL.md + references/ + 주입 프롬프트 |
 | **Productivity** | `gws-sync` | 로컬 → Google Drive 단방향 제안형 동기화 (gws CLI 기반). 매핑 설정 기억 → Drive 트리 탐색 → 신규·변경 diff 리포트 → 업로드 위치 AskUserQuestion 승인 → 업로드(기존 파일 content update로 ID·공유링크 보존). 삭제는 제안만. gws 미설치 시 설치 안내 후 중단. googleworkspace/cli 스킬 95종 카탈로그(llms.txt) 동봉 |
+| **Productivity** | `plaud-note-taking` | PLAUD 음성 녹음 노트(Whisper 전사록 + 별도 LLM 요약) 검토·정정. **요약이 아니라 전사록 기준**으로 STT 오인식(한·영 코드스위칭·고유명사·수치)을 프로젝트 용어 사전에 맞춰 고치고, 애매한 담당자·기한·수치와 "요약이 지어낸 결정"은 `interview:interview-methodology`(grill-me) 위임으로 캐물어 확정, 원본은 손대지 않고 `.llmwiki/raw/transcripts/`에 `*.corrected.md` 생성 |
 
 ## 설치 옵션
 
@@ -636,6 +637,23 @@ CLAUDE.md 와 `.claude/rules/*.md` 를 Claude Code 2026 공식 패턴
 
 </details>
 
+<details>
+<summary><strong>plaud-note-taking</strong> - PLAUD 노트(전사록+요약) STT·용어 정정</summary>
+
+PLAUD 음성 녹음기가 만든 노트를 검토·정정합니다. PLAUD는 녹음 하나당 **두 산출물**을 냅니다 — Whisper STT **전사록**과, 그 전사록을 다시 LLM이 요약한 **별도 요약**. 이 스킬의 철칙은 **요약이 아니라 전사록을 기준으로 정정**하는 것입니다 (요약은 없던 결정을 매끄럽게 지어낼 수 있음).
+
+**입력/출력:** 손으로 `.llmwiki/raw/transcripts/`에 올린 `<YYYY-MM-DD-slug>.transcript.txt`(+선택 `.note.txt`)를 읽어, 같은 폴더에 `<slug>.corrected.md`를 씁니다. **원본은 절대 수정하지 않습니다.**
+
+**정정 규율(보수적):**
+- STT 최대 오류원인 **한국어+영어 코드스위칭**(기술용어·고유명사)을 `terminology.md` 프로젝트 용어 사전 근거로 정정
+- 숫자·날짜·금액·계약 조건은 추측 금지 → `[확인 필요]`
+- 화자 `Speaker N`은 추정값 — 실명·담당자로 확정하지 않음
+- 태깅: `[확인됨]` / `[정정]` / `[해석]` / `[확인 필요]`
+
+**Open question → grill me:** 애매한 담당자·기한·수치·화자 귀속과 "요약이 지어낸 결정"은 `interview:interview-methodology` relentless 위임으로 하나씩 집요하게 캐물어 확정하고, 남으면 `[확인 필요]`로 둡니다.
+
+</details>
+
 ## Configuration
 
 ### settings.json
@@ -680,7 +698,7 @@ codex plugin marketplace add ~/.claude/plugins/marketplaces/my-claude-plugins
 codex plugin add llm-wiki@my-claude-plugins
 ```
 
-Codex 에서 제외되는 플러그인은 `codex-image` 하나뿐입니다 (Claude->Codex 브리지 — Codex 로 sync 하면 순환). `core-config` 는 skill 이 없지만 번들 Codex hooks (`hooks/codex-hooks.json`) 를 실어 hooks-only 매니페스트로 Codex 에 sync 됩니다 (native `UserPromptSubmit` 훅). 즉 23 / 24 플러그인이 Codex 로 sync 되며 (core-config 는 hooks-only, 나머지는 skill 단위), `deepwiki` 와 `project-init` 은 1.41.0 부터 Claude 에서는 command + skill 양쪽으로, Codex 에서는 skill 로만 동작합니다 (Codex 는 command surface 를 로드하지 않음).
+Codex 에서 제외되는 플러그인은 `codex-image` 하나뿐입니다 (Claude->Codex 브리지 — Codex 로 sync 하면 순환). `core-config` 는 skill 이 없지만 번들 Codex hooks (`hooks/codex-hooks.json`) 를 실어 hooks-only 매니페스트로 Codex 에 sync 됩니다 (native `UserPromptSubmit` 훅). 즉 24 / 25 플러그인이 Codex 로 sync 되며 (core-config 는 hooks-only, 나머지는 skill 단위), `deepwiki` 와 `project-init` 은 1.41.0 부터 Claude 에서는 command + skill 양쪽으로, Codex 에서는 skill 로만 동작합니다 (Codex 는 command surface 를 로드하지 않음).
 
 Codex 0.135 manifest top-level은 `skills` / `hooks` / `mcpServers` / `apps` 만 지원하므로, command-bearing 플러그인(`docs-forge`, `deepwiki` 등)도 Codex 측에는 skill만 노출됩니다 — Claude 측 commands 는 그대로 동작합니다. `github-dev` 는 모든 워크플로가 skill 로 전환돼 command surface 가 없으므로 Claude·Codex 양쪽에서 동일하게 동작합니다.
 
@@ -799,6 +817,7 @@ node scripts/install-skills.mjs                  # 또는 hermes plugins install
 │   ├── tally-form/            # 체크리스트 md -> Tally 설문/문의 폼 빌더
 │   ├── project-init/          # Day-1 프로젝트 부트스트랩 (인터뷰 + .claude/ + AGENTS.md + gh repo)
 │   ├── gws-sync/              # 로컬 → Google Drive 단방향 제안형 동기화 (gws CLI 기반)
+│   ├── plaud-note-taking/     # PLAUD 노트(Whisper 전사록+LLM 요약) STT·용어 정정
 │   └── mem0-ops/              # 플릿 레벨 mem0 진단·정리 (fleet-scan/doctor/cleanup)
 ├── AGENTS.md                 # 세 런타임 공통 최상위 지침 (정본)
 ├── CLAUDE.md                 # @AGENTS.md import

--- a/README.md
+++ b/README.md
@@ -751,7 +751,7 @@ shared-source 배선은 5개 가드가 매 PR 과 매 커밋(`.githooks/pre-comm
 
 - `sync-codex-manifests.mjs --check` — Codex 매니페스트 drift + skill `description` 1024자 초과(Codex silent skip) + 번들 hook 디스크립터 shape·참조 스크립트 존재·orphan.
 - `sync-hermes-manifests.mjs --check` — Hermes 어댑터 drift + orphan.
-- `check-doc-consistency.mjs` — 플러그인 트리·표·카운트(총 24 / Codex-eligible 23 / Hermes 7)가 `manifest-eligibility.mjs` SoT 와 일치.
+- `check-doc-consistency.mjs` — 플러그인 트리·표·카운트(총 25 / Codex-eligible 24 / Hermes 7)가 `manifest-eligibility.mjs` SoT 와 일치.
 - `check-skill-tool-portability.mjs --check` — 공유 스킬 본문의 `AskUserQuestion` 사용이 파일럿 표준 매핑 또는 baseline 에 등록됐는지(미등록 크로스런타임 상호작용 경로 차단).
 - `check-skill-prose.mjs` — 500줄 초과·깊은 참조 경로에 대한 정보성 경고(비차단, 항상 exit 0).
 

--- a/plugins/plaud-note-taking/.claude-plugin/plugin.json
+++ b/plugins/plaud-note-taking/.claude-plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "plaud-note-taking",
+  "version": "0.1.0",
+  "description": "Review and correct PLAUD voice-recorder notes (Whisper transcript + separate LLM summary). Fixes STT misrecognition (Korean+English code-switching, proper nouns, numbers) against a project term dictionary, grill-me interviews to resolve ambiguities, and writes a transcript-grounded *.corrected.md back to .llmwiki/raw/transcripts without touching the originals."
+}

--- a/plugins/plaud-note-taking/.codex-plugin/plugin.json
+++ b/plugins/plaud-note-taking/.codex-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "plaud-note-taking",
+  "version": "0.1.0",
+  "description": "Review and correct PLAUD voice-recorder notes (Whisper transcript + separate LLM summary). Fixes STT misrecognition (Korean+English code-switching, proper nouns, numbers) against a project term dictionary, grill-me interviews to resolve ambiguities, and writes a transcript-grounded *.corrected.md back to .llmwiki/raw/transcripts without touching the originals.",
+  "author": {
+    "name": "YoungjaeDev"
+  },
+  "license": "MIT",
+  "skills": "./skills/"
+}

--- a/plugins/plaud-note-taking/skills/plaud-note-taking/SKILL.md
+++ b/plugins/plaud-note-taking/skills/plaud-note-taking/SKILL.md
@@ -64,7 +64,10 @@ scope) use `AskUserQuestion`. For **resolving a list of open questions**, borrow
      self-correction, or a cited trusted source. Context is a signal that *flags* a candidate —
      it is not standalone authorization to rewrite a proper noun or a number. When the only
      basis is "it probably means X", flag `[확인 필요]` instead of correcting.
-   - Terminology fixes use **only** the verified entries in `terminology.md`. A term not in the
+   - Terminology fixes use **only** verified entries in the **project's** term dictionary at
+     `.llmwiki/raw/transcripts/terminology.md`. On first run, seed it by copying the bundled
+     `references/terminology.md` template (the bundled file is an empty template, never the live
+     dictionary — a plugin-cache copy cannot hold a project's terms). A term not in the
      dictionary is not corrected from memory — it becomes an open question or a proposed
      dictionary addition.
    - **Numbers, dates, prices, contract terms**: never "clean up" by guessing. If STT-suspect
@@ -83,10 +86,12 @@ scope) use `AskUserQuestion`. For **resolving a list of open questions**, borrow
    anything the user defers as `[확인 필요]`.
 
 5. **Write the corrected file.** Produce `<slug>.corrected.md` in the same folder using
-   `templates/corrected-note.md`. Do not edit `terminology.md` yourself — if recurring unknown
-   terms look worth adding, list them as candidates at the bottom of the corrected file for the
-   user to confirm later. Do not dump raw personal data (phone numbers, emails, credentials)
-   into the corrected file.
+   `templates/corrected-note.md`. **Never silently overwrite an existing corrected file** — the
+   user may have hand-edited it; if `<slug>.corrected.md` already exists, write the next free
+   `<slug>.corrected-vN.md` (or ask before overwriting). Do not edit the project dictionary
+   yourself — if recurring unknown terms look worth adding, list them as candidates at the
+   bottom of the corrected file for the user to confirm later. Do not dump raw personal data
+   (phone numbers, emails, credentials) into the corrected file.
 
 ## Prohibitions
 
@@ -129,5 +134,5 @@ scope) use `AskUserQuestion`. For **resolving a list of open questions**, borrow
 
 - `references/plaud-note-format.md` — what a PLAUD note is; STT error classes; transcript-over-summary rule.
 - `references/correction-policy.md` — the four states and when each applies; open-question rules.
-- `references/terminology.md` — the verified project term dictionary (the only basis for a terminology `[정정]`).
+- `references/terminology.md` — empty template for the project term dictionary (seeded into `.llmwiki/raw/transcripts/terminology.md`; the only basis for a terminology `[정정]`).
 - `templates/corrected-note.md` — the `*.corrected.md` output format.

--- a/plugins/plaud-note-taking/skills/plaud-note-taking/SKILL.md
+++ b/plugins/plaud-note-taking/skills/plaud-note-taking/SKILL.md
@@ -65,11 +65,12 @@ scope) use `AskUserQuestion`. For **resolving a list of open questions**, borrow
      it is not standalone authorization to rewrite a proper noun or a number. When the only
      basis is "it probably means X", flag `[확인 필요]` instead of correcting.
    - Terminology fixes use **only** verified entries in the **project's** term dictionary at
-     `.llmwiki/raw/transcripts/terminology.md`. On first run, seed it by copying the bundled
-     `references/terminology.md` template (the bundled file is an empty template, never the live
-     dictionary — a plugin-cache copy cannot hold a project's terms). A term not in the
-     dictionary is not corrected from memory — it becomes an open question or a proposed
-     dictionary addition.
+     `.claude/plaud-note-taking/terminology.md` (a stable config path — never under
+     `.llmwiki/raw/`, which llm-wiki treats as immutable evidence). On first run, seed it by
+     copying the bundled `references/terminology.md` template (the bundled file is an empty
+     template, never the live dictionary — a plugin-cache copy cannot hold a project's terms). A
+     term not in the dictionary is not corrected from memory — it becomes an open question or a
+     proposed dictionary addition.
    - **Numbers, dates, prices, contract terms**: never "clean up" by guessing. If STT-suspect
      or unbased, flag `[확인 필요]`.
    - Never change meaning. A correction restores what was said; it does not improve it.
@@ -134,5 +135,5 @@ scope) use `AskUserQuestion`. For **resolving a list of open questions**, borrow
 
 - `references/plaud-note-format.md` — what a PLAUD note is; STT error classes; transcript-over-summary rule.
 - `references/correction-policy.md` — the four states and when each applies; open-question rules.
-- `references/terminology.md` — empty template for the project term dictionary (seeded into `.llmwiki/raw/transcripts/terminology.md`; the only basis for a terminology `[정정]`).
+- `references/terminology.md` — empty template for the project term dictionary (seeded into `.claude/plaud-note-taking/terminology.md`; the only basis for a terminology `[정정]`).
 - `templates/corrected-note.md` — the `*.corrected.md` output format.

--- a/plugins/plaud-note-taking/skills/plaud-note-taking/SKILL.md
+++ b/plugins/plaud-note-taking/skills/plaud-note-taking/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: plaud-note-taking
+description: "Use to review and correct a PLAUD voice-recorder note that was dropped into .llmwiki/raw/transcripts/. PLAUD emits two separate artifacts per recording — a raw Whisper STT transcript and a separate LLM summary — and this skill corrects the transcript (never the summary) for STT misrecognition and project terminology, relentlessly interviews the user (grill-me) to resolve anything ambiguous, and writes a *.corrected.md next to the originals without modifying them. Triggers: PLAUD transcript, 플라우드 노트, 전사록 정정, STT 수정, 회의록 교정, plaud note review, correct meeting transcript."
+version: 0.1.0
+---
+
+# PLAUD Note Review & Correction
+
+## When to use
+
+- A PLAUD note (transcript, or transcript + summary) has been placed in
+  `.llmwiki/raw/transcripts/` and needs cleaning before it is usable.
+- "이 회의록 정정해줘", "plaud 전사 STT 고쳐줘", "전사록 오탈자·용어 맞춰줘", "correct this PLAUD transcript".
+
+## What a PLAUD note is (read first)
+
+Read `references/plaud-note-format.md` before touching content. Two facts drive everything:
+
+1. **A PLAUD note is two separate artifacts.** The **transcript** is raw single-language
+   Whisper STT output (speaker-labeled). The **summary/note** is a *separate* LLM pass over
+   that transcript. They are generated and stored independently.
+2. **The transcript is ground truth; the summary is not.** The summary reads fluently even
+   when it silently invents a decision that was never made. **Correct against the transcript
+   and audio, never against the summary.** Where the summary asserts something the transcript
+   does not support, that is a flag, not a fact.
+
+## Role and scope
+
+This skill corrects a transcript conservatively and writes a **new** corrected file. It never
+edits the uploaded originals. It sorts every span into four states (see
+`references/correction-policy.md`), tagged inline in the corrected file:
+
+- `[확인됨]` — present in the transcript and not in conflict with a trusted source.
+- `[정정]` — a misrecognition fixable with certain evidence (`terminology.md` or an
+  in-transcript self-correction). Keep original → corrected → basis.
+- `[해석]` — useful context inferred from flow, not stated verbatim. Never promote to a
+  decision, action item, or commitment.
+- `[확인 필요]` — ambiguous / conflicting / STT-suspect. Becomes an open question.
+
+## Process
+
+Two ways to ask: for a **single direct question** (which recording to process, confirming
+scope) use `AskUserQuestion`. For **resolving a list of open questions**, borrow
+`interview:interview-methodology` in grill-me posture (step 4).
+
+1. **Locate input.** Find `<YYYY-MM-DD-slug>.transcript.txt` (and optional `.note.txt`) in
+   `.llmwiki/raw/transcripts/`. If more than one recording is present, or the files are
+   loosely / oddly named, ask via `AskUserQuestion` which recording to process and confirm the
+   `<YYYY-MM-DD-slug>`, then normalize **copies** — never destructively rename or edit an
+   original. If only a summary/note exists and there is no transcript, **stop**: you cannot
+   correct against a summary. Report the missing transcript.
+
+2. **Understand the note.** Read transcript and summary as separate inputs. Keep PLAUD's
+   `Speaker 1 / Speaker 2` labels as **estimates** — PLAUD over-splits one person or merges
+   two on cross-talk. Never convert a speaker label into a real name, an attendee count, or
+   attribution of a decision without independent evidence.
+
+3. **Correct** (conservative — `references/correction-policy.md` + `references/terminology.md`):
+   - STT fixes target the known error zone: Korean+English **code-switched tech terms**,
+     **proper nouns** (company / product / person), garbled **English loanwords**, dropped or
+     merged sentences, and orthography (맞춤법). Fix only with contextual + terminology basis.
+   - Terminology fixes use **only** the verified entries in `terminology.md`. A term not in the
+     dictionary is not corrected from memory — it becomes an open question or a proposed
+     dictionary addition.
+   - **Numbers, dates, prices, contract terms**: never "clean up" by guessing. If STT-suspect
+     or unbased, flag `[확인 필요]`.
+   - Never change meaning. A correction restores what was said; it does not improve it.
+
+4. **Resolve open questions — grill me.** Collect every `[확인 필요]`: ambiguous owner /
+   deadline / number, uncertain speaker attribution that affects a decision, and any place the
+   **summary asserts a decision the transcript does not support**. If one or more open
+   questions remain, load `interview:interview-methodology` and run it in a **relentless,
+   grill-me posture** ("집요하게 캐물어") over the open-question list — one fact per question, do
+   not accept a vague answer, keep pressing until each is resolved or the user explicitly
+   defers it. Ask it to run a focused close (resolve this list; do not spin up a separate
+   spec). If the interview plugin is unavailable, question each open item directly, in the
+   same relentless posture. Fold confirmed answers back in as `[확인됨]` / `[정정]`; leave
+   anything the user defers as `[확인 필요]`.
+
+5. **Write the corrected file.** Produce `<slug>.corrected.md` in the same folder using
+   `templates/corrected-note.md`. Do not edit `terminology.md` yourself — if recurring unknown
+   terms look worth adding, list them as candidates at the bottom of the corrected file for the
+   user to confirm later. Do not dump raw personal data (phone numbers, emails, credentials)
+   into the corrected file.
+
+## Prohibitions
+
+- Never modify, rename, or delete the uploaded `.transcript.txt` / `.note.txt` originals.
+- Never treat the summary as a source of confirmed decisions, owners, or deadlines.
+- Never correct a name / company / product / number from memory — only from `terminology.md`
+  or a cited trusted source.
+- Never promote a `[해석]` or a mere request/proposal into a confirmed decision or action item.
+
+## Verification before writing
+
+- [ ] Corrected against the transcript, not the summary?
+- [ ] Every `[정정]` has a basis (dictionary entry / in-transcript self-correction / cited source)?
+- [ ] No owner / deadline / number invented to fill a gap?
+- [ ] Speaker labels left as estimates unless independently confirmed?
+- [ ] Open questions grilled to resolution or explicitly deferred?
+- [ ] Summary claims the transcript does not support are flagged, not adopted?
+- [ ] Originals untouched; output is a new `*.corrected.md`?
+
+## Example (Korean domain)
+
+```md
+# 랜딩페이지 논의 (corrected)
+자료: 2026-07-22-landing.transcript.txt (+ .note.txt) · PLAUD (Whisper STT + LLM 요약)
+정정 기준: 전사록 근거, terminology.md
+
+## 정정한 표현
+- "투디제로" → "2dzero"        (terminology.md)
+- "지피티 포" → "GPT-4"        (STT 코드스위칭, 기술용어)
+
+## 확인 필요
+- [OQ-01] 가격표 수정 담당자는 누구인가요?
+  전사록에는 "저희 쪽에서 수정"만 있어 담당자가 특정되지 않음.
+
+## 요약 vs 전사록 불일치
+- note.txt는 "금요일 출시 확정"이라 적었으나, 전사록에는 제안 발화만 있고 합의 확인이 없음.
+```
+
+## Reference files
+
+- `references/plaud-note-format.md` — what a PLAUD note is; STT error classes; transcript-over-summary rule.
+- `references/correction-policy.md` — the four states and when each applies; open-question rules.
+- `references/terminology.md` — the verified project term dictionary (the only basis for a terminology `[정정]`).
+- `templates/corrected-note.md` — the `*.corrected.md` output format.

--- a/plugins/plaud-note-taking/skills/plaud-note-taking/SKILL.md
+++ b/plugins/plaud-note-taking/skills/plaud-note-taking/SKILL.md
@@ -31,8 +31,8 @@ edits the uploaded originals. It sorts every span into four states (see
 `references/correction-policy.md`), tagged inline in the corrected file:
 
 - `[확인됨]` — present in the transcript and not in conflict with a trusted source.
-- `[정정]` — a misrecognition fixable with certain evidence (`terminology.md` or an
-  in-transcript self-correction). Keep original → corrected → basis.
+- `[정정]` — a misrecognition fixable with certain evidence: a `terminology.md` entry, an
+  in-transcript self-correction, or a cited trusted source. Keep original → corrected → basis.
 - `[해석]` — useful context inferred from flow, not stated verbatim. Never promote to a
   decision, action item, or commitment.
 - `[확인 필요]` — ambiguous / conflicting / STT-suspect. Becomes an open question.
@@ -57,8 +57,13 @@ scope) use `AskUserQuestion`. For **resolving a list of open questions**, borrow
 
 3. **Correct** (conservative — `references/correction-policy.md` + `references/terminology.md`):
    - STT fixes target the known error zone: Korean+English **code-switched tech terms**,
-     **proper nouns** (company / product / person), garbled **English loanwords**, dropped or
-     merged sentences, and orthography (맞춤법). Fix only with contextual + terminology basis.
+     **proper nouns** (company / product / person), garbled **English loanwords**, and
+     orthography (맞춤법). **Dropped or merged sentences are not reconstructed** — leave them
+     `[확인 필요]` unless the boundary re-segments unambiguously (never invent missing content).
+   - A correction needs a defensible basis: a `terminology.md` entry, an in-transcript
+     self-correction, or a cited trusted source. Context is a signal that *flags* a candidate —
+     it is not standalone authorization to rewrite a proper noun or a number. When the only
+     basis is "it probably means X", flag `[확인 필요]` instead of correcting.
    - Terminology fixes use **only** the verified entries in `terminology.md`. A term not in the
      dictionary is not corrected from memory — it becomes an open question or a proposed
      dictionary addition.
@@ -110,7 +115,7 @@ scope) use `AskUserQuestion`. For **resolving a list of open questions**, borrow
 
 ## 정정한 표현
 - "투디제로" → "2dzero"        (terminology.md)
-- "지피티 포" → "GPT-4"        (STT 코드스위칭, 기술용어)
+- "리액트" → "React"          (terminology.md — 코드스위칭 기술용어)
 
 ## 확인 필요
 - [OQ-01] 가격표 수정 담당자는 누구인가요?

--- a/plugins/plaud-note-taking/skills/plaud-note-taking/references/correction-policy.md
+++ b/plugins/plaud-note-taking/skills/plaud-note-taking/references/correction-policy.md
@@ -1,0 +1,71 @@
+# Correction policy — states, open questions, discrepancies
+
+Conservative discipline for turning a PLAUD transcript into a corrected note. The transcript
+is the primary source; the summary and any project docs are secondary. Never let a plausible
+guess pass as a confirmed fact.
+
+## Source roles
+
+| Source | Role | Standalone rule |
+|---|---|---|
+| PLAUD transcript | Primary record of what was said | Can carry misrecognition + speaker split/merge errors. Do not infer owner / deadline / attendee count from it alone. |
+| PLAUD summary / note | Fast-navigation aid only | Never a source of confirmed decisions, owners, or deadlines. Can fabricate — see "Summary vs transcript". |
+| Verified project docs / calendar / email | External verification | Must be cited when used. |
+| `terminology.md` | Terminology-correction basis | A name not in the list is not corrected from memory. |
+
+## The four states
+
+Tag every non-trivial span inline in the corrected file.
+
+### `[확인됨]` (confirmed)
+All of: appears directly in the transcript (or a verified external source); no material
+conflict across transcript / summary / external basis; owner / deadline / decision not filled
+by inference.
+
+### `[정정]` (corrected)
+One of these bases only: a standard term from `terminology.md`; a trusted external source for a
+date / number / proper noun; a speaker's own immediate self-correction inside the transcript.
+Record `original → corrected → basis`. A correction restores meaning; it never changes it.
+
+### `[해석]` (interpretation)
+Context useful for reading the meeting but not stated verbatim. Always tag it. Never promote it
+to a decision, action item, or commitment.
+
+### `[확인 필요]` (needs confirmation → open question)
+Make an open question when any of: transcript and summary disagree; speaker / owner / project
+name is unclear; a baseline-less phrase ("next week", "our side", "곧") appears; an action is
+mentioned with no owner or deadline; a number / date / price / term is ambiguous or
+STT-suspect; a source conflicts with a project doc and recency is unknown.
+
+## Speaker attribution
+
+PLAUD `Speaker N` labels are voice-segment estimates (over-split / merge on cross-talk). Do not
+use speaker count as attendee count, and do not bind a label to a real name without independent
+evidence. If attribution affects who owns a decision or task, keep the attribution
+`[확인 필요]` even when the sentence is clear.
+
+## Summary vs transcript
+
+The summary can assert a decision the transcript never supports (and can also silently fix a
+transcript error). For every summary claim of a decision / owner / deadline, verify it against
+the transcript. If the transcript shows only a proposal, request, or discussion, it is **not** a
+confirmed decision — record it as a proposal and, if it matters, raise an open question. Collect
+these mismatches in the corrected file's "summary vs transcript" section.
+
+## Open-question format
+
+A good question is directly answerable — one fact each.
+
+```text
+[OQ-01] <the precise question>
+왜 확인이 필요한가: <what is ambiguous / conflicting / STT-suspect in the source>
+답변 대상: <name if known, else 답변 대상 미정>
+```
+
+Resolve open questions by interviewing the user relentlessly (grill-me). Fold confirmed answers
+back in as `[확인됨]` / `[정정]`; leave anything the user defers as `[확인 필요]`.
+
+## Sensitive information
+
+Keep only what the corrected note needs. Do not copy phone numbers, email addresses,
+credentials, or unnecessary personal circumstances into the corrected file.

--- a/plugins/plaud-note-taking/skills/plaud-note-taking/references/plaud-note-format.md
+++ b/plugins/plaud-note-taking/skills/plaud-note-taking/references/plaud-note-format.md
@@ -43,9 +43,9 @@ stack until meaning shifts. Prioritize these correction targets:
 
 | Error class | What to expect | Correction stance |
 |---|---|---|
-| **Code-switched tech terms** (KO + EN) | The #1 error zone — embedded English is approximated by the single-language model. | Fix from `terminology.md` / context; the biggest win. |
+| **Code-switched tech terms** (KO + EN) | The #1 error zone — embedded English is approximated by the single-language model. | Fix from `terminology.md` or a cited source; context only flags a candidate. The biggest win. |
 | **Proper nouns** (company / product / person) | Pronunciation-dependent misrecognition. | Fix only from the dictionary or a cited source; else open question. |
-| **English loanwords** | Mangled or half-transliterated. | Fix from context + dictionary. |
+| **English loanwords** | Mangled or half-transliterated. | Fix from the dictionary; context only flags a candidate. |
 | **Dropped / merged sentences** | Fragments omitted; sentences fused on overlap. | Mark `[확인 필요]`; do not invent the missing content. |
 | **Orthography (맞춤법)** | Severe on noisy audio. | Fix spelling without changing meaning. |
 | **Numbers / dates / prices / terms** | STT reliably mangles these; no safe auto-fix. | **Never guess** — flag `[확인 필요]`. |

--- a/plugins/plaud-note-taking/skills/plaud-note-taking/references/plaud-note-format.md
+++ b/plugins/plaud-note-taking/skills/plaud-note-taking/references/plaud-note-format.md
@@ -1,0 +1,69 @@
+# What a PLAUD note is
+
+PLAUD (PLAUD.AI) makes small AI voice recorders (Plaud Note / Note Pro / NotePin). The device
+only records; all processing happens in the PLAUD app/web ("PLAUD Intelligence"). Every
+recording becomes a **note** made of two independently generated artifacts plus extras
+(mind map, etc.). For correction, only the first two matter.
+
+## The two-stage pipeline (the fact that drives everything)
+
+1. **Transcript — raw STT.** Produced by **OpenAI Whisper (v3-large) + Azure ASR** (PLAUD also
+   runs its own trained ASR on newer paths). Speaker-labeled, paragraph-broken, timestamps
+   optional (off by default). This is the verbatim "what was said."
+2. **Summary / note — a separate LLM pass.** A user-chosen model (GPT / Claude / Gemini)
+   re-writes the transcript into a template (meeting recap, action items, etc.). Generated and
+   stored **separately** from the transcript; can be regenerated without re-transcribing.
+
+**Correct the transcript, never the summary.** The summary reads perfectly fluently even when
+it fabricates — e.g. "the team agreed to launch Friday" when the transcript only shows a
+proposal. It can also silently *fix* a transcript error, so the two diverge in both directions.
+The transcript (and, ideally, the audio) is the ground truth. Treat any summary claim the
+transcript does not support as a flag, not a fact.
+
+## Speaker labels are estimates
+
+Auto speaker labeling assigns `Speaker 1 / Speaker 2 …` and is renamable in-app, but it
+**over-splits one person into two and merges two people into one on overlapping/cross-talk
+audio**. So:
+
+- Speaker **count is not the attendee count.**
+- Never bind a `Speaker N` to a real name from voice pattern or tone alone.
+- Real names come only from independent evidence (calendar invite, email, an explicit
+  self-introduction in the transcript).
+- If speaker attribution affects who owns a decision or task, and it is not independently
+  confirmed, it is an open question — even when the sentence itself is clear.
+
+## STT error classes to expect (esp. Korean business audio)
+
+PLAUD transcribes **one language per recording** — no bilingual mode, no translation — and is
+tuned to standard pronunciation (**dialects / 사투리 are officially unsupported**). Accuracy is
+condition-dependent (~90% clean Korean, down to ~60% in a noisy real meeting), not a fixed
+number. When audio is unclear the model **fills gaps with plausible guesses**, so small errors
+stack until meaning shifts. Prioritize these correction targets:
+
+| Error class | What to expect | Correction stance |
+|---|---|---|
+| **Code-switched tech terms** (KO + EN) | The #1 error zone — embedded English is approximated by the single-language model. | Fix from `terminology.md` / context; the biggest win. |
+| **Proper nouns** (company / product / person) | Pronunciation-dependent misrecognition. | Fix only from the dictionary or a cited source; else open question. |
+| **English loanwords** | Mangled or half-transliterated. | Fix from context + dictionary. |
+| **Dropped / merged sentences** | Fragments omitted; sentences fused on overlap. | Mark `[확인 필요]`; do not invent the missing content. |
+| **Orthography (맞춤법)** | Severe on noisy audio. | Fix spelling without changing meaning. |
+| **Numbers / dates / prices / terms** | STT reliably mangles these; no safe auto-fix. | **Never guess** — flag `[확인 필요]`. |
+| **Sentence boundaries / punctuation** | Auto-segmentation imperfect, worse on overlap. | Re-segment only where meaning is unambiguous. |
+
+PLAUD's own mitigation is a **Custom Vocabulary + industry glossary** — this skill mirrors that
+as `terminology.md`, the single basis for a terminology correction.
+
+## Export shape (why a `.txt` post-processor fits)
+
+Transcript exports as plain **TXT / SRT / DOCX / PDF** (summary as TXT / Markdown / DOCX / PDF).
+So the input to this skill is naturally the exported `.transcript.txt` (+ optional summary
+`.note.txt`) placed in `.llmwiki/raw/transcripts/`.
+
+---
+
+Sources (verified 2026-07-22; vendor numbers marked where relevant): PLAUD device/AI-model FAQ
+`plaud.ai/pages/plaud-devices`, User Guide PDF, support articles on languages / bilingual /
+translation / export, accuracy trade-off blog (WER 23.4%), and KO reviews (IT조선, monopick.kr,
+plaud.kr 사용후기). Numbers/dates and homophone cases are a general-STT expectation, not a
+PLAUD-documented example — hence the "always flag, never guess" stance.

--- a/plugins/plaud-note-taking/skills/plaud-note-taking/references/terminology.md
+++ b/plugins/plaud-note-taking/skills/plaud-note-taking/references/terminology.md
@@ -1,9 +1,11 @@
 # Project term dictionary (template)
 
 This bundled file is an **empty template**, not the live dictionary. The live, per-project
-dictionary lives in the user's project at `.llmwiki/raw/transcripts/terminology.md` — the skill
-seeds it by copying this template on first run, then reads and grows that copy (a plugin-cache
-file cannot hold a project's terms and is wiped on cache refresh).
+dictionary lives in the user's project at `.claude/plaud-note-taking/terminology.md` — a stable
+config path outside `.llmwiki/raw/` (which llm-wiki treats as immutable, date-named evidence, so
+a growing dictionary must not live there). The skill seeds it by copying this template on first
+run, then reads and grows that copy (a plugin-cache file cannot hold a project's terms and is
+wiped on cache refresh).
 
 It is the **only** basis for a terminology `[정정]`, mirroring PLAUD's own Custom Vocabulary: a
 verified map from what STT tends to produce → the correct project spelling. A term is added only

--- a/plugins/plaud-note-taking/skills/plaud-note-taking/references/terminology.md
+++ b/plugins/plaud-note-taking/skills/plaud-note-taking/references/terminology.md
@@ -1,0 +1,27 @@
+# Project term dictionary
+
+The **only** basis for a terminology `[정정]`. This mirrors PLAUD's own Custom Vocabulary: a
+verified map from what STT tends to produce → the correct project spelling. Populate it per
+project. A term is added only after the user confirms it, or a trusted project doc verifies it —
+never because it "appears a lot" in a transcript.
+
+## Entries
+
+| STT misrecognition (candidates) | Correct spelling | Basis |
+|---|---|---|
+| _(example)_ 투디제로, 투디 제로, 2D 제로 | 2dzero | example row — replace with your project's terms |
+
+Start from an empty table for a new project; the row above only shows the shape.
+
+## How to add an entry
+
+Record all three fields. Add an entry only after the user confirms it — the skill proposes
+candidates at the bottom of its corrected-note output and never edits this file on its own.
+
+```text
+| <what STT produces> | <correct spelling> | <verifying doc or user confirmation> |
+```
+
+Do **not** add people's names, client/company names, amounts, or contract terms to this table
+without separate verification — those are high-cost to get wrong and default to an open question
+rather than an auto-correction.

--- a/plugins/plaud-note-taking/skills/plaud-note-taking/references/terminology.md
+++ b/plugins/plaud-note-taking/skills/plaud-note-taking/references/terminology.md
@@ -7,11 +7,11 @@ never because it "appears a lot" in a transcript.
 
 ## Entries
 
+The dictionary starts **empty** for a new project — no live row ships by default. Add only
+verified entries (see "How to add an entry"); the row shape is illustrated there.
+
 | STT misrecognition (candidates) | Correct spelling | Basis |
 |---|---|---|
-| _(example)_ 투디제로, 투디 제로, 2D 제로 | 2dzero | example row — replace with your project's terms |
-
-Start from an empty table for a new project; the row above only shows the shape.
 
 ## How to add an entry
 

--- a/plugins/plaud-note-taking/skills/plaud-note-taking/references/terminology.md
+++ b/plugins/plaud-note-taking/skills/plaud-note-taking/references/terminology.md
@@ -1,9 +1,14 @@
-# Project term dictionary
+# Project term dictionary (template)
 
-The **only** basis for a terminology `[정정]`. This mirrors PLAUD's own Custom Vocabulary: a
-verified map from what STT tends to produce → the correct project spelling. Populate it per
-project. A term is added only after the user confirms it, or a trusted project doc verifies it —
-never because it "appears a lot" in a transcript.
+This bundled file is an **empty template**, not the live dictionary. The live, per-project
+dictionary lives in the user's project at `.llmwiki/raw/transcripts/terminology.md` — the skill
+seeds it by copying this template on first run, then reads and grows that copy (a plugin-cache
+file cannot hold a project's terms and is wiped on cache refresh).
+
+It is the **only** basis for a terminology `[정정]`, mirroring PLAUD's own Custom Vocabulary: a
+verified map from what STT tends to produce → the correct project spelling. A term is added only
+after the user confirms it, or a trusted project doc verifies it — never because it "appears a
+lot" in a transcript.
 
 ## Entries
 

--- a/plugins/plaud-note-taking/skills/plaud-note-taking/templates/corrected-note.md
+++ b/plugins/plaud-note-taking/skills/plaud-note-taking/templates/corrected-note.md
@@ -5,7 +5,7 @@ content. Keep it readable — one fact per line, no tables of raw transcript, no
 
 ```md
 # {회의/녹음 제목} (corrected)
-자료: {slug}.transcript.txt (+ {slug}.note.txt) · PLAUD (Whisper STT + LLM 요약)
+자료: {slug}.transcript.txt · PLAUD (Whisper STT)  {요약 .note.txt 가 있을 때만 " (+ {slug}.note.txt) · LLM 요약" 을 덧붙인다}
 정정 기준: 전사록 근거, terminology.md · 정정일 {YYYY-MM-DD}
 
 ## 요약 (확인된 내용만)

--- a/plugins/plaud-note-taking/skills/plaud-note-taking/templates/corrected-note.md
+++ b/plugins/plaud-note-taking/skills/plaud-note-taking/templates/corrected-note.md
@@ -1,0 +1,42 @@
+# Corrected-note template
+
+Write `<slug>.corrected.md` in the same folder as the originals. Drop any section that has no
+content. Keep it readable — one fact per line, no tables of raw transcript, no sensitive data.
+
+```md
+# {회의/녹음 제목} (corrected)
+자료: {slug}.transcript.txt (+ {slug}.note.txt) · PLAUD (Whisper STT + LLM 요약)
+정정 기준: 전사록 근거, terminology.md · 정정일 {YYYY-MM-DD}
+
+## 요약 (확인된 내용만)
+{전사록이 실제로 뒷받침하는 2~3문장. 요약 파일의 미검증 주장은 넣지 않는다.}
+
+## 정정한 전사
+{화자 라벨을 보존한 정정 본문. 바뀐 곳은 인라인 태깅:}
+{  [정정] "원문" → "정정" (근거)}
+{  [확인 필요] STT 의심 구간 또는 모호한 부분}
+{  Speaker N 은 추정값으로 유지 — 실명·담당자로 확정하지 않음}
+
+## 정정한 표현
+- "{PLAUD 원문}" → "{정정}"   ({근거: terminology.md / 자기수정 / 인용})
+
+## 확인 필요 (grill 후에도 미해결)
+[OQ-01] {질문}
+왜 확인이 필요한가: {무엇이 모호/충돌/STT 의심인지}
+답변 대상: {이름 또는 답변 대상 미정}
+
+## 요약 vs 전사록 불일치
+- {요약이 결정으로 적었으나 전사록엔 제안/논의만 있는 항목 → 확정 결정 아님}
+```
+
+## Ordering
+
+1. 회의 식별 + 정정 기준
+2. 확인된 요약
+3. 정정한 전사 (인라인 태깅)
+4. 정정 표현 목록
+5. 확인 필요 (open questions)
+6. 요약 vs 전사록 불일치
+
+Put open questions and the summary-vs-transcript flags where they are easy to find — these are
+what the reader must act on.

--- a/scripts/check-skill-tool-portability.mjs
+++ b/scripts/check-skill-tool-portability.mjs
@@ -13,7 +13,7 @@
 //   - a malformed or duplicate baseline entry, or one that overlaps a pilot
 //   - a stale baseline entry (file gone, or debt removed — no AskUserQuestion left)
 //
-// FOLLOW-UP DEBT (issue #123): only the 2 pilots below are migrated. The 18 BASELINE
+// FOLLOW-UP DEBT (issue #123): only the 2 pilots below are migrated. The 19 BASELINE
 // paths still hardcode AskUserQuestion; migrating them to the standardized mapping is
 // deferred fleet work. Move a path from BASELINE to PILOTS as it is migrated.
 //
@@ -49,6 +49,7 @@ const BASELINE = [
   'plugins/llm-wiki/skills/bootstrap-wiki/SKILL.md',
   'plugins/llm-wiki/skills/migrate-wiki/SKILL.md',
   'plugins/mem0-ops/skills/cleanup/SKILL.md',
+  'plugins/plaud-note-taking/skills/plaud-note-taking/SKILL.md',
   'plugins/ppt-yeong-style/skills/ppt-yeong-style/SKILL.md',
   'plugins/project-init/skills/wiring/SKILL.md',
   'plugins/rules-forge/skills/write-rules/SKILL.md',


### PR DESCRIPTION
## 개요

PLAUD 음성 녹음기 노트를 검토·정정하는 새 마켓플레이스 플러그인 `plaud-note-taking` (v0.1.0, productivity).

PLAUD는 녹음 하나당 **두 산출물**을 낸다 — Whisper STT **전사록**과, 그 전사록을 다시 LLM이 요약한 **별도 요약**. 이 스킬은 사용자가 `.llmwiki/raw/transcripts/`에 손으로 올린 `*.transcript.txt`(+선택 `*.note.txt`)를 읽어:

- **전사록 기준으로만** STT 오인식을 정정 (요약은 없던 결정을 지어낼 수 있어 근거로 쓰지 않음 — PLAUD 조사 결과의 핵심 규율)
- 최대 오류원인 **한국어+영어 코드스위칭**(기술용어·고유명사·수치)을 프로젝트 용어 사전(`terminology.md`)에 맞춰 교정
- 애매한 담당자·기한·수치·화자 귀속과 "요약이 지어낸 결정"은 `interview:interview-methodology`(grill-me)로 집요하게 캐물어 확정
- 원본은 절대 수정하지 않고 같은 폴더에 `*.corrected.md` 생성

## 변경

- `plugins/plaud-note-taking/` — SKILL.md + references 3종(plaud-note-format / correction-policy / terminology) + templates/corrected-note.md + manifests
- marketplace 엔트리 + `metadata.version` 2.5.9 → 2.6.0
- `.claude/settings.json` plugins.local 등록
- 카운트: plugins 24 → 25, Codex-eligible 23 → 24, portability baseline 18 → 19
- Codex-eligible (매니페스트 생성), Hermes 비대상

## 상호작용 설계

- 단발성 직접 질문(어떤 녹음 처리? 스코프) → `AskUserQuestion`
- open question 묶음 해소 → `interview:interview-methodology` (grill-me) 위임
- cross-runtime/Hermes 블록 없음 → 이식성 가드에는 baseline로 등록

## 검증

로컬에서 모두 통과 (pre-commit 훅 포함):

- `sync-codex-manifests.mjs --check` / `sync-hermes-manifests.mjs --check`
- `check-doc-consistency.mjs` — 25 plugins, Codex-eligible 24, Hermes 7
- `check-skill-tool-portability.mjs --check` — pilots 2, baseline 19
- github-dev 테스트 스위트 87 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `plaud-note-taking` plugin (Productivity) for reviewing and correcting PLAUD voice-recording transcripts.
  * Produces transcript-grounded `*.corrected.md` outputs while keeping original files unchanged.
  * Applies conservative terminology corrections, uses inline confirmation/correction tagging, and routes ambiguous items through follow-up question resolution.

* **Documentation**
  * Added/updated plugin manifests and end-user guidance (correction policy, expected corrected-note structure, templates, and terminology rules).
  * Updated marketplace/project documentation and plugin inventory/counts to reflect the new plugin.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->