### PR TITLE
docs(agents): drop derivable directory tree

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,39 +97,7 @@
 
 ## 저장소 구조
 
-```
-.
-├── .claude/
-│   └── settings.json       # Plugin configuration
-├── plugins/
-│   ├── core-config/        # Guidelines + hooks
-│   ├── github-dev/         # GitHub workflow
-│   ├── e2e-harness/        # Playwright E2E test-harness (setup/author/debug)
-│   ├── code-scout/         # Resource discovery
-│   ├── deepwiki/           # Repo docs
-│   ├── paper-search-tools/ # Academic papers
-│   ├── brightdata-guide/   # Bright Data web-data guide (MCP + CLI)
-│   ├── notebook/           # Jupyter
-│   ├── ml-toolkit/         # ML tools
-│   ├── translator/         # Translation
-│   ├── codex-image/        # Claude->Codex image gen bridge
-│   ├── interview/          # Requirements
-│   ├── docs-forge/         # README/CHANGELOG + deploy-doc + MOC
-│   ├── rules-forge/        # write-rules skill (auto mode detection)
-│   ├── tcrei-prompt/       # TCREI prompt structuring
-│   ├── llm-wiki/           # LLM-Wiki 3-layer (wiki lore)
-│   ├── mem0-ops/           # Fleet-level mem0 diagnostics/cleanup (fleet-scan/doctor/cleanup)
-│   ├── spec-state/         # spec/issue/PR work-pipeline aggregate
-│   ├── anti-slop-design/   # Anti-AI-slop design guard (web/ppt/dashboard/copy)
-│   ├── ppt-yeong-style/    # yeong-style lecture/proposal deck writing layer (on ppt-master)
-│   ├── tally-form/         # Checklist md -> Tally questionnaire/survey form builder
-│   ├── gws-sync/           # Local -> Google Drive one-way proposal sync
-│   ├── plaud-note-taking/  # PLAUD note (Whisper transcript + LLM summary) STT + terminology correction
-│   └── project-init/       # Day-1 bootstrap (new) + existing-repo setup diagnostic (wiring)
-├── AGENTS.md               # This file — 정본
-├── CLAUDE.md               # @AGENTS.md import (한 줄)
-└── README.md               # Full documentation
-```
+디렉터리 배치 자체는 `ls plugins/` 로 확인한다. 아래는 그 배치만 봐서는 알 수 없는 각 경로의 역할과 편집 금지 여부다.
 
 - `AGENTS.md`: 이 문서. 세 런타임 공통 최상위 지침 + 플러그인 목록 + 구조 요약.
 - `CLAUDE.md`: `@AGENTS.md` 를 import 하는 한 줄 파일. Claude Code 진입점일 뿐, 별도 내용이 없습니다.
@@ -187,7 +155,7 @@
 - `plugins/<name>/` 아래 **어떤 파일이든** 바뀌면 버전 범프 대상입니다 — 코드/스킬뿐 아니라 번들 `references/`·`docs`·asset 편집도 포함. 캐시로 게이트된 사용자는 버전 범프가 있어야 새 내용을 받으므로, 문서만 고쳐도 해당 플러그인 PATCH + `metadata.version`을 올립니다 (Codex-eligible 이면 매니페스트 재생성). 반면 루트 문서(`AGENTS.md`, `README.md`, `code_review.md`, `.claude/rules/*`)는 플러그인 콘텐츠가 아니라 어떤 플러그인도 범프하지 않습니다.
 - Hermes-eligible 플러그인: `plugins/<name>/plugin.yaml`(Hermes 어댑터)의 `version`은 `sync-hermes-manifests.mjs` 가 marketplace 에서 파생해 생성하므로, 버전 범프 후 `node scripts/sync-hermes-manifests.mjs` 재실행으로 갱신하세요. `sync-hermes-manifests.mjs --check` 가 drift 를 가드하므로 수동 동기화는 불필요합니다 (단 Codex `--check` 는 Codex 매니페스트만 봅니다).
 - 어떤 플러그인 버전이든 변경하면 `.claude-plugin/marketplace.json`의 `metadata.version`도 marketplace release 버전으로 올리세요.
-- 플러그인을 추가하거나 제거하면 이 문서의 `## Plugins (N)` 수와 구조 트리, `README.md`의 플러그인 수와 목록도 갱신하세요. 이 문서의 미러 카운트(Hermes allowlist `현재 N개`, Codex 검증 주석 `# N entries`)도 같은 변경에서 함께 갱신하세요 — `--check` 가 못 잡습니다.
+- 플러그인을 추가하거나 제거하면 이 문서의 `## Plugins (N)` 수와 목록, `README.md`의 플러그인 수와 목록도 갱신하세요. 이 문서의 미러 카운트(Hermes allowlist `현재 N개`, Codex 검증 주석 `# N entries`)도 같은 변경에서 함께 갱신하세요 — `--check` 가 못 잡습니다.
 - 버전은 semver를 따릅니다. 버그 수정은 PATCH, 하위 호환 기능은 MINOR, 깨지는 변경은 MAJOR입니다.
 - Claude Code 플러그인 캐시 이슈 때문에 사용자 문서나 릴리스 안내에는 필요 시 `rm -rf ~/.claude/plugins/cache/my-claude-plugins/` 후 marketplace update 및 Claude Code 재시작 절차를 유지하세요.
 
@@ -313,7 +281,7 @@ codex plugin marketplace remove my-claude-plugins   # 검증 후 정리
 
 ### 핵심 최소본 (전문은 `code_review.md`)
 - **P0 (must-block)** — secret/token 노출, 사용자 확인 없는 destructive `gh` 명령 (`gh pr merge` / `gh repo create` / `gh api`), Codex 매니페스트 (`.agents/**`, `plugins/*/.codex-plugin/**`) 손편집, shell injection (사용자 입력 unquoted).
-- **P1 (should-block)** — 모든 should-block 규칙은 하드 유지한다 (soft-follow 미검증이므로 code_review.md 로 demote 하지 않는다): plugin version/count drift (`plugin.json` ↔ `marketplace.json` ↔ AGENTS/README 트리·배지·`metadata.version`), idempotency 회귀 (재실행 시 사용자 파일 덮어쓰기·`nothing to commit` abort·`origin` 충돌), cross-platform shell 가정 (`sed -i`·`realpath -m` GNU-only / `${VAR,,}` Bash 4+), `gh api --paginate`+`--jq` 에 `--slurp` 누락, sed 치환 안전성 (`&`·구분자·`\` escape, 사용자 입력 정화), API 실패를 빈 결과로 삼키는 패턴 (`gh api ... || echo "[]"`), skill/command frontmatter `name`/`description` 누락·오류, `Read`/`Edit` 영역을 `Bash cat`/`sed` 로 우회, 새 dependency·GitHub Actions·CI/CD 권한 변경 (최소 권한·lockfile·supply-chain).
+- **P1 (should-block)** — 모든 should-block 규칙은 하드 유지한다 (soft-follow 미검증이므로 code_review.md 로 demote 하지 않는다): plugin version/count drift (`plugin.json` ↔ `marketplace.json` ↔ AGENTS 플러그인 목록·README 트리·배지·`metadata.version`), idempotency 회귀 (재실행 시 사용자 파일 덮어쓰기·`nothing to commit` abort·`origin` 충돌), cross-platform shell 가정 (`sed -i`·`realpath -m` GNU-only / `${VAR,,}` Bash 4+), `gh api --paginate`+`--jq` 에 `--slurp` 누락, sed 치환 안전성 (`&`·구분자·`\` escape, 사용자 입력 정화), API 실패를 빈 결과로 삼키는 패턴 (`gh api ... || echo "[]"`), skill/command frontmatter `name`/`description` 누락·오류, `Read`/`Edit` 영역을 `Bash cat`/`sed` 로 우회, 새 dependency·GitHub Actions·CI/CD 권한 변경 (최소 권한·lockfile·supply-chain).
 - **Do not flag** — 포매터 영역 (들여쓰기·따옴표·trailing whitespace), import 순서, 단순 typo, 루트 `CLAUDE.md` 가 `@AGENTS.md` 한 줄 포인터인 것 ("CLAUDE.md 가 없다/내용 없다" 지적은 오탐).
 - 위 P0/P1/Do-not-flag 은 하드 최소본이다. **elaboration 만 soft** — 발견사항 제시 순서, Domain-specific 플러그인 추가/제거·skill 추가 문서 동기화 상세 체크리스트, 도입-버전 마커 오탐 예외, plugin-cache refresh 등 **전문은 [`code_review.md`](code_review.md)**.
 

--- a/code_review.md
+++ b/code_review.md
@@ -21,7 +21,7 @@
 
 ## P1 — Performance / Maintainability
 - **Plugin versioning 위반** — `plugins/<name>/.claude-plugin/plugin.json` 와 `.claude-plugin/marketplace.json` 의 version 불일치, `metadata.version` 누락.
-- **Plugin count drift** — `AGENTS.md` / `README.md` 의 플러그인 수 / badge / 트리가 marketplace.json 과 어긋남.
+- **Plugin count drift** — `AGENTS.md` 의 플러그인 수 / 목록, `README.md` 의 플러그인 수 / badge / 트리가 marketplace.json 과 어긋남.
 - **`gh api --paginate` + `--jq` 조합에 `--slurp` 누락** — multi-page 응답에서 jq 가 multiple JSON document 받음. 단, `gh` 는 `--slurp` 와 `--jq` 동시 사용을 거부하므로 `gh api --paginate --slurp ENDPOINT | jq ...` 패턴을 쓴다.
 - **Idempotency 회귀** — 같은 디렉토리 재실행 시 사용자 파일 덮어쓰기, `git commit` 이 변경 없을 때 `nothing to commit` 으로 abort, 이미 등록된 `origin` remote 에 `gh repo create --remote=origin` 충돌, 등. `[ -f X ] || cp ...` / `git diff --cached --quiet` / `git remote get-url origin` 류 가드를 한 곳에 모아 점검.
 - **Cross-platform shell 가정** — `sed -i 'cmd'` 는 GNU-only, BSD/macOS 는 `sed -i '' 'cmd'` 시그니처. `${VAR,,}` 는 Bash 4+ 전용이라 macOS 기본 `/bin/bash` 3.2 에서 bad substitution 으로 깨짐. `realpath -m` 도 GNU-only (BSD 는 `illegal option`) 이고, 맨 `realpath` 는 GNU/BSD 양쪽 다 미존재 경로에서 실패하므로 대체재가 아니다 — 아직 없는 경로까지 다루려면 `cd` + `pwd -P` 로 부모를 해석하되, 최종 컴포넌트 symlink 도 `readlink` 로 따라가야 containment 검사가 뚫리지 않는다. 전부 detect+branch (`sed --version`) 또는 POSIX alternative (`tr '[:upper:]' '[:lower:]'`) 사용.

--- a/scripts/check-doc-consistency.mjs
+++ b/scripts/check-doc-consistency.mjs
@@ -83,7 +83,9 @@ const readme = readFileSync(join(ROOT, 'README.md'), 'utf8');
 const agents = readFileSync(join(ROOT, 'AGENTS.md'), 'utf8');
 
 compareSet('README.md tree', treePluginNames(readme));
-compareSet('AGENTS.md tree', treePluginNames(agents));
+// AGENTS.md carries no structure tree (the directory layout is derivable from
+// `ls plugins/`). Its plugin name-set is guarded by the ## Plugins table below,
+// which asserts the same canonical set in both directions.
 compareSet('AGENTS.md ## Plugins table', agentsTablePlugins(agents));
 
 checkCount('README.md badge', readme, /plugins-(\d+)-blue/g, [TOTAL]);


### PR DESCRIPTION
## 배경

`/doctor` 진단에서 `AGENTS.md` 가 40,852자로 대용량 메모리 경고 하한(~40,000자)을 넘고 있었다. 이 파일은 루트 `CLAUDE.md` 의 `@AGENTS.md` import 로 **매 세션 항상 로드**되고, Codex 와 Hermes 도 같은 파일을 축자로 읽는다.

가장 큰 파생 가능(derivable) 블록은 `## 저장소 구조` 의 31줄 ASCII 디렉터리 트리였다. `ls plugins/` 한 번이면 재구성되는 내용이라 세션이 비용을 치를 이유가 없다.

## 변경

**1. `AGENTS.md` — 디렉터리 트리 삭제 (-34줄)**

트리를 한 줄 안내로 대체했다. 트리 아래 **주석 불릿 13개는 유지**한다 — `plugins/<name>/.codex-plugin/plugin.json: generated, do not edit by hand` 같은 항목은 파일 목록에서 유도되지 않는 에이전트 지시라서 파생 가능이 아니다.

40,852자 → 39,003자. 경고 기준선 아래로 내려간다. 세션당 약 500 est. 토큰 절감.

**2. `scripts/check-doc-consistency.mjs` — `AGENTS.md tree` 검사 제거 (-1줄, +주석 3줄)**

이 가드가 `AGENTS.md` 트리의 존재를 강제하고 있어 함께 뺐다. **탐지력 손실은 없다** — 바로 다음 줄의 `## Plugins` 표 검사가 같은 canonical name-set 을 같은 양방향(missing + extra)으로 이미 `AGENTS.md` 에 대해 검증한다.

검증했다. 표에서 `gws-sync` 행 하나를 지우고 실행하면:

```
doc-consistency drift detected:
  AGENTS.md ## Plugins table: missing gws-sync
exit 1
```

`README.md` 트리 검사(line 85)는 그대로 두었고, `README.md` 의 트리 27줄도 손대지 않았다.

**3. 지운 블록을 가리키던 참조 3곳 정리**

- `AGENTS.md` 플러그인 변경 규칙: `## Plugins (N)` 수와 ~~구조 트리~~ → 목록
- `AGENTS.md` P1 규칙: ~~AGENTS/README 트리·배지~~ → AGENTS 플러그인 목록·README 트리·배지
- `code_review.md` 같은 P1 항목도 동일하게 AGENTS=목록 / README=트리 로 분리

## 검증

| 게이트 | 결과 |
|---|---|
| `sync-codex-manifests.mjs --check` | up to date (24 manifests) |
| `sync-hermes-manifests.mjs --check` | up to date (14 adapter files, 7 plugins) |
| `check-doc-consistency.mjs` | OK — 24 plugins, Codex-eligible 23, Hermes 7 |
| `check-doc-consistency.mjs` (negative) | 표 행 제거 시 exit 1 — 탐지력 보존 확인 |
| `check-skill-tool-portability.mjs --check` | OK — 2 pilots, 18 baseline |
| `mock-load-hermes.py` | OK — 7 adapters |
| `cr-fix/tests/run-tests.sh` | 87 passed, 0 failed |

## 버전 범프 없음

루트 문서(`AGENTS.md`, `code_review.md`)와 `scripts/` 변경이라 `plugins/<name>/` 아래 콘텐츠가 아니다. AGENTS.md 규약대로 어떤 플러그인도 범프하지 않고 `metadata.version` 도 그대로다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Simplified the plugin directory guidance in the repository documentation.
  - Clarified requirements for keeping plugin counts, lists, and validation references synchronized when plugins change.
  - Refined review checklist wording for detecting plugin count or version discrepancies.

- **Chores**
  - Updated documentation consistency checks to validate plugin listings against the canonical plugin table.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->