### PR TITLE
fix: macOS/BSD broken 2건 — md5sum 무음 오작동 + sed c\ 이슈 본문 파괴

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Personal Claude Code plugin collection with 24 specialized plugins. Codex 0.135 + Hermes Agent native — generated `.agents/plugins/marketplace.json` + per-plugin `.codex-plugin/plugin.json` (`scripts/sync-codex-manifests.mjs`) and Hermes `plugin.yaml` + `__init__.py` adapters (`scripts/sync-hermes-manifests.mjs`).",
-    "version": "2.7.0"
+    "version": "2.7.1"
   },
   "plugins": [
     {
@@ -19,7 +19,7 @@
       "name": "github-dev",
       "source": "./plugins/github-dev",
       "description": "GitHub workflow: commit, PR, issue, worktree, unified CodeRabbit + ChatGPT-Codex cr-fix pipeline v2 (Step 5 pre-flight review detection across CR commit-status + comments + Codex reviews + Codex emoji 3-channel; autonomous Step 9 judgment replaces per-finding AskUserQuestion — LLM judges real/spurious + severity + fix-size and applies/defers/skips with logged reasoning; rate-limit sniffer now covers commit-status description + in-place comment edits; polling interval 60s → 8s; --auto-merge + --skip-minor + --cr-source retained), project tracking, release. All workflows are now skills (commit-and-push, create-issue-label, decompose-issue, update-progress, resolve-issue, release, cr-fix, post-merge) — no commands surface, so they run under Codex too. post-merge runs a mandatory built-in wiki-lore ingest step (absorbed llm-wiki:post-merge-wiki) plus an optional Step 4.5 ephemeral-artifact pruning gate (heuristic candidates → AskUserQuestion → git rm). 2.8.0 correctness repairs: CR-state fetch failures map to a real error channel (no longer masked as a clean 'none'), a null-repository GraphQL response fails loudly instead of a silent false-clean convergence, and an active `@coderabbitai rate limit` query resolves ambiguous passive rate-limit sniffs.",
-      "version": "2.11.0",
+      "version": "2.11.1",
       "category": "github"
     },
     {
@@ -68,7 +68,7 @@
       "name": "translator",
       "source": "./plugins/translator",
       "description": "Web article translation to Korean",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "category": "content"
     },
     {

--- a/plugins/github-dev/.claude-plugin/plugin.json
+++ b/plugins/github-dev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "github-dev",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "description": "GitHub workflow: commit, PR, issue, worktree, unified CodeRabbit + ChatGPT-Codex cr-fix pipeline v2 (Step 5 pre-flight review detection across CR commit-status + comments + Codex reviews + Codex emoji 3-channel; autonomous Step 9 judgment replaces per-finding AskUserQuestion — LLM judges real/spurious + severity + fix-size and applies/defers/skips with logged reasoning; rate-limit sniffer now covers commit-status description + in-place comment edits; polling interval 60s → 8s; --auto-merge + --skip-minor + --cr-source retained), project tracking, release. All workflows are now skills (commit-and-push, create-issue-label, decompose-issue, update-progress, resolve-issue, release, cr-fix, post-merge) — no commands surface, so they run under Codex too. post-merge runs a mandatory built-in wiki-lore ingest step (absorbed llm-wiki:post-merge-wiki) plus an optional Step 4.5 ephemeral-artifact pruning gate (heuristic candidates → AskUserQuestion → git rm). 2.8.0 correctness repairs: CR-state fetch failures map to a real error channel (no longer masked as a clean 'none'), a null-repository GraphQL response fails loudly instead of a silent false-clean convergence, and an active `@coderabbitai rate limit` query resolves ambiguous passive rate-limit sniffs.",
   "skills": [
     "./skills/cr-fix",

--- a/plugins/github-dev/.codex-plugin/plugin.json
+++ b/plugins/github-dev/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "github-dev",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "description": "GitHub workflow: commit, PR, issue, worktree, unified CodeRabbit + ChatGPT-Codex cr-fix pipeline v2 (Step 5 pre-flight review detection across CR commit-status + comments + Codex reviews + Codex emoji 3-channel; autonomous Step 9 judgment replaces per-finding AskUserQuestion — LLM judges real/spurious + severity + fix-size and applies/defers/skips with logged reasoning; rate-limit sniffer now covers commit-status description + in-place comment edits; polling interval 60s → 8s; --auto-merge + --skip-minor + --cr-source retained), project tracking, release. All workflows are now skills (commit-and-push, create-issue-label, decompose-issue, update-progress, resolve-issue, release, cr-fix, post-merge) — no commands surface, so they run under Codex too. post-merge runs a mandatory built-in wiki-lore ingest step (absorbed llm-wiki:post-merge-wiki) plus an optional Step 4.5 ephemeral-artifact pruning gate (heuristic candidates → AskUserQuestion → git rm). 2.8.0 correctness repairs: CR-state fetch failures map to a real error channel (no longer masked as a clean 'none'), a null-repository GraphQL response fails loudly instead of a silent false-clean convergence, and an active `@coderabbitai rate limit` query resolves ambiguous passive rate-limit sniffs.",
   "author": {
     "name": "YoungjaeDev"

--- a/plugins/github-dev/plugin.yaml
+++ b/plugins/github-dev/plugin.yaml
@@ -1,5 +1,5 @@
 name: github-dev
-version: "2.11.0"
+version: "2.11.1"
 description: "GitHub workflow: commit, PR, issue, worktree, unified CodeRabbit + ChatGPT-Codex cr-fix pipeline v2 (Step 5 pre-flight review detection across CR commit-status + comments + Codex reviews + Codex emoji 3-channel; autonomous Step 9 judgment replaces per-finding AskUserQuestion — LLM judges real/spurious + severity + fix-size and applies/defers/skips with logged reasoning; rate-limit sniffer now covers commit-status description + in-place comment edits; polling interval 60s → 8s; --auto-merge + --skip-minor + --cr-source retained), project tracking, release. All workflows are now skills (commit-and-push, create-issue-label, decompose-issue, update-progress, resolve-issue, release, cr-fix, post-merge) — no commands surface, so they run under Codex too. post-merge runs a mandatory built-in wiki-lore ingest step (absorbed llm-wiki:post-merge-wiki) plus an optional Step 4.5 ephemeral-artifact pruning gate (heuristic candidates → AskUserQuestion → git rm). 2.8.0 correctness repairs: CR-state fetch failures map to a real error channel (no longer masked as a clean 'none'), a null-repository GraphQL response fails loudly instead of a silent false-clean convergence, and an active `@coderabbitai rate limit` query resolves ambiguous passive rate-limit sniffs."
 author: "YoungjaeDev"
 kind: standalone

--- a/plugins/github-dev/skills/cr-fix/scripts/engagement-gate.sh
+++ b/plugins/github-dev/skills/cr-fix/scripts/engagement-gate.sh
@@ -10,8 +10,16 @@ reviews=$(gh api --paginate "repos/$OWNER/$REPO/pulls/$PR_NUM/reviews" 2>/dev/nu
   | jq -s 'add // []' \
   | jq --arg t "$PUSH_TIME" '[.[] | select(.user.login | test("coderabbit"; "i")) | select(.submitted_at > $t)] | length')
 
+# updated_at, not just created_at: when a re-review finds nothing, CR does not
+# post a new comment — it edits its existing walkthrough in place, leaving
+# created_at at the FIRST review. Counting created_at alone read that as "CR
+# never looked at this push", so Step 8c waited out the iteration budget and
+# ended in cr_inactive, making --auto-merge unreachable on the normal converged
+# path. sniff-cr-rate-limit.sh:25 already anchors both ways for the same reason.
+# (issue #184; reviews above keep submitted_at — a review body is not edited in
+# place the way the walkthrough comment is. unverified, tracked in #184.)
 comments=$(gh api --paginate "repos/$OWNER/$REPO/issues/$PR_NUM/comments" 2>/dev/null \
   | jq -s 'add // []' \
-  | jq --arg t "$PUSH_TIME" '[.[] | select(.user.login | test("coderabbit"; "i")) | select(.created_at > $t)] | length')
+  | jq --arg t "$PUSH_TIME" '[.[] | select(.user.login | test("coderabbit"; "i")) | select(.created_at > $t or .updated_at > $t)] | length')
 
 printf '%d\n' "$((reviews + comments))"

--- a/plugins/github-dev/skills/cr-fix/tests/fixtures/issue-comments-cr-edited-in-place.json
+++ b/plugins/github-dev/skills/cr-fix/tests/fixtures/issue-comments-cr-edited-in-place.json
@@ -1,0 +1,9 @@
+[
+  {
+    "id": 9001,
+    "user": { "login": "coderabbitai[bot]" },
+    "created_at": "2026-07-27T14:10:37Z",
+    "updated_at": "2026-07-27T14:23:19Z",
+    "body": "<!-- This is an auto-generated comment: summarize by coderabbit.ai -->\nNo actionable comments were generated in the recent review.\n\nReviewing files that changed from the base of the PR and between 86b604f13062715e11801304d6b58a0b6c90c84e and 3e5ee3e4d477b7345ca5737210a2e76cc8ea4dfe."
+  }
+]

--- a/plugins/github-dev/skills/cr-fix/tests/fixtures/issue-comments-cr-stale-only.json
+++ b/plugins/github-dev/skills/cr-fix/tests/fixtures/issue-comments-cr-stale-only.json
@@ -1,0 +1,9 @@
+[
+  {
+    "id": 9002,
+    "user": { "login": "coderabbitai[bot]" },
+    "created_at": "2026-07-27T14:10:37Z",
+    "updated_at": "2026-07-27T14:11:02Z",
+    "body": "<!-- This is an auto-generated comment: summarize by coderabbit.ai -->\nWalkthrough from a review of an EARLIER push. Never touched after the new push."
+  }
+]

--- a/plugins/github-dev/skills/cr-fix/tests/run-tests.sh
+++ b/plugins/github-dev/skills/cr-fix/tests/run-tests.sh
@@ -342,9 +342,15 @@ cat > "$GSHIM2/gh" <<SH
 cat "$FIX/pr-reviews-codex-none.json"
 SH
 chmod +x "$GSHIM2/gh"
+# Keep run_capped's status: empty stdout alone cannot tell "the watchdog killed a
+# still-waiting poll" (the pass condition) from "setup broke and the child died
+# instantly" (a false green). Measured: SIGTERM -> 143, missing script -> 127,
+# both with empty stdout. Asserting 143 is what makes the empty-output check mean
+# anything. (CodeRabbit 🟠 Major, PR #183)
 g=$(run_capped 3 env PATH="$GSHIM2:$PATH" OWNER=o REPO=r PR_NUM=42 PROCESSED='[555]' INTERVAL=1 \
-      bash "$SCRIPTS/poll-codex-grace.sh" 2>/dev/null) || true
+      bash "$SCRIPTS/poll-codex-grace.sh" 2>/dev/null); g_rc=$?
 is "no unprocessed review -> no terminal line" "$g" ""
+is "no unprocessed review -> watchdog killed it (not an early exit)" "$g_rc" 143
 rm -rf "$GSHIM2"
 
 echo

--- a/plugins/github-dev/skills/cr-fix/tests/run-tests.sh
+++ b/plugins/github-dev/skills/cr-fix/tests/run-tests.sh
@@ -19,6 +19,21 @@ ok()   { pass=$((pass+1)); printf '  ok   %s\n' "$1"; }
 bad()  { fail=$((fail+1)); printf '  FAIL %s\n     expected: %s\n     actual:   %s\n' "$1" "$2" "$3"; }
 is()   { [ "$2" = "$3" ] && ok "$1" || bad "$1" "$3" "$2"; }
 
+# run_capped SECS CMD... -- run CMD, SIGTERM it after SECS, pass its stdout through.
+# The portable stand-in for GNU `timeout`, which stock macOS/BSD does not ship;
+# used where the script under test only ends on an external signal. Always used
+# (never gated behind `command -v timeout`) so the GNU CI leg exercises the same
+# path a Mac takes -- a fallback only BSD reaches is a fallback that rots.
+# The watchdog's own stdout is closed, or command substitution would block on it.
+run_capped() {
+  local secs=$1; shift
+  "$@" & local cmd_pid=$!
+  ( sleep "$secs"; kill -TERM "$cmd_pid" 2>/dev/null ) >/dev/null 2>&1 & local wd_pid=$!
+  wait "$cmd_pid" 2>/dev/null; local rc=$?
+  kill -TERM "$wd_pid" 2>/dev/null; wait "$wd_pid" 2>/dev/null
+  return "$rc"
+}
+
 echo "parse-cr-cli-jsonl.sh"
 
 # CLI 0.6.5: `suggestions` holds patch STRINGS. `.suggestions[0].line` aborted jq
@@ -315,20 +330,22 @@ rm -rf "$GSHIM"
 # empty id. Without jq -r the empty jq result printed the two-char string '""',
 # which passed [ -n ] and ended the until-loop on round 1 (reproduced live:
 # grace poll returned {"codex_review_id":""} instantly). RED against the -s
-# variant by construction. Needs GNU timeout as the loop-breaker; skipped on
-# BSD/macOS where the suite runs via pre-commit without coreutils.
-if command -v timeout >/dev/null 2>&1; then
-  GSHIM2=$(mktemp -d)
-  cat > "$GSHIM2/gh" <<SH
+# variant by construction. poll-codex-grace.sh has no bounded-round env (its
+# contract is "caller wraps with a timeout"), so this case needs a real
+# loop-breaker. It used GNU `timeout`, absent on stock macOS/BSD, so the whole
+# block was skipped there and this regression had zero coverage on the platform
+# the pre-commit hook actually runs on. run_capped is the portable stand-in;
+# env(1) carries the environment so no assignment leaks into the shell.
+GSHIM2=$(mktemp -d)
+cat > "$GSHIM2/gh" <<SH
 #!/usr/bin/env bash
 cat "$FIX/pr-reviews-codex-none.json"
 SH
-  chmod +x "$GSHIM2/gh"
-  g=$(PATH="$GSHIM2:$PATH" OWNER=o REPO=r PR_NUM=42 PROCESSED='[555]' INTERVAL=1 \
-        timeout 3 bash "$SCRIPTS/poll-codex-grace.sh" 2>/dev/null) || true
-  is "no unprocessed review -> no terminal line" "$g" ""
-  rm -rf "$GSHIM2"
-fi
+chmod +x "$GSHIM2/gh"
+g=$(run_capped 3 env PATH="$GSHIM2:$PATH" OWNER=o REPO=r PR_NUM=42 PROCESSED='[555]' INTERVAL=1 \
+      bash "$SCRIPTS/poll-codex-grace.sh" 2>/dev/null) || true
+is "no unprocessed review -> no terminal line" "$g" ""
+rm -rf "$GSHIM2"
 
 echo
 echo "poll-cr-status.sh"

--- a/plugins/github-dev/skills/cr-fix/tests/run-tests.sh
+++ b/plugins/github-dev/skills/cr-fix/tests/run-tests.sh
@@ -354,6 +354,46 @@ is "no unprocessed review -> watchdog killed it (not an early exit)" "$g_rc" 143
 rm -rf "$GSHIM2"
 
 echo
+echo "engagement-gate.sh"
+
+# CR does NOT post a new comment when a re-review finds nothing — it EDITS its
+# existing walkthrough comment in place. Counting only `created_at` therefore
+# reads a genuine clean re-review as "CR never looked at this push", which Step
+# 8c turns into an infinite wait and finally cr_inactive, so --auto-merge can
+# never fire on the normal converged path. Reproduced on PR #183: commit status
+# said "Review completed" at 14:23:22 while the comment still carried
+# created_at 14:10:37. The sibling sniff-cr-rate-limit.sh:25 already anchors on
+# `created_at > $t or updated_at > $t`; the gate was left behind. RED against
+# the created_at-only filter by construction. (issue #184)
+ESHIM=$(mktemp -d)
+cat > "$ESHIM/gh" <<SH
+#!/usr/bin/env bash
+case "\$3" in
+  *pulls*reviews) echo '[]';;
+  *) cat "$FIX/issue-comments-cr-edited-in-place.json";;
+esac
+SH
+chmod +x "$ESHIM/gh"
+e=$(PATH="$ESHIM:$PATH" bash "$SCRIPTS/engagement-gate.sh" o r 42 "2026-07-27T14:20:43Z" 2>/dev/null) || true
+is "in-place comment edit after push counts as engagement" "$e" 1
+rm -rf "$ESHIM"
+
+# The inverse must still hold, or the gate would call every stale walkthrough
+# "engaged" and Step 8c would declare a PR converged that CR never re-read.
+ESHIM2=$(mktemp -d)
+cat > "$ESHIM2/gh" <<SH
+#!/usr/bin/env bash
+case "\$3" in
+  *pulls*reviews) echo '[]';;
+  *) cat "$FIX/issue-comments-cr-stale-only.json";;
+esac
+SH
+chmod +x "$ESHIM2/gh"
+e2=$(PATH="$ESHIM2:$PATH" bash "$SCRIPTS/engagement-gate.sh" o r 42 "2026-07-27T14:20:43Z" 2>/dev/null) || true
+is "comment untouched since before the push is not engagement" "$e2" 0
+rm -rf "$ESHIM2"
+
+echo
 echo "poll-cr-status.sh"
 
 # A persistent fetch error (state:"error" from cr-commit-state.sh) must become

--- a/plugins/github-dev/skills/update-progress/SKILL.md
+++ b/plugins/github-dev/skills/update-progress/SKILL.md
@@ -203,12 +203,26 @@ Manually sync project progress to GitHub milestones and issues. Regenerates arch
    b. **Each issue body** (Type M-2 Mermaid, marker-based replacement):
       ```bash
       # For each issue in the milestone:
-      CURRENT_BODY=$(gh issue view $ISSUE_NUM --json body --jq '.body')
+      CURRENT_BODY=$(gh issue view "$ISSUE_NUM" --json body --jq '.body')
 
       # Check for existing markers
-      if echo "$CURRENT_BODY" | grep -q "<!-- project-tracking-start -->"; then
-        # Replace section between markers
-        NEW_BODY=$(echo "$CURRENT_BODY" | sed '/<!-- project-tracking-start -->/,/<!-- project-tracking-end -->/c\<!-- project-tracking-start -->\n'"$TRACKING_SECTION"'\n<!-- project-tracking-end -->')
+      if printf '%s\n' "$CURRENT_BODY" | grep -q "<!-- project-tracking-start -->"; then
+        # Replace section between markers.
+        # awk, not `sed c\`: BSD sed rejects text on the same line as `c\`
+        # ("extra characters after \ at the end of c command") and does not expand
+        # \n inside a/i/c text. sed then wrote nothing to stdout, NEW_BODY became
+        # empty, and the unchecked `gh issue edit --body ""` below wiped the issue.
+        # TRACKING_SECTION goes through the environment rather than `awk -v`,
+        # because -v processes backslash escapes in the value.
+        # END exits non-zero on a start marker with no matching end, so a
+        # malformed body fails the guard below instead of being truncated.
+        NEW_BODY=$(TRACKING_SECTION="$TRACKING_SECTION" awk '
+          BEGIN { sec = ENVIRON["TRACKING_SECTION"] }
+          index($0, "<!-- project-tracking-start -->") { print; print sec; skip = 1; next }
+          index($0, "<!-- project-tracking-end -->")   { skip = 0 }
+          !skip
+          END { if (skip) exit 1 }
+        ' <<< "$CURRENT_BODY") || NEW_BODY=""
       else
         # Append tracking section at end
         NEW_BODY="$CURRENT_BODY
@@ -218,7 +232,12 @@ Manually sync project progress to GitHub milestones and issues. Regenerates arch
       <!-- project-tracking-end -->"
       fi
 
-      gh issue edit $ISSUE_NUM --body "$NEW_BODY"
+      # An empty body would destroy the issue. Never edit on an empty result.
+      if [ -z "$NEW_BODY" ]; then
+        echo "update-progress: marker replacement produced an empty body for #$ISSUE_NUM; skipping" >&2
+      else
+        gh issue edit "$ISSUE_NUM" --body "$NEW_BODY"
+      fi
       ```
 
    c. **Open PRs** (Type M-2 Mermaid, same marker logic):
@@ -226,8 +245,13 @@ Manually sync project progress to GitHub milestones and issues. Regenerates arch
       # For issues with open PRs:
       PR_NUMBER=$(gh pr list --search "head:feat/$ISSUE_NUM" --json number --jq '.[0].number')
       if [ -n "$PR_NUMBER" ]; then
-        # Same marker-based replacement as issues
-        gh pr edit $PR_NUMBER --body "$NEW_PR_BODY"
+        # Same marker-based replacement as issues -- including the awk form and
+        # the empty-body guard. An empty --body would wipe the PR description.
+        if [ -z "$NEW_PR_BODY" ]; then
+          echo "update-progress: marker replacement produced an empty body for PR #$PR_NUMBER; skipping" >&2
+        else
+          gh pr edit "$PR_NUMBER" --body "$NEW_PR_BODY"
+        fi
       fi
       ```
 

--- a/plugins/translator/.claude-plugin/plugin.json
+++ b/plugins/translator/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "translator",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Web article translation to Korean"
 }

--- a/plugins/translator/.codex-plugin/plugin.json
+++ b/plugins/translator/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "translator",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Web article translation to Korean",
   "author": {
     "name": "YoungjaeDev"

--- a/plugins/translator/skills/translate-web-article/scripts/download_image.sh
+++ b/plugins/translator/skills/translate-web-article/scripts/download_image.sh
@@ -13,8 +13,16 @@ if [ -z "$IMAGE_URL" ]; then
     exit 1
 fi
 
-# Generate hash from URL for unique filename
-URL_HASH=$(echo -n "$IMAGE_URL" | md5sum | cut -d' ' -f1 | head -c 12)
+# Generate hash from URL for unique filename.
+# POSIX `cksum`, not `md5sum`: md5sum does not exist on stock macOS, and because
+# it sat mid-pipeline the substitution still exited 0 (the status came from
+# `head`), so `set -e` never fired and every URL collapsed to `img_.png` —
+# multi-image articles silently overwrote one file and reported success.
+URL_HASH=$(printf '%s' "$IMAGE_URL" | cksum | cut -d' ' -f1)
+if [ -z "$URL_HASH" ]; then
+    echo "Error: failed to hash image URL" >&2
+    exit 1
+fi
 
 # Extract extension from URL (default to png)
 EXT=$(echo "$IMAGE_URL" | grep -oE '\.(png|jpg|jpeg|gif|webp|svg)' | tail -1 || echo ".png")


### PR DESCRIPTION
2026-07-27 macOS/BSD 이식성 전수 감사에서 나온 **broken 2건**과, 같은 감사의 cosmetic 항목 중 이 두 플러그인에 속하는 1건을 묶었다.

Closes #172
Closes #173
Refs #180 (`run-tests.sh:320` 부분만 — 나머지 cosmetic 항목은 후속 PR)

---

## 1. `download_image.sh` — macOS 전용 무음 오작동

```bash
set -e                                                                    # line 6
URL_HASH=$(echo -n "$IMAGE_URL" | md5sum | cut -d' ' -f1 | head -c 12)    # line 17
```

stock macOS 에 `md5sum` 이 없다. **파이프 중간**이라 command substitution 의 종료 상태는 마지막 `head` 의 0 이고 `pipefail` 도 없어 `set -e` 가 발동하지 않는다. `URL_HASH` 가 비고, line 29 의 `OUTPUT_FILE` 이 모든 URL 에서 `img_.png` 로 붕괴하며, `[ -s ]` 검사는 curl 이 성공했으므로 통과해 **exit 0 으로 성공 보고**한다. 기사에 이미지가 2장 이상이면 전부 마지막 한 장으로 덮어써진다.

`md5sum` 을 PATH 에서 제거하고 재현했다.

```
수정 전: URL_HASH=''          -> img_.png       (두 URL 모두)
수정 후: URL_HASH='253102336' -> img_253102336.png / img_719093438.png
```

POSIX `cksum` 으로 교체했다. 이 저장소가 `plugins/llm-wiki/CLAUDE.md:111` 에서 이미 `md5sum` 의 대체재로 지정해 둔 것이고, llm-wiki 훅들은 per-cwd rate-limit 마커에서 그대로 따르고 있었다 — 이 스크립트만 규칙 밖에 있었다. 빈 해시 가드도 함께 넣어 어떤 이유로든 해시가 비면 조용히 진행하지 않는다.

`echo -n` 도 같은 줄이라 `printf '%s'` 로 바꿨다 (`echo -n` 은 `/bin/sh` 빌트인에서 이식성이 없다).

## 2. `update-progress` — 이슈 본문 파괴 (플랫폼 무관)

```bash
NEW_BODY=$(echo "$CURRENT_BODY" | sed '/start/,/end/c\<!-- start -->\n'"$TRACKING_SECTION"'\n<!-- end -->')
gh issue edit $ISSUE_NUM --body "$NEW_BODY"    # 종료 상태 검사 없음
```

BSD sed 는 `c\` 뒤 같은 줄 텍스트를 거부하고 a/i/c 텍스트의 `\n` 을 확장하지 않는다.

**감사는 이것을 BSD 문제로 제출했지만, 실제로는 GNU sed 에서도 깨진다.** `$TRACKING_SECTION` 이 다중행 Mermaid 라 삽입된 실제 개행이 `c` 명령 텍스트를 종료시키기 때문이다. GNU sed 로 재현했다:

```
rc=1  stdout=0 bytes  stderr='sed: -e expression #1, char 113: extra characters after command'
```

sed 가 stdout 에 아무것도 쓰지 않아 `NEW_BODY=""` 가 되고, 검사 없이 `gh issue edit --body ""` 가 실행되어 **마일스톤 안의 모든 이슈 본문이 공백으로 파괴된다.** line 229-230 의 PR 경로도 같은 로직이다.

portable awk 마커 치환으로 교체했다. 설계 근거 셋:

- **`awk -v` 가 아니라 `ENVIRON` 경유.** `-v` 는 값 안의 백슬래시 이스케이프를 확장한다. 실측: `-v` 로 넘긴 `line1\nline2 with \t backslashes` 가 실제 개행 + 탭으로 확장됐고, `ENVIRON` 은 리터럴을 보존했다. (`wiki_session_capture.sh:41` 이 같은 함정을 이미 주석으로 남겨 뒀다.)
- **`END { if (skip) exit 1 }`.** start 마커만 있고 end 가 없는 malformed 본문에서 sed 의 range 는 EOF 까지 삼켜 뒷부분을 조용히 잘라낸다. awk 가 비영점으로 끝나면 `|| NEW_BODY=""` 가 걸리고 아래 가드가 edit 자체를 막는다. 재현으로 확인했다.
- **`index()` 사용.** 마커 문자열을 정규식이 아니라 리터럴로 다룬다.

그리고 **빈 값 가드를 issue / PR 양쪽 edit 앞에 넣었다.** 치환 메커니즘을 앞으로 무엇으로 바꾸든 이 가드가 데이터 파괴를 막는 마지막 선이다.

## 3. `run-tests.sh:320` — macOS 에서 스킵되던 회귀 케이스

`poll-codex-grace.sh` 는 종료 조건 env 가 없다 (line 3 의 계약이 "caller wraps with a timeout"). 그래서 이 케이스에는 진짜 loop-breaker 가 필요한데, GNU `timeout` 에 의존하고 있어 **stock macOS — pre-commit 훅이 실제로 도는 플랫폼 — 에서는 블록 전체가 스킵**됐다. 그 회귀(빈 결과에서 가짜 terminal 라인 방출)는 그 플랫폼에서 커버리지가 0 이었다.

`timeout` 만 제거한 PATH 로 측정했다:

```
수정 전: 86 passed
수정 후: 87 passed   ("no unprocessed review -> no terminal line" 실행됨)
```

`run_capped` watchdog 을 헬퍼로 추가하고, **`command -v timeout` 게이트 없이 무조건 사용**하도록 했다. GNU CI 레그가 Mac 과 같은 경로를 타야 썩지 않는다 — 같은 파일 line 553 이 이미 그 이유로 BSD 폴백을 GNU 러너에서도 assert 하고 있다. 환경 변수는 `env(1)` 로 실어 함수 호출 앞 할당이 셸로 새지 않게 했다.

`timeout` 의 나머지 4개 사용처(132·342·354·384)는 **손대지 않았다.** 그쪽은 `TMO=""` 폴백을 가진 hang guard 이고 케이스 자체가 결정론적으로 종료하므로 이미 정상이다.

---

## 검증

로컬 실행 결과다.

| 검사 | 결과 |
|---|---|
| `sync-codex-manifests.mjs --check` | up to date (24 manifests) |
| `sync-hermes-manifests.mjs --check` | up to date (14 adapter files, 7 plugins) |
| `check-doc-consistency.mjs` | OK — 24 plugins, Codex 23, Hermes 7 |
| `check-skill-tool-portability.mjs --check` | OK — 2 pilots, 18 baseline |
| `mock-load-hermes.py` | OK — 7 adapters |
| `cr-fix/tests/run-tests.sh` | 87 passed, 0 failed |
| `run-tests.sh` (timeout 제거 PATH) | 87 passed, 0 failed (수정 전 86) |

버전 범프: `translator 1.1.0 -> 1.1.1`, `github-dev 2.11.0 -> 2.11.1`, `metadata.version 2.7.0 -> 2.7.1`. Codex 매니페스트 + Hermes 어댑터 재생성.

**실제 macOS 하드웨어 검증은 하지 않았다(unverified).** 위 재현은 전부 Linux 에서의 등가 시뮬레이션(바이너리 제거, GNU sed 직접 실행)이다. macOS CI 레그 추가는 #182 에서 다룬다.

## 범위 밖으로 남긴 것

`update-progress/SKILL.md` 의 append 분기(마커가 아직 없을 때)가 6칸 들여쓰기된 문자열을 이슈 본문에 넣는다. GitHub 마크다운에서 6칸 들여쓰기는 코드 블록이라 트래킹 섹션이 렌더링되지 않을 수 있다. 이번 변경이 만든 문제가 아니고 sed/가드 수정과도 무관해 surgical-diff 원칙에 따라 건드리지 않았다. 별도 이슈로 다룰 가치가 있다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Bumped marketplace and plugin versions (Marketplace to 2.7.1; GitHub Dev to 2.11.1; Translator to 1.1.1).
- **Bug Fixes**
  - Prevent progress updates from overwriting issue/PR descriptions when generated content is empty.
  - Improved CR engagement counting to consider updates to existing comments after the push time.
  - Made article image downloads more portable and added stronger hashing and failure validation.
- **Tests**
  - Improved cross-platform timeout/regression testing by enforcing capped execution and validating SIGTERM behavior.
- **Documentation**
  - Updated the update-progress workflow logic to use safer section replacement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## 추가 (cr-fix 루프 중 발견)

### 4. `run-tests.sh` — watchdog 종료 상태를 버리고 있었다 (CodeRabbit 🟠 Major)

`run_capped`는 자식의 종료 상태를 돌려주는데 `|| true`가 그걸 버렸다. stdout이 비었다는 사실만으로는 통과 조건(watchdog이 아직 정상 대기 중인 poll을 SIGTERM)과 fixture 파손(자식이 즉사해 폴링을 아예 안 함)을 구분할 수 없다 — 둘 다 stdout이 비어 assertion이 자명하게 성립한다. 측정: SIGTERM 143, 스크립트 부재 127.

143을 assert하도록 고쳤다. 호출 대상을 존재하지 않는 스크립트로 바꿔 검증: `expected 143 / actual 127`로 실패한다.

역설적이게도 이건 감사 리포트가 cr-fix-tests 표면에 대해 직접 세운 기준("false-green은 skip보다 나쁘다")을, 그 결함을 고치는 코드가 스스로 어긴 사례다.

### 5. `engagement-gate.sh` — CR의 제자리 코멘트 수정을 놓쳤다 (issue #184)

이 PR의 cr-fix 루프 iter 2에서 걸렸다. CR이 재리뷰 후 지적이 없으면 새 코멘트를 달지 않고 기존 walkthrough를 제자리 수정하므로 `created_at`이 최초 리뷰 시각에 고정된다. 게이트가 `created_at`만 세어 정상 수렴을 "CR이 이 push를 안 봤다"로 오판했고, Step 8c가 이를 무한 대기 → `cr_inactive`로 처리해 **`--auto-merge`가 정상 수렴 경로에서 영원히 성립하지 못했다.**

라이브 근거 (SHA `3e5ee3e`):

```
commit status:  Review queued 14:20:43 -> in progress 14:20:45 -> completed 14:23:22 (success)
CR comment:     created_at 14:10:37 / updated_at 14:23:19
CR body:        "No actionable comments were generated in the recent review."
                "Reviewing files that changed ... between 86b604f... and 3e5ee3e..."
push_time:      14:20:43
engagement-gate -> 0     (15분 대기 후에도 0)
```

같은 디렉터리의 `sniff-cr-rate-limit.sh:25`가 이미 `created_at > $t or updated_at > $t`를 쓰고 line 18에 이유까지 적어놨다 — 한 원인에 대한 수정이 두 소비자 중 rate-limit 쪽에만 적용돼 있었다. 같은 앵커를 게이트에도 적용했다.

fixture 2종으로 양방향을 가드한다: push 이후 제자리 수정은 engagement으로 계수(구 필터에 대해 RED), push 이전 이후로 안 건드린 코멘트는 여전히 0(stale walkthrough가 수렴을 위조하지 못하게). 라이브 PR #183에 대해 `0 -> 1`로 뒤집히는 것을 확인했다.

`reviews` 분기는 `submitted_at`을 유지했다 — 리뷰 본문은 walkthrough처럼 제자리 수정되지 않지만, 이건 `unverified`이고 #184에 남겼다.

Closes #184
