### PR TITLE
fix: 이식성 잔여 — python3, 개행 경계 순회, 캐시 resolver 정렬 2중 결함

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Personal Claude Code plugin collection with 24 specialized plugins. Codex 0.135 + Hermes Agent native — generated `.agents/plugins/marketplace.json` + per-plugin `.codex-plugin/plugin.json` (`scripts/sync-codex-manifests.mjs`) and Hermes `plugin.yaml` + `__init__.py` adapters (`scripts/sync-hermes-manifests.mjs`).",
-    "version": "2.7.2"
+    "version": "2.7.3"
   },
   "plugins": [
     {
@@ -61,7 +61,7 @@
       "name": "ml-toolkit",
       "source": "./plugins/ml-toolkit",
       "description": "ML/multimodal development principles, GPU parallel processing, Gradio CV apps, CV notebook generation, interactive CV data exploration",
-      "version": "1.4.3",
+      "version": "1.4.4",
       "category": "development"
     },
     {
@@ -124,7 +124,7 @@
       "name": "project-init",
       "source": "./plugins/project-init",
       "description": "Agent-harness project lifecycle. `new` — one-shot first-day bootstrap (interview, .claude/ scaffold, minimal CLAUDE.md, AGENTS.md with Codex GitHub cloud reviewer guidelines in general/ml/web variants, README/CHANGELOG seed, gh repo create + initial push) behind a hardened preflight guard that refuses a non-empty cwd. `wiring` — its inverse for existing repos: a read-only 14-axis setup diagnostic (FAIL / WARN / ASK / INFO / SKIP / OK) covering guidance files, .claude/rules paths: scoping defeated by @import, llm-wiki layout + staging backlog, Serena onboarding, memory posture, MCP duplicate registration, Codex CLI posture + AGENTS.md byte budget, spec homes, gws-sync, .tmp, core.hooksPath, .gitignore coverage. ASK answers persist to .claude/state/wiring.json. Shared read-only detector: scripts/project_state.sh.",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "category": "planning"
     },
     {
@@ -152,7 +152,7 @@
       "name": "ppt-yeong-style",
       "source": "./plugins/ppt-yeong-style",
       "description": "yeong 스타일 강의·제안 덱 작성 규약 — ppt-master 빌드 엔진 위에 얹는 작성 레이어(엔진 자체가 아님). 스킬 3종: 메인 ppt-yeong-style(미감 시그니처 §0 'Editorial restraint, one committed accent'·md 소스 규약·작성 원칙 16종·밀도 리듬·역할 기반 색·codex-image vs SVG 경계·앱 UI 실물 강제·레버 조합 차별화·윤문·렌더 QA + references/ 6종 + 주입 페이로드) + lecture-deck(강의 덱 운영 — 실습 handouts 생성 규약·프롬프트 카드·placeholder→실캡처 스크린샷 슬롯·리넘버링 4중 동기화·전사 회고 루프·강사 노트 태그 + cc-common 47장 레퍼런스) + deck-review(관점별 리뷰 서브에이전트 4종 audience-fit·story-flow·fact-check·design-qa 병렬 오케스트레이션 + codex:rescue 교차 리뷰, 페르소나는 파라미터). 의존 스킬은 있으면 사용, 없으면 생략 + 설치 제안 문구(ppt-master만 prerequisite-stop). ppt-master로 그냥 'PPT 만들기'와 달리 yeong 규약이 필요할 때.",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "category": "design"
     },
     {

--- a/plugins/ml-toolkit/.claude-plugin/plugin.json
+++ b/plugins/ml-toolkit/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "ml-toolkit",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "ML/multimodal development principles, GPU parallel processing, Gradio CV apps, CV notebook generation, interactive CV data exploration"
 }

--- a/plugins/ml-toolkit/.codex-plugin/plugin.json
+++ b/plugins/ml-toolkit/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ml-toolkit",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "ML/multimodal development principles, GPU parallel processing, Gradio CV apps, CV notebook generation, interactive CV data exploration",
   "author": {
     "name": "YoungjaeDev"

--- a/plugins/ml-toolkit/plugin.yaml
+++ b/plugins/ml-toolkit/plugin.yaml
@@ -1,5 +1,5 @@
 name: ml-toolkit
-version: "1.4.3"
+version: "1.4.4"
 description: "ML/multimodal development principles, GPU parallel processing, Gradio CV apps, CV notebook generation, interactive CV data exploration"
 author: "YoungjaeDev"
 kind: standalone

--- a/plugins/ml-toolkit/skills/cv-notebook/references/environment-setup.md
+++ b/plugins/ml-toolkit/skills/cv-notebook/references/environment-setup.md
@@ -315,7 +315,7 @@ HF_HOME=/path/to/huggingface/cache
 #### Using venv
 ```bash
 # Create virtual environment
-python -m venv .venv
+python3 -m venv .venv
 
 # Activate
 source .venv/bin/activate  # Linux/Mac

--- a/plugins/ml-toolkit/skills/cv-notebook/references/environment-setup.md
+++ b/plugins/ml-toolkit/skills/cv-notebook/references/environment-setup.md
@@ -314,8 +314,11 @@ HF_HOME=/path/to/huggingface/cache
 
 #### Using venv
 ```bash
-# Create virtual environment
-python3 -m venv .venv
+# Create virtual environment (runs before activation, so it resolves against the
+# system PATH: macOS 12.3+ has no `python`, and a python.org Windows install has
+# no `python3` -- only `python` and the `py` launcher)
+python3 -m venv .venv        # Linux/Mac
+# py -3 -m venv .venv        # Windows
 
 # Activate
 source .venv/bin/activate  # Linux/Mac

--- a/plugins/ml-toolkit/skills/gpu-parallel-pipeline/SKILL.md
+++ b/plugins/ml-toolkit/skills/gpu-parallel-pipeline/SKILL.md
@@ -127,7 +127,16 @@ else
   SKILL_DIR="$HOME/.hermes/plugins/ml-toolkit/skills/gpu-parallel-pipeline"    # Hermes default install
 fi
 [ -d "$SKILL_DIR" ] || { echo "gpu-parallel-pipeline: skill dir not resolved" >&2; exit 1; }
-python3 "$SKILL_DIR/scripts/check_gpu_memory.py"
+
+# No single interpreter name works everywhere: macOS 12.3+ dropped `python`, and
+# a python.org Windows install ships `python` plus the `py` launcher but no
+# `python3`. Windows matters here because CUDA is actually available there.
+# Indexed array (Bash 2+, so 3.2-safe) so `py -3` stays two words under quoting.
+if   command -v python3 >/dev/null 2>&1; then PY=(python3)
+elif command -v python  >/dev/null 2>&1; then PY=(python)
+elif command -v py      >/dev/null 2>&1; then PY=(py -3)
+else echo "gpu-parallel-pipeline: no Python interpreter on PATH" >&2; exit 1; fi
+"${PY[@]}" "$SKILL_DIR/scripts/check_gpu_memory.py"
 ```
 
 **Rule of thumb:**

--- a/plugins/ml-toolkit/skills/gpu-parallel-pipeline/SKILL.md
+++ b/plugins/ml-toolkit/skills/gpu-parallel-pipeline/SKILL.md
@@ -127,7 +127,7 @@ else
   SKILL_DIR="$HOME/.hermes/plugins/ml-toolkit/skills/gpu-parallel-pipeline"    # Hermes default install
 fi
 [ -d "$SKILL_DIR" ] || { echo "gpu-parallel-pipeline: skill dir not resolved" >&2; exit 1; }
-python "$SKILL_DIR/scripts/check_gpu_memory.py"
+python3 "$SKILL_DIR/scripts/check_gpu_memory.py"
 ```
 
 **Rule of thumb:**

--- a/plugins/ml-toolkit/skills/gpu-parallel-pipeline/scripts/check_gpu_memory.py
+++ b/plugins/ml-toolkit/skills/gpu-parallel-pipeline/scripts/check_gpu_memory.py
@@ -1,11 +1,11 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """GPU memory check utility for parallel pipeline planning.
 
 Reports available GPU memory and recommends workers per GPU based on model size.
 
 Usage:
-    python check_gpu_memory.py
-    python check_gpu_memory.py --model-memory 5.0  # Specify model memory in GB
+    python3 check_gpu_memory.py
+    python3 check_gpu_memory.py --model-memory 5.0  # Specify model memory in GB
 """
 
 from __future__ import annotations

--- a/plugins/ppt-yeong-style/.claude-plugin/plugin.json
+++ b/plugins/ppt-yeong-style/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ppt-yeong-style",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "yeong 스타일 강의·제안 덱 작성 규약 — ppt-master 빌드 엔진 위에 얹는 작성 레이어(엔진 자체가 아님). 스킬 3종: 메인 ppt-yeong-style(미감 시그니처 §0 'Editorial restraint, one committed accent'·md 소스 규약·작성 원칙 16종·밀도 리듬·역할 기반 색·codex-image vs SVG 경계·앱 UI 실물 강제·레버 조합 차별화·윤문·렌더 QA + references/ 6종 + 주입 페이로드) + lecture-deck(강의 덱 운영 — 실습 handouts 생성 규약·프롬프트 카드·placeholder→실캡처 스크린샷 슬롯·리넘버링 4중 동기화·전사 회고 루프·강사 노트 태그 + cc-common 47장 레퍼런스) + deck-review(관점별 리뷰 서브에이전트 4종 audience-fit·story-flow·fact-check·design-qa 병렬 오케스트레이션 + codex:rescue 교차 리뷰, 페르소나는 파라미터). 의존 스킬은 있으면 사용, 없으면 생략 + 설치 제안 문구(ppt-master만 prerequisite-stop). ppt-master로 그냥 'PPT 만들기'와 달리 yeong 규약이 필요할 때.",
   "skills": [
     "./skills/ppt-yeong-style",

--- a/plugins/ppt-yeong-style/.codex-plugin/plugin.json
+++ b/plugins/ppt-yeong-style/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ppt-yeong-style",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "yeong 스타일 강의·제안 덱 작성 규약 — ppt-master 빌드 엔진 위에 얹는 작성 레이어(엔진 자체가 아님). 스킬 3종: 메인 ppt-yeong-style(미감 시그니처 §0 'Editorial restraint, one committed accent'·md 소스 규약·작성 원칙 16종·밀도 리듬·역할 기반 색·codex-image vs SVG 경계·앱 UI 실물 강제·레버 조합 차별화·윤문·렌더 QA + references/ 6종 + 주입 페이로드) + lecture-deck(강의 덱 운영 — 실습 handouts 생성 규약·프롬프트 카드·placeholder→실캡처 스크린샷 슬롯·리넘버링 4중 동기화·전사 회고 루프·강사 노트 태그 + cc-common 47장 레퍼런스) + deck-review(관점별 리뷰 서브에이전트 4종 audience-fit·story-flow·fact-check·design-qa 병렬 오케스트레이션 + codex:rescue 교차 리뷰, 페르소나는 파라미터). 의존 스킬은 있으면 사용, 없으면 생략 + 설치 제안 문구(ppt-master만 prerequisite-stop). ppt-master로 그냥 'PPT 만들기'와 달리 yeong 규약이 필요할 때.",
   "author": {
     "name": "YoungjaeDev"

--- a/plugins/ppt-yeong-style/plugin.yaml
+++ b/plugins/ppt-yeong-style/plugin.yaml
@@ -1,5 +1,5 @@
 name: ppt-yeong-style
-version: "0.9.3"
+version: "0.9.4"
 description: "yeong 스타일 강의·제안 덱 작성 규약 — ppt-master 빌드 엔진 위에 얹는 작성 레이어(엔진 자체가 아님). 스킬 3종: 메인 ppt-yeong-style(미감 시그니처 §0 'Editorial restraint, one committed accent'·md 소스 규약·작성 원칙 16종·밀도 리듬·역할 기반 색·codex-image vs SVG 경계·앱 UI 실물 강제·레버 조합 차별화·윤문·렌더 QA + references/ 6종 + 주입 페이로드) + lecture-deck(강의 덱 운영 — 실습 handouts 생성 규약·프롬프트 카드·placeholder→실캡처 스크린샷 슬롯·리넘버링 4중 동기화·전사 회고 루프·강사 노트 태그 + cc-common 47장 레퍼런스) + deck-review(관점별 리뷰 서브에이전트 4종 audience-fit·story-flow·fact-check·design-qa 병렬 오케스트레이션 + codex:rescue 교차 리뷰, 페르소나는 파라미터). 의존 스킬은 있으면 사용, 없으면 생략 + 설치 제안 문구(ppt-master만 prerequisite-stop). ppt-master로 그냥 'PPT 만들기'와 달리 yeong 규약이 필요할 때."
 author: "YoungjaeDev"
 kind: standalone

--- a/plugins/ppt-yeong-style/skills/lecture-deck/scripts/render-qa.sh
+++ b/plugins/ppt-yeong-style/skills/lecture-deck/scripts/render-qa.sh
@@ -43,7 +43,14 @@ b_hits=$(grep -REl '>[^<]*\[[^]]*\][^<]*<' "$SVG_DIR" 2>/dev/null || true)
 if [ -n "$b_hits" ]; then
   fail=1
   echo "  FAIL — bracket placeholder(s) leaked into rendered text:"
-  for f in $b_hits; do
+  # Iterate on newline boundaries: `for f in $b_hits` word-splits on IFS and
+  # glob-expands, so an absolute DECK_ROOT containing a space arrives here as two
+  # fragments, the grep below fails on both, and its stderr is discarded -- the
+  # FAIL detail degrades to half-paths with (0) counts. The gate itself is
+  # unaffected (fail=1 is already set above); this is the report, which is what
+  # the user reads to find the leak.
+  printf '%s\n' "$b_hits" | while IFS= read -r f; do
+    [ -n "$f" ] || continue
     c=$(grep -Eo '>[^<]*\[[^]]*\][^<]*<' "$f" 2>/dev/null | wc -l | tr -d ' ')
     echo "    $f ($c)"
   done

--- a/plugins/project-init/.claude-plugin/plugin.json
+++ b/plugins/project-init/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "project-init",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Agent-harness project lifecycle. `new` — one-shot first-day bootstrap (interview, .claude/ scaffold, minimal CLAUDE.md, AGENTS.md with Codex GitHub cloud reviewer guidelines in general/ml/web variants, README/CHANGELOG seed, gh repo create + initial push) behind a hardened preflight guard that refuses a non-empty cwd. `wiring` — its inverse for existing repos: a read-only 14-axis setup diagnostic (FAIL / WARN / ASK / INFO / SKIP / OK) covering guidance files, .claude/rules paths: scoping defeated by @import, llm-wiki layout + staging backlog, Serena onboarding, memory posture, MCP duplicate registration, Codex CLI posture + AGENTS.md byte budget, spec homes, gws-sync, .tmp, core.hooksPath, .gitignore coverage. ASK answers persist to .claude/state/wiring.json. Shared read-only detector: scripts/project_state.sh.",
   "author": {
     "name": "YoungjaeDev"

--- a/plugins/project-init/.codex-plugin/plugin.json
+++ b/plugins/project-init/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "project-init",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Agent-harness project lifecycle. `new` — one-shot first-day bootstrap (interview, .claude/ scaffold, minimal CLAUDE.md, AGENTS.md with Codex GitHub cloud reviewer guidelines in general/ml/web variants, README/CHANGELOG seed, gh repo create + initial push) behind a hardened preflight guard that refuses a non-empty cwd. `wiring` — its inverse for existing repos: a read-only 14-axis setup diagnostic (FAIL / WARN / ASK / INFO / SKIP / OK) covering guidance files, .claude/rules paths: scoping defeated by @import, llm-wiki layout + staging backlog, Serena onboarding, memory posture, MCP duplicate registration, Codex CLI posture + AGENTS.md byte budget, spec homes, gws-sync, .tmp, core.hooksPath, .gitignore coverage. ASK answers persist to .claude/state/wiring.json. Shared read-only detector: scripts/project_state.sh.",
   "author": {
     "name": "YoungjaeDev"

--- a/plugins/project-init/references/gh-repo-create-flow.md
+++ b/plugins/project-init/references/gh-repo-create-flow.md
@@ -66,8 +66,20 @@ The `--license <name>` flag of `gh repo create` can auto-generate a LICENSE file
 
 ```bash
 # Auto-seed the license
+# ${VISIBILITY,,} is a Bash 4 expansion; macOS /bin/bash is 3.2 and fails with
+# "bad substitution". Normalize with the POSIX tr helper the executable
+# procedure already uses (new-procedure.md Phase 4/6), and match on a token
+# rather than passing the raw answer straight into a CLI flag.
+to_lower() { printf '%s' "$1" | tr '[:upper:]' '[:lower:]'; }
+case "$(to_lower "$VISIBILITY")" in
+  *private*)  VIS_FLAG="private" ;;
+  *public*)   VIS_FLAG="public" ;;
+  *internal*) VIS_FLAG="internal" ;;
+  *) echo "unknown visibility: $VISIBILITY" >&2; exit 1 ;;
+esac
+
 gh repo create "${OWNER}/${PROJECT_NAME}" \
-  --${VISIBILITY,,} \
+  --${VIS_FLAG} \
   --description "${ONE_LINER}" \
   --license "${LICENSE}" \
   --source=. --remote=origin --push
@@ -88,8 +100,20 @@ git add .claude/ CLAUDE.md AGENTS.md README.md CHANGELOG.md
 git commit -m "chore: bootstrap project skeleton via project-init"
 
 # 3. gh repo create + auto push
+# ${VISIBILITY,,} is a Bash 4 expansion; macOS /bin/bash is 3.2 and fails with
+# "bad substitution". Normalize with the POSIX tr helper the executable
+# procedure already uses (new-procedure.md Phase 4/6), and match on a token
+# rather than passing the raw answer straight into a CLI flag.
+to_lower() { printf '%s' "$1" | tr '[:upper:]' '[:lower:]'; }
+case "$(to_lower "$VISIBILITY")" in
+  *private*)  VIS_FLAG="private" ;;
+  *public*)   VIS_FLAG="public" ;;
+  *internal*) VIS_FLAG="internal" ;;
+  *) echo "unknown visibility: $VISIBILITY" >&2; exit 1 ;;
+esac
+
 gh repo create "${OWNER}/${PROJECT_NAME}" \
-  --${VISIBILITY,,} \
+  --${VIS_FLAG} \
   --description "${ONE_LINER}" \
   --source=. --remote=origin --push
 ```

--- a/plugins/project-init/references/new-procedure.md
+++ b/plugins/project-init/references/new-procedure.md
@@ -30,14 +30,19 @@ if [ -z "$PLUGIN_ROOT" ]; then
   # Best-effort Codex cache lookup. Order: latest version directory under the
   # configured marketplace name; user override via $CODEX_PLUGIN_CACHE.
   cache_root="${CODEX_PLUGIN_CACHE:-$HOME/.codex/plugins/cache}"
-  # Prefer `sort -V` (GNU) for proper semver ordering; macOS / BSD sort lacks
-  # -V and would fail silently, so fall back to plain lexicographic sort.
-  # Picks fine for typical X.Y.Z under 10 — covers the realistic version range
-  # the plugin cache will ever hold for a single plugin.
+  # Sort on the version basename, not the full path: with two marketplace dirs a
+  # name like zeta/project-init/0.4.0 would otherwise outrank alpha/project-init/0.6.0.
+  # `sort -V` orders X.Y.Z properly and is present on GNU and on Apple's FreeBSD
+  # sort (10.13+), but the probe stays for userlands that predate it; the fallback
+  # is a numeric dotted-field sort, because plain lexicographic ranks 0.6.0 above
+  # 0.10.0 and would resolve to an older cached version. Same form as
+  # plugins/github-dev/skills/cr-fix/SKILL.md, whose regression test guards it.
   if sort -V </dev/null >/dev/null 2>&1; then
-    candidate=$(ls -1d "$cache_root"/*/project-init/* 2>/dev/null | sort -V | tail -1)
+    candidate=$(ls -1d "$cache_root"/*/project-init/* 2>/dev/null \
+      | awk -F/ '{print $NF "\t" $0}' | sort -V | tail -1 | cut -f2-)
   else
-    candidate=$(ls -1d "$cache_root"/*/project-init/* 2>/dev/null | sort | tail -1)
+    candidate=$(ls -1d "$cache_root"/*/project-init/* 2>/dev/null \
+      | awk -F/ '{print $NF "\t" $0}' | sort -t. -k1,1n -k2,2n -k3,3n | tail -1 | cut -f2-)
   fi
   [ -n "$candidate" ] && [ -d "$candidate" ] && PLUGIN_ROOT="$candidate"
 fi
@@ -61,7 +66,11 @@ CWD=$(pwd)
 DIR_NAME=$(basename "$CWD")
 HAS_GIT=$([ -d .git ] && echo "yes" || echo "no")
 HAS_CLAUDE=$([ -d .claude ] && echo "yes" || echo "no")
-HAS_CODE=$(find . -maxdepth 2 -type f \( -name "*.py" -o -name "*.ts" -o -name "*.js" -o -name "*.go" -o -name "*.rs" -o -name "*.java" \) 2>/dev/null | head -1 | wc -l)
+# yes/no like its neighbours, not a count: BSD `wc -l` right-pads its output, so
+# the old `| head -1 | wc -l` form yielded "       1" here while HAS_GIT and
+# HAS_CLAUDE were clean tokens. `-print -quit` also stops at the first match
+# instead of walking the whole tree.
+HAS_CODE=$([ -n "$(find . -maxdepth 2 -type f \( -name "*.py" -o -name "*.ts" -o -name "*.js" -o -name "*.go" -o -name "*.rs" -o -name "*.java" \) -print -quit 2>/dev/null)" ] && echo "yes" || echo "no")
 
 # Collect GitHub owner candidates
 bash "$PLUGIN_ROOT/scripts/infer-github-context.sh"


### PR DESCRIPTION
macOS/BSD 이식성 감사의 남은 코드 수정 묶음. 플러그인 3개(ml-toolkit, ppt-yeong-style, project-init)만 건드리므로 PR A/B 와 `marketplace.json` 충돌이 없다.

Closes #177
Closes #178
Closes #179
Refs #180 (project-init 부분 — `gh-repo-create-flow.md` 의 `${VISIBILITY,,}` 2곳, `new-procedure.md:69` 의 `wc -l`)

---

## 1. `python` -> `python3` 3곳 (#177)

macOS 12.3 (Monterey) 부터 `/usr/bin/python` 이 제거됐다.

**실질적으로 문제가 되는 건 한 곳이다.** `cv-notebook/references/environment-setup.md:318` 의 `python -m venv .venv` 는 **venv 활성화 이전**(활성화는 321행)에 실행되므로 시스템 PATH 에서 해석된다. 그 블록이 `# Linux/Mac` 으로 자기 대상을 명시하고 있어, 문서대로 따라 한 Mac 사용자는 환경 자체를 못 만든다.

같은 파일 329·348 행의 `python` 은 활성화 **이후**라 venv 인터프리터를 쓴다 — **의도적으로 손대지 않았다.**

나머지 둘(`gpu-parallel-pipeline/SKILL.md:130`, `check_gpu_memory.py` shebang + docstring)은 대상 스크립트가 `torch.cuda.is_available()` 실패 시 즉시 exit 하므로 macOS 에서는 인터프리터가 있어도 유의미한 결과가 안 나온다. 차이는 오류 메시지뿐이라 cosmetic 이고, 일관성 차원에서 같이 고쳤다.

`check_gpu_memory.py:1` 은 감사에서 **회의적 검증 판정이 기록되지 않은 유일한 항목**(`verdict: null`)이었다. 고치되 "검증됨" 으로 기록하지 않는다.

## 2. `render-qa.sh` 개행 경계 순회 (#178)

`grep -REl` 의 결과를 `for f in $b_hits` 로 순회하면 IFS 단어 분리 + glob 확장이 일어난다. 공백이 든 `DECK_ROOT` 로 재현했다.

```
[옛 형태]  /tmp/qa (0)
           test/svg_output/P03.svg (0)
[새 형태]  /tmp/qa test/svg_output/P03.svg (1)
```

조각난 경로에서 grep 이 실패하고 그 stderr 는 `2>/dev/null` 로 삼켜져, FAIL 상세가 반쪽 경로 + `(0)` 으로 오염된다.

**게이트 판정 자체는 원래 무사했다** — `fail=1` 이 이 루프보다 먼저 서기 때문이다. 손상되는 건 사용자가 leak 위치를 찾을 때 읽는 리포트다. macOS 전용이 아니고 Linux 에서 동일하게 재현된다.

## 3. project-init 캐시 resolver 백포트 (#179)

감사는 폴백이 사전순이라 `0.6.1` 이 `0.10.0` 을 이긴다는 것을 잡았다. **고치다 보니 독립된 결함이 하나 더 있었다.**

`zeta/0.4.0` 대 `alpha/0.10.0` 으로 측정했다 (정답은 `alpha/0.10.0`):

| 형태 | 결과 | |
|---|---|---|
| 전체경로 평문 `sort` | `zeta/project-init/0.4.0` | FAIL |
| 전체경로 `sort -V` | `zeta/project-init/0.4.0` | **FAIL** |
| basename 키 + `sort -V` | `alpha/project-init/0.10.0` | PASS |
| basename 키 + 숫자필드 | `alpha/project-init/0.10.0` | PASS |

**전체 경로를 정렬하면 `sort -V` 조차 틀린다** — marketplace 디렉터리 이름이 버전 성분보다 먼저 비교되어 버전에 도달하지도 못한다. basename 을 정렬 키로 앞세우는 것이 두 결함을 동시에 닫는다. `plugins/github-dev/skills/cr-fix/SKILL.md` 가 이미 쓰는 형태이고 `tests/run-tests.sh` 의 "fallback sort: 2.10.0 outranks 2.9.0" 케이스가 그걸 가드하고 있다 — 백포트가 누락돼 있었을 뿐이다.

**주석도 고쳤다.** "macOS / BSD sort lacks -V" 는 사실이 아니다 (Apple 의 FreeBSD sort 는 10.13 부터 `-V` 지원, synopsis `[-bcCdfghiRMmnrsuVz]`). 문제는 그 틀린 전제로 "X.Y.Z under 10 이면 충분" 이라며 사전순 폴백을 정당화하고 있었다는 점이다. capability probe 자체는 구형 유저랜드 대비로 유지한다.

## 4. `${VISIBILITY,,}` 2곳 + `HAS_CODE` (#180 부분)

- `gh-repo-create-flow.md:70,92` — Bash 4 전용 확장이라 macOS `/bin/bash` 3.2 에서 `bad substitution`. 실행되는 절차(`new-procedure.md` Phase 4/6)는 이미 POSIX `to_lower` + `case` 토큰 매칭으로 해결돼 있었으므로 **그 형태를 그대로 미러**했다 — 새로 설계하지 않았다. 덤으로 사용자 답변을 CLI 플래그에 날것으로 넘기지 않게 된다.
- `new-procedure.md:69` — `HAS_CODE` 가 `| head -1 | wc -l` 이라 BSD `wc` 우측 정렬 패딩으로 `"       1"` 이 된다. 이웃 `HAS_GIT`/`HAS_CLAUDE` 는 깨끗한 yes/no 였다. 같은 형태로 맞추고 `-print -quit` 으로 첫 매치에서 멈추게 했다. (감사에서 "읽는 곳이 없는 dead variable" 로 판정이 갈렸던 항목 — 저장소 전역 `git grep HAS_CODE` 는 자기 정의 한 줄뿐인 게 맞다. 삭제 대신 이웃과 일관되게 살렸다.)

---

## 검증

| 검사 | 결과 |
|---|---|
| `sync-codex-manifests.mjs --check` | up to date (24 manifests) |
| `sync-hermes-manifests.mjs --check` | up to date (14 adapter files, 7 plugins) |
| `check-doc-consistency.mjs` | OK — 24 plugins, Codex 23, Hermes 7 |
| `check-skill-tool-portability.mjs --check` | OK |
| `mock-load-hermes.py` | OK — 7 adapters |
| `cr-fix/tests/run-tests.sh` | 90 passed, 0 failed |
| `bash -n render-qa.sh` | OK |
| `py_compile check_gpu_memory.py` | OK |
| bash 4 구문 전수 스윕 | 실행 경로 잔존 0건 (남은 히트는 전부 "쓰지 말라" 는 규칙/주석) |

버전 범프: `ml-toolkit 1.4.3 -> 1.4.4`, `ppt-yeong-style 0.9.3 -> 0.9.4`, `project-init 0.6.1 -> 0.6.2`, `metadata.version 2.7.2 -> 2.7.3`. Codex 매니페스트 + Hermes 어댑터 재생성 (ml-toolkit·ppt-yeong-style 은 HERMES_ELIGIBLE).

**실제 macOS 하드웨어 검증은 없다(unverified).** 위 재현은 전부 Linux 에서의 등가 시뮬레이션이다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Releases**
  * Updated marketplace listing and bumped plugin versions for ML Toolkit, Project Init, and PPT Yeong Style.
* **Bug Fixes**
  * Improved QA leak reporting in lecture deck rendering.
  * Enhanced GPU parallel memory-check behavior by selecting the available Python interpreter automatically.
  * Improved Project Init logic for selecting cached plugin versions and detecting whether a repo contains code.
* **Documentation**
  * Updated ML Toolkit setup and examples to prefer `python3` (including venv creation guidance).
  * Refreshed Project Init `gh repo create` visibility examples for macOS-compatible behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->