### PR TITLE
feat(ci): 셸 이식성 가드 + macOS 레그 — 규칙에 강제력 부여

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -16,6 +16,10 @@ if command -v node >/dev/null 2>&1; then
   node "$repo_root/scripts/sync-hermes-manifests.mjs" --check
   node "$repo_root/scripts/check-doc-consistency.mjs"
   node "$repo_root/scripts/check-skill-tool-portability.mjs" --check
+  # GNU-only shell constructs shipped without a BSD fallback. code_review.md P1
+  # has forbidden these for a while with nothing enforcing it, which is how
+  # md5sum reached translator and broke image downloads on macOS (issue #172).
+  node "$repo_root/scripts/check-shell-portability.mjs"
   # Skill-prose progressive-disclosure smell detector — INFORMATIONAL ONLY. It exits 0
   # regardless, but the `|| true` keeps it non-blocking even if node itself errors.
   node "$repo_root/scripts/check-skill-prose.mjs" || true

--- a/.github/workflows/validate-codex.yml
+++ b/.github/workflows/validate-codex.yml
@@ -40,3 +40,53 @@ jobs:
       # primary path fails, so nothing exercised them until they broke in
       # production (issues #105, #110). Fixture-driven, no network, sub-second.
       - run: bash plugins/github-dev/skills/cr-fix/tests/run-tests.sh
+      # code_review.md P1 forbids unguarded GNU-only shell constructs, and until
+      # now nothing enforced it -- md5sum shipped in translator and collapsed every
+      # downloaded image to one filename on macOS (issue #172). Flags a construct
+      # only when no fallback, capability probe, or `# portability-ok:` sits near it.
+      - run: node scripts/check-shell-portability.mjs
+
+  # The BSD fallbacks the suite is full of can only be proven on a BSD userland.
+  # Without this leg every `stat -c || stat -f` and `date -d || date -j` branch is
+  # asserted on the GNU half alone and the other half rots unexecuted (issue #182).
+  macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - name: runner userland (informational)
+        run: |
+          echo "bash on PATH: $(which -a bash | tr '\n' ' ')"
+          echo "PATH bash:    $(bash --version | head -1)"
+          echo "/bin/bash:    $(/bin/bash --version | head -1)"
+          for t in sed grep date stat jq md5sum timeout gsed gdate gstat; do
+            printf '%-8s %s\n' "$t" "$(command -v "$t" || echo '(absent)')"
+          done
+      # `env -i PATH=/usr/bin:/bin` is the obvious way to force stock userland and
+      # it is WRONG here: on macOS jq lives under Homebrew, not /usr/bin, and the
+      # suite is built on jq -- the run would die on a missing tool rather than
+      # exercise anything. Keep the full PATH so jq resolves, and assert instead
+      # that the tools whose GNU/BSD split this leg exists to cover really are the
+      # BSD ones. GNU builds answer --version; the BSD ones reject it, so a
+      # SUCCEEDING --version means Homebrew coreutils shadowed the system tool and
+      # this leg would be re-testing the GNU half the ubuntu job already covers.
+      # Failing loudly beats a green run that proved nothing.
+      - name: assert stock BSD userland
+        run: |
+          fail=0
+          for t in sed date stat; do
+            if "$t" --version >/dev/null 2>&1; then
+              echo "::error::$t on PATH is a GNU build ($(command -v "$t")) — Homebrew coreutils shadow the BSD tool, so this leg is not testing BSD"
+              fail=1
+            else
+              echo "ok: $t is the BSD build ($(command -v "$t"))"
+            fi
+          done
+          command -v jq >/dev/null 2>&1 || { echo "::error::jq is absent; the suite cannot run"; fail=1; }
+          exit "$fail"
+      # /bin/bash explicitly, never `bash`: the runner image may carry Homebrew's
+      # bash 5 earlier on PATH, and a real Mac user's /bin/bash is 3.2. Running the
+      # suite under 5 would let a bash-4-only construct pass here and break for them.
+      - name: cr-fix suite under /bin/bash (3.2) + BSD tools
+        run: /bin/bash plugins/github-dev/skills/cr-fix/tests/run-tests.sh

--- a/.github/workflows/validate-codex.yml
+++ b/.github/workflows/validate-codex.yml
@@ -76,7 +76,14 @@ jobs:
         run: |
           fail=0
           for t in sed date stat; do
-            if "$t" --version >/dev/null 2>&1; then
+            # Presence first. `"$t" --version` failing means EITHER "BSD rejects
+            # the flag" OR "the tool is not installed", and folding those together
+            # would report an absent tool as a healthy BSD one -- the exact
+            # could-not-look-reads-as-nothing-wrong bug this step exists to prevent.
+            if ! command -v "$t" >/dev/null 2>&1; then
+              echo "::error::$t is not on PATH — cannot tell whether this runner has a BSD userland"
+              fail=1
+            elif "$t" --version >/dev/null 2>&1; then
               echo "::error::$t on PATH is a GNU build ($(command -v "$t")) — Homebrew coreutils shadow the BSD tool, so this leg is not testing BSD"
               fail=1
             else

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -256,9 +256,14 @@ node scripts/sync-hermes-manifests.mjs --check   # CI drift guard (validate-code
 node scripts/sync-codex-manifests.mjs --check
 node scripts/sync-hermes-manifests.mjs --check
 node scripts/check-doc-consistency.mjs
+node scripts/check-shell-portability.mjs
 ```
 
-`check-doc-consistency.mjs` 는 README 구조 트리·`## Plugins` 표·문서에 박힌 카운트 문자열을 marketplace.json 과 대조하고 `.githooks/pre-commit` 에서 차단한다. 문서 블록이 관례가 아니라 기계적으로 강제된다는 뜻이므로, 어떤 문서 내용을 "코드에서 재생성 가능하니 지워도 된다" 고 판단하기 전에 훅이 그 블록을 요구하는지 먼저 확인한다. 가드 5종 전체 설명은 `README.md` 의 "CI 가드가 지키는 것".
+`check-doc-consistency.mjs` 는 README 구조 트리·`## Plugins` 표·문서에 박힌 카운트 문자열을 marketplace.json 과 대조하고 `.githooks/pre-commit` 에서 차단한다. 문서 블록이 관례가 아니라 기계적으로 강제된다는 뜻이므로, 어떤 문서 내용을 "코드에서 재생성 가능하니 지워도 된다" 고 판단하기 전에 훅이 그 블록을 요구하는지 먼저 확인한다. 가드 6종 전체 설명은 `README.md` 의 "CI 가드가 지키는 것".
+
+`check-shell-portability.mjs` 는 `code_review.md` P1 의 크로스플랫폼 규칙을 기계적으로 강제한다 — GNU 전용 구문(`md5sum`·`sed -i`·`grep -P`·`date -d`·`stat -c`·`timeout`·`${VAR,,}`·`mapfile`·`declare -A` 등)이 **폴백도 capability probe 도 없이** 쓰인 경우만 잡는다. 정상 폴백 쌍(`stat -c … || stat -f …`)과 probe 분기는 통과하며, 증거는 **코드여야 하고 주석은 인정하지 않는다** (대체재를 언급하는 주석이 실제 폴백으로 계수되면 이 가드가 존재하는 이유인 `md5sum` 자체가 새어나간다). 정말 예외인 줄은 `# portability-ok: <사유>` 로 표시한다. `.llmwiki/`·`.claude/spec/`·`code_review.md`·`AGENTS.md` 는 그 구문을 *설명*할 뿐이라 스캔에서 제외된다.
+
+macOS CI 레그(`validate-codex.yml` 의 `macos` job)는 BSD 폴백이 실제로 실행되는 유일한 지점이다. `env -i PATH=/usr/bin:/bin` 는 쓰지 않는다 — macOS 에서 `jq` 가 Homebrew 경로에 있어 스위트가 도구 부재로 죽는다. 대신 `sed`/`date`/`stat` 이 `--version` 을 거부하는지(=BSD 빌드인지) assert 하고, Homebrew coreutils 가 시스템 도구를 가리면 시끄럽게 실패시킨다. 스위트는 `bash` 가 아니라 `/bin/bash` 로 돌려 bash 3.2 를 강제한다 (러너 PATH 의 Homebrew bash 5 로 돌면 bash-4 전용 구문이 여기서 통과하고 사용자에게서 깨진다).
 
 - 로컬 Codex CLI 에서 marketplace 등록 확인:
 

--- a/README.md
+++ b/README.md
@@ -725,15 +725,18 @@ node scripts/install-skills.mjs
 
 ### CI 가드가 지키는 것 (curation / security)
 
-shared-source 배선은 5개 가드가 매 PR 과 매 커밋(`.githooks/pre-commit`)에서 함께 검증합니다 — 한 런타임에만 보이는 변경이 다른 도구체인에 조용히 깨진 채로 나가는 것을 막는 것이 목적입니다:
+shared-source 배선은 6개 가드가 매 PR 과 매 커밋(`.githooks/pre-commit`)에서 함께 검증합니다 — 한 런타임에만 보이는 변경이 다른 도구체인에 조용히 깨진 채로 나가는 것을 막는 것이 목적입니다:
 
 - `sync-codex-manifests.mjs --check` — Codex 매니페스트 drift + skill `description` 1024자 초과(Codex silent skip) + 번들 hook 디스크립터 shape·참조 스크립트 존재·orphan.
 - `sync-hermes-manifests.mjs --check` — Hermes 어댑터 drift + orphan.
 - `check-doc-consistency.mjs` — 플러그인 트리·표·카운트(총 24 / Codex-eligible 23 / Hermes 7)가 `manifest-eligibility.mjs` SoT 와 일치.
 - `check-skill-tool-portability.mjs --check` — 공유 스킬 본문의 `AskUserQuestion` 사용이 파일럿 표준 매핑 또는 baseline 에 등록됐는지(미등록 크로스런타임 상호작용 경로 차단).
+- `check-shell-portability.mjs` — GNU 전용 셸 구문(`md5sum`·`sed -i`·`grep -P`·`date -d`·`stat -c`·`timeout`·`${VAR,,}`·`mapfile`·`declare -A` 등)이 **폴백도 capability probe 도 없이** 쓰인 경우 차단. 정상 폴백 쌍(`stat -c … || stat -f …`)과 probe 분기는 통과하고, 증거는 코드만 인정합니다(대체재를 언급하는 주석은 폴백이 아님). 예외는 `# portability-ok: <사유>`.
 - `check-skill-prose.mjs` — 500줄 초과·깊은 참조 경로에 대한 정보성 경고(비차단, 항상 exit 0).
 
-drift·길이·shape 위반은 **차단**(exit 1)이고, prose 경고는 측정치일 뿐 커밋을 막지 않습니다. 어느 가드도 소스를 자동 수정하지 않습니다 — 위반을 보고할 뿐이니, 로컬에서 generator 를 재실행해 파생물을 맞춘 뒤 다시 커밋하세요.
+CI 는 여기에 더해 **macOS 레그**(`validate-codex.yml` 의 `macos` job)를 돌립니다. cr-fix 스위트가 품은 BSD 폴백들은 GNU 러너에서 절반만 실행되므로, macOS 레그가 그 나머지 절반이 실제로 도는 유일한 지점입니다. `env -i PATH=/usr/bin:/bin` 는 쓰지 않습니다 — macOS 에서 `jq` 가 Homebrew 경로에 있어 스위트가 도구 부재로 죽습니다. 대신 `sed`/`date`/`stat` 이 BSD 빌드인지 assert 하고(Homebrew coreutils 가 시스템 도구를 가리면 실패), 스위트는 `/bin/bash` 로 돌려 bash 3.2 를 강제합니다.
+
+drift·길이·shape·이식성 위반은 **차단**(exit 1)이고, prose 경고는 측정치일 뿐 커밋을 막지 않습니다. 어느 가드도 소스를 자동 수정하지 않습니다 — 위반을 보고할 뿐이니, 로컬에서 generator 를 재실행해 파생물을 맞춘 뒤 다시 커밋하세요.
 
 ### 머신 로컬 운영 갱신 (PR 밖 오퍼레이터 체크리스트)
 

--- a/docs/audit/measure-skills.mjs
+++ b/docs/audit/measure-skills.mjs
@@ -58,6 +58,10 @@ function extractDescription(text) {
 
 function walkDepth(dir, base, acc) {
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    // .DS_Store is gitignored, so it never shows in a diff -- but this script
+    // walks the working tree, and on a Mac Finder leaves one in every visited
+    // directory, inflating ref_files by one for the affected skill.
+    if (entry.name.startsWith('.')) continue;
     const full = join(dir, entry.name);
     if (entry.isDirectory()) {
       walkDepth(full, base, acc);
@@ -122,18 +126,27 @@ function measure(root) {
 
 const root = process.cwd();
 const rows = measure(root);
+// Ties on `lines` used to keep readdir order, which differs between ext4 and
+// APFS -- so regenerating skill-measurements.csv on a Mac produced a diff with
+// no content change (there are real ties in it: 39, 52, 67, 81). Break ties on
+// plugin+skill with plain byte comparison; localeCompare would swap one
+// platform dependency for an ICU one.
+const byLinesThenName = (a, b) =>
+  b.lines - a.lines ||
+  (a.plugin < b.plugin ? -1 : a.plugin > b.plugin ? 1 : 0) ||
+  (a.skill < b.skill ? -1 : a.skill > b.skill ? 1 : 0);
 const cols = ['plugin', 'skill', 'lines', 'body_tokens', 'desc_chars', 'desc_tokens',
   'sections', 'ref_files', 'ref_depth', 'has_scripts', 'v_lines', 'v_desc', 'v_refdepth'];
 
 if (process.argv.includes('--md')) {
   console.log('| ' + cols.join(' | ') + ' |');
   console.log('|' + cols.map(() => '---').join('|') + '|');
-  for (const r of rows.sort((a, b) => b.lines - a.lines)) {
+  for (const r of rows.sort(byLinesThenName)) {
     console.log('| ' + cols.map((c) => r[c]).join(' | ') + ' |');
   }
 } else {
   console.log(cols.join(','));
-  for (const r of rows.sort((a, b) => b.lines - a.lines)) {
+  for (const r of rows.sort(byLinesThenName)) {
     console.log(cols.map((c) => r[c]).join(','));
   }
 }

--- a/scripts/check-shell-portability.mjs
+++ b/scripts/check-shell-portability.mjs
@@ -31,29 +31,37 @@ import { readFileSync } from 'node:fs'
 // alt:   the POSIX / portable replacement named in the failure message
 // probe: extra regex whose presence nearby proves the author branched on it
 const RULES = [
-  { id: 'md5sum',      token: /(^|[\s|(`$])md5sum\b/,            bsd: /\b(cksum|md5)\b/,        alt: 'cksum (POSIX) or `md5sum || md5`' },
-  { id: 'sha256sum',   token: /(^|[\s|(`$])sha256sum\b/,         bsd: /\bshasum\b/,             alt: '`sha256sum || shasum -a 256`' },
-  { id: 'sed -i',      token: /\bsed\s+(-[a-zA-Z]*\s+)*-i(\s|$)(?!\s*(''|""))/, bsd: /sed\s+-i\s+''/,           alt: "a sed_inplace() helper branching on `sed --version` (GNU takes `-i`, BSD takes `-i ''`)" },
-  { id: 'sed -r',      token: /\bsed\s+(-[a-zA-Z]*\s+)*-r(\s|$)/, alt: 'sed -E (accepted by both GNU and BSD)' },
-  { id: 'grep -P',     token: /\bgrep\s+(-[a-zA-Z]*\s+)*-[a-zA-Z]*P(\s|$)/, alt: "sed -n 's/…/\\1/p' or awk (BSD grep has no PCRE at all)" },
-  { id: 'date -d',     token: /\bdate\s+(-[a-zA-Z]+\s+)*-d(\s|=)/, bsd: /\bdate\s+-j\b/,          alt: '`date -d … || date -j -f FMT …`' },
-  { id: 'stat -c',     token: /\bstat\s+(-[a-zA-Z]+\s+)*-c(\s|=)/, bsd: /\bstat\s+(-[a-zA-Z]+\s+)*-f\b/, alt: '`stat -c … || stat -f …`' },
-  { id: 'timeout',     token: /(^|[\s|(`$])timeout\s+\d/,        alt: 'a bash watchdog (see cr-fix tests run_capped) -- stock macOS has no timeout(1)' },
-  { id: 'tac',         token: /(^|[\s|(`$])tac(\s|$)/,           bsd: /\btail\s+-r\b/,          alt: 'tail -r' },
-  { id: 'nproc',       token: /(^|[\s|(`$])nproc(\s|$)/,         bsd: /sysctl\s+-n\s+hw\.ncpu/, alt: '`nproc || sysctl -n hw.ncpu`' },
-  { id: 'realpath -m', token: /\brealpath\s+(-[a-zA-Z]+\s+)*-m(\s|$)/, alt: 'cd + pwd -P on the parent, then re-append the basename (see cr-fix path-trust.sh)' },
-  { id: 'readlink -f', token: /\breadlink\s+(-[a-zA-Z]+\s+)*-f(\s|$)/, alt: 'a readlink loop, or guard on macOS >= 12.3' },
-  { id: 'bash4-case',  token: /\$\{[A-Za-z_][A-Za-z0-9_]*(,,|\^\^)\}/, alt: "tr '[:upper:]' '[:lower:]' -- macOS /bin/bash is 3.2" },
-  { id: 'bash4-mapfile', token: /(^|[\s;&|(])(mapfile|readarray)(\s|$)/, alt: 'a while read -r loop -- mapfile is bash 4+' },
-  { id: 'bash4-assoc', token: /\bdeclare\s+(-[a-zA-Z]+\s+)*-A(\s|$)/, alt: 'parallel indexed arrays -- associative arrays are bash 4+' },
-  { id: 'bash4-nameref', token: /\b(declare|local)\s+(-[a-zA-Z]+\s+)*-n(\s|$)/, alt: 'pass the value, not the name -- namerefs are bash 4.3+' },
-]
+  { id: 'md5sum', tool: 'md5sum',      token: /(^|[\s|(`$])md5sum\b/,            bsd: /\b(cksum|md5)\b/,        alt: 'cksum (POSIX) or `md5sum || md5`' },
+  { id: 'sha256sum', tool: 'sha256sum',   token: /(^|[\s|(`$])sha256sum\b/,         bsd: /\bshasum\b/,             alt: '`sha256sum || shasum -a 256`' },
+  { id: 'sed -i', tool: 'sed',      token: /\bsed\s+(-[a-zA-Z]*\s+)*-i(\s|$)(?!\s*(''|""))/, bsd: /sed\s+-i\s+''/,           alt: "a sed_inplace() helper branching on `sed --version` (GNU takes `-i`, BSD takes `-i ''`)" },
+  { id: 'sed -r', tool: 'sed',      token: /\bsed\s+(-[a-zA-Z]*\s+)*-[a-zA-Z]*r[a-zA-Z]*(\s|$)/, alt: 'sed -E (accepted by both GNU and BSD)' },
+  { id: 'grep -P', tool: 'grep',     token: /\bgrep\s+(-[a-zA-Z]*\s+)*-[a-zA-Z]*P[a-zA-Z]*(\s|$)/, alt: "sed -n 's/…/\\1/p' or awk (BSD grep has no PCRE at all)" },
+  { id: 'date -d', tool: 'date',     token: /\bdate\s+(-[a-zA-Z]+\s+)*-[a-zA-Z]*d[a-zA-Z]*(\s|=)/, bsd: /\bdate\s+-j\b/,          alt: '`date -d … || date -j -f FMT …`' },
+  { id: 'stat -c', tool: 'stat',     token: /\bstat\s+(-[a-zA-Z]+\s+)*-[a-zA-Z]*c[a-zA-Z]*(\s|=)/, bsd: /\bstat\s+(-[a-zA-Z]+\s+)*-f\b/, alt: '`stat -c … || stat -f …`' },
+  { id: 'timeout', tool: 'timeout',     token: /(^|[\s|(`$])timeout\s+\d/,        alt: 'a bash watchdog (see cr-fix tests run_capped) -- stock macOS has no timeout(1)' },
+  { id: 'tac', tool: 'tac',         token: /(^|[\s|(`$])tac(\s|$)/,           bsd: /\btail\s+-r\b/,          alt: 'tail -r' },
+  { id: 'nproc', tool: 'nproc',       token: /(^|[\s|(`$])nproc(\s|$)/,         bsd: /sysctl\s+-n\s+hw\.ncpu/, alt: '`nproc || sysctl -n hw.ncpu`' },
+  { id: 'realpath -m', tool: 'realpath', token: /\brealpath\s+(-[a-zA-Z]+\s+)*-m(\s|$)/, alt: 'cd + pwd -P on the parent, then re-append the basename (see cr-fix path-trust.sh)' },
+  { id: 'readlink -f', tool: 'readlink', token: /\breadlink\s+(-[a-zA-Z]+\s+)*-f(\s|$)/, alt: 'a readlink loop, or guard on macOS >= 12.3' },
+  { id: 'bash4-case', tool: 'bash',  token: /\$\{[A-Za-z_][A-Za-z0-9_]*(,,|\^\^)\}/, alt: "tr '[:upper:]' '[:lower:]' -- macOS /bin/bash is 3.2" },
+  { id: 'bash4-mapfile', tool: 'bash', token: /(^|[\s;&|(])(mapfile|readarray)(\s|$)/, alt: 'a while read -r loop -- mapfile is bash 4+' },
+  { id: 'bash4-assoc', tool: 'bash', token: /\bdeclare\s+(-[a-zA-Z]+\s+)*-A(\s|$)/, alt: 'parallel indexed arrays -- associative arrays are bash 4+' },
+  { id: 'bash4-nameref', tool: 'bash', token: /\b(declare|local)\s+(-[a-zA-Z]+\s+)*-n(\s|$)/, alt: 'pass the value, not the name -- namerefs are bash 4.3+' },
+].map((r) => ({ ...r, probe: toolProbe(r.tool) }))
 
 // A probe or an alternative anywhere in this window proves the author handled it.
 // A GNU-first idiom often puts its BSD counterpart on the NEXT lines
 // (`ts=$(date -d …) && return; ts=$(date -j -f …) && return`), so look both ways.
 const WINDOW = 4
-const PROBE = /command\s+-v\s|--version|type\s+-P\s|sort\s+-V\s*<\s*\/dev\/null|\bcase\s+"?\$\(uname/
+// A probe must name the tool it is probing. A generic /command -v/ let an
+// UNRELATED probe nearby clear a finding: `command -v node || exit` two lines
+// above an `md5sum` call marked the md5sum handled. `uname` branching is the one
+// probe that legitimately covers any tool, so it stays generic.
+const GENERIC_PROBE = /\bcase\s+"?\$\(uname|\buname\s+-s\b/
+function toolProbe(tool) {
+  const t = tool.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  return new RegExp(`(command\\s+-v\\s+${t}|type\\s+-P\\s+${t}|\\b${t}\\s+(-[a-zA-Z]+\\s+)*--version|${t}\\s+-V\\s*<\\s*/dev/null)`)
+}
 const ESCAPE = /#\s*portability-ok/
 
 // Rule text and lore DESCRIBE these constructs; they never run them.
@@ -131,7 +139,8 @@ for (const file of files) {
         if (near === undefined) continue
         if (ESCAPE.test(near)) { handled = true; break }
         const nearCode = stripComment(near)
-        if (PROBE.test(nearCode)) { handled = true; break }
+        if (GENERIC_PROBE.test(nearCode)) { handled = true; break }
+        if (rule.probe.test(nearCode)) { handled = true; break }
         if (rule.bsd && k !== 0 && rule.bsd.test(nearCode)) { handled = true; break }
       }
       if (handled) continue

--- a/scripts/check-shell-portability.mjs
+++ b/scripts/check-shell-portability.mjs
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+// Flag GNU-only shell constructs that ship WITHOUT a BSD/macOS fallback.
+//
+// Usage: node scripts/check-shell-portability.mjs [--check]
+//        (--check is accepted for symmetry with the other guards; the script
+//         always just reports and exits non-zero on a finding)
+//
+// This exists because code_review.md P1 has forbidden these constructs for a
+// while and nothing enforced it: `md5sum` shipped in translator's
+// download_image.sh and silently collapsed every image to one filename on
+// macOS (issue #172). A grep denylist would have caught it in a second.
+//
+// The hard part is NOT finding the tokens, it is not crying wolf. This repo is
+// full of CORRECT uses -- `stat -c %Y f || stat -f %m f`, `sha256sum || shasum
+// -a 256`, `sed -i` inside a `sed --version` probe branch -- and a guard that
+// flags those gets switched off within a week. So a token only counts as a
+// finding when nothing nearby makes it portable:
+//
+//   - a `||` alternative on the same line
+//   - a capability probe (`command -v x`, `x --version`, `sort -V </dev/null`)
+//     or the tool's BSD counterpart within 4 lines either way -- in CODE, not
+//     in a comment that merely names the alternative
+//   - an explicit `# portability-ok: <reason>` escape hatch
+//
+// Node 18 builtins only, per the repo's generator convention.
+
+import { execFileSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+
+// token: a regex matching the GNU-only construct
+// alt:   the POSIX / portable replacement named in the failure message
+// probe: extra regex whose presence nearby proves the author branched on it
+const RULES = [
+  { id: 'md5sum',      token: /(^|[\s|(`$])md5sum\b/,            bsd: /\b(cksum|md5)\b/,        alt: 'cksum (POSIX) or `md5sum || md5`' },
+  { id: 'sha256sum',   token: /(^|[\s|(`$])sha256sum\b/,         bsd: /\bshasum\b/,             alt: '`sha256sum || shasum -a 256`' },
+  { id: 'sed -i',      token: /\bsed\s+(-[a-zA-Z]*\s+)*-i(\s|$)(?!\s*(''|""))/, bsd: /sed\s+-i\s+''/,           alt: "a sed_inplace() helper branching on `sed --version` (GNU takes `-i`, BSD takes `-i ''`)" },
+  { id: 'sed -r',      token: /\bsed\s+(-[a-zA-Z]*\s+)*-r(\s|$)/, alt: 'sed -E (accepted by both GNU and BSD)' },
+  { id: 'grep -P',     token: /\bgrep\s+(-[a-zA-Z]*\s+)*-[a-zA-Z]*P(\s|$)/, alt: "sed -n 's/…/\\1/p' or awk (BSD grep has no PCRE at all)" },
+  { id: 'date -d',     token: /\bdate\s+(-[a-zA-Z]+\s+)*-d(\s|=)/, bsd: /\bdate\s+-j\b/,          alt: '`date -d … || date -j -f FMT …`' },
+  { id: 'stat -c',     token: /\bstat\s+(-[a-zA-Z]+\s+)*-c(\s|=)/, bsd: /\bstat\s+(-[a-zA-Z]+\s+)*-f\b/, alt: '`stat -c … || stat -f …`' },
+  { id: 'timeout',     token: /(^|[\s|(`$])timeout\s+\d/,        alt: 'a bash watchdog (see cr-fix tests run_capped) -- stock macOS has no timeout(1)' },
+  { id: 'tac',         token: /(^|[\s|(`$])tac(\s|$)/,           bsd: /\btail\s+-r\b/,          alt: 'tail -r' },
+  { id: 'nproc',       token: /(^|[\s|(`$])nproc(\s|$)/,         bsd: /sysctl\s+-n\s+hw\.ncpu/, alt: '`nproc || sysctl -n hw.ncpu`' },
+  { id: 'realpath -m', token: /\brealpath\s+(-[a-zA-Z]+\s+)*-m(\s|$)/, alt: 'cd + pwd -P on the parent, then re-append the basename (see cr-fix path-trust.sh)' },
+  { id: 'readlink -f', token: /\breadlink\s+(-[a-zA-Z]+\s+)*-f(\s|$)/, alt: 'a readlink loop, or guard on macOS >= 12.3' },
+  { id: 'bash4-case',  token: /\$\{[A-Za-z_][A-Za-z0-9_]*(,,|\^\^)\}/, alt: "tr '[:upper:]' '[:lower:]' -- macOS /bin/bash is 3.2" },
+  { id: 'bash4-mapfile', token: /(^|[\s;&|(])(mapfile|readarray)(\s|$)/, alt: 'a while read -r loop -- mapfile is bash 4+' },
+  { id: 'bash4-assoc', token: /\bdeclare\s+(-[a-zA-Z]+\s+)*-A(\s|$)/, alt: 'parallel indexed arrays -- associative arrays are bash 4+' },
+  { id: 'bash4-nameref', token: /\b(declare|local)\s+(-[a-zA-Z]+\s+)*-n(\s|$)/, alt: 'pass the value, not the name -- namerefs are bash 4.3+' },
+]
+
+// A probe or an alternative anywhere in this window proves the author handled it.
+// A GNU-first idiom often puts its BSD counterpart on the NEXT lines
+// (`ts=$(date -d …) && return; ts=$(date -j -f …) && return`), so look both ways.
+const WINDOW = 4
+const PROBE = /command\s+-v\s|--version|type\s+-P\s|sort\s+-V\s*<\s*\/dev\/null|\bcase\s+"?\$\(uname/
+const ESCAPE = /#\s*portability-ok/
+
+// Rule text and lore DESCRIBE these constructs; they never run them.
+const SKIP_FILES = [
+  'code_review.md',
+  'AGENTS.md',
+  'scripts/check-shell-portability.mjs',
+]
+const SKIP_PREFIXES = ['.llmwiki/', '.claude/spec/', 'docs/superpowers/']
+
+function tracked(patterns) {
+  return execFileSync('git', ['ls-files', ...patterns], { encoding: 'utf8' })
+    .split('\n').filter(Boolean)
+}
+
+// For .md, only fenced bash/sh blocks are executable; the rest is prose.
+function executableLines(path, text) {
+  const out = []
+  const lines = text.split('\n')
+  if (!path.endsWith('.md')) {
+    lines.forEach((l, i) => out.push({ n: i + 1, text: l }))
+    return out
+  }
+  let inBlock = false
+  lines.forEach((l, i) => {
+    const fence = l.match(/^\s*```+\s*(\w+)?/)
+    if (fence) {
+      if (inBlock) inBlock = false
+      else inBlock = ['bash', 'sh', 'shell', 'zsh'].includes((fence[1] || '').toLowerCase())
+      return
+    }
+    if (inBlock) out.push({ n: i + 1, text: l })
+  })
+  return out
+}
+
+function stripComment(line) {
+  // Good enough for shell: drop from an unquoted # to end of line.
+  let q = null
+  for (let i = 0; i < line.length; i++) {
+    const c = line[i]
+    if (q) { if (c === q && line[i - 1] !== '\\') q = null; continue }
+    if (c === '"' || c === "'") { q = c; continue }
+    if (c === '#' && (i === 0 || /\s/.test(line[i - 1]))) return line.slice(0, i)
+  }
+  return line
+}
+
+const files = tracked(['*.sh', '*.md', '*.bash'])
+  .filter((f) => !SKIP_FILES.includes(f) && !SKIP_PREFIXES.some((p) => f.startsWith(p)))
+
+const findings = []
+for (const file of files) {
+  let text
+  try { text = readFileSync(file, 'utf8') } catch { continue }
+  const lines = executableLines(file, text)
+  const byIndex = new Map(lines.map((l) => [l.n, l.text]))
+  for (const { n, text: raw } of lines) {
+    if (ESCAPE.test(raw)) continue
+    const code = stripComment(raw)
+    if (!code.trim()) continue
+    for (const rule of RULES) {
+      if (!rule.token.test(code)) continue
+      // same-line alternative
+      if (code.includes('||')) continue
+      // probe on this line or just above (comments included -- a `sed --version`
+      // probe is often the line before, and its own comment names the tool)
+      // Evidence has to be CODE. A comment that names the portable alternative
+      // ("POSIX cksum, not md5sum: ...") is documentation, not a fallback -- and
+      // counting it let the exact md5sum bug this guard exists for slip through.
+      // The escape hatch is the one thing that IS a comment, by design.
+      let handled = false
+      for (let k = -WINDOW; k <= WINDOW; k++) {
+        const near = byIndex.get(n + k)
+        if (near === undefined) continue
+        if (ESCAPE.test(near)) { handled = true; break }
+        const nearCode = stripComment(near)
+        if (PROBE.test(nearCode)) { handled = true; break }
+        if (rule.bsd && k !== 0 && rule.bsd.test(nearCode)) { handled = true; break }
+      }
+      if (handled) continue
+      findings.push({ file, n, id: rule.id, alt: rule.alt, code: code.trim() })
+    }
+  }
+}
+
+if (findings.length === 0) {
+  console.log(`shell-portability OK — ${files.length} files scanned, no unguarded GNU-only construct.`)
+  process.exit(0)
+}
+
+console.error(`shell-portability: ${findings.length} unguarded GNU-only construct(s)\n`)
+for (const f of findings) {
+  console.error(`  ${f.file}:${f.n}  [${f.id}]`)
+  console.error(`    ${f.code}`)
+  console.error(`    use: ${f.alt}`)
+}
+console.error(`
+Each of these runs on a contributor's machine. Stock macOS ships BSD userland and
+bash 3.2, so an unguarded GNU-only call either errors or -- worse -- succeeds with
+the wrong result (see code_review.md P1, "종료 상태가 사라지는 자리").
+
+Add a portable fallback, branch on a capability probe, or -- when the construct is
+genuinely fine here -- annotate the line with "# portability-ok: <reason>".`)
+process.exit(1)


### PR DESCRIPTION
macOS/BSD 이식성 감사의 **구조적 갭** 두 개를 닫는다. 이 PR 이 마지막이고, 의도적으로 마지막이다 — denylist 는 PR A/B/C 가 위반을 전부 없앤 뒤에만 green 일 수 있다.

Closes #176
Closes #182
Refs #180 (`measure-skills.mjs` 부분 — cosmetic 목록 잔여)

---

## 1. `check-shell-portability.mjs` — 규칙에 강제력 부여 (#176)

`code_review.md` P1 은 GNU 전용 셸 구문을 오래전부터 should-block 으로 규정했는데 **강제하는 것이 없었다.** 그래서 `md5sum` 이 translator 에 실려 나가 macOS 에서 기사 안 모든 이미지를 한 파일로 붕괴시키고 exit 0 으로 성공 보고했다 (#172).

쉬운 절반은 토큰을 grep 하는 것이고, **가드의 생존을 결정하는 절반은 정상 코드를 안 잡는 것**이다. 이 저장소는 올바른 사용으로 가득하다 — `stat -c %Y f || stat -f %m f`, `sha256sum || shasum -a 256`, `sed --version` probe 분기 안의 `sed -i`, 그리고 `--timeout` **플래그를 설명하는 산문** 3건. 그런 걸 잡는 가드는 한 주 안에 꺼진다.

그래서 토큰은 **근처에 이식성을 만드는 것이 아무것도 없을 때만** 계수한다: 같은 줄의 `||`, capability probe, 4줄 이내의 BSD 대응물, 또는 명시적 `# portability-ok: <사유>`.

### 만들면서 나온 것 두 가지 — 둘 다 기록할 가치가 있다

**증거는 코드여야 한다.** 첫 버전은 근처 주석을 증거로 인정했다. 그런데 고쳐진 `md5sum` 줄 위 주석이 `cksum` 을 언급하고 있어서, **가드가 자기가 존재하는 이유인 바로 그 버그를 통과시켰다.** 이제 주석은 계수 전에 제거된다.

**`sed -i` 는 정밀한 부정 lookahead 가 필요했다.** "따옴표가 뒤따르면 제외" 는 BSD 의 `sed -i ''` 를 허용하려던 것인데, `sed -i "s/a/b/"` 까지 조용히 허용했다. 이제 빈 인자 형태만 제외한다.

```
FLAG  sed -i "s/a/b/" f      <- GNU 형태
FLAG  sed -i s/a/b/ f
pass  sed -i "" "s/a/b/" f   <- BSD
pass  sed -i '' "s/a/b/" f   <- BSD
pass  sed -i.bak "s/a/b/" f  <- 양쪽 호환
```

### 양방향 검증

| 방향 | 결과 |
|---|---|
| 현재 트리 | `245 files scanned, no unguarded GNU-only construct` (오탐 0) |
| 실제 결함 6종 재주입한 워크트리 | **정확히 6건 검출** — `md5sum` / `${VAR,,}` / `sed -i` / `grep -P` / `declare -A` / `stat -c` |

재주입한 것은 가상의 예제가 아니라 **이번 4개 PR 이 실제로 고친 결함들** 이다.

`.githooks/pre-commit` 과 `validate-codex.yml` 양쪽에 배선했다.

## 2. macOS CI 레그 (#182)

cr-fix 스위트가 품은 BSD 폴백 분기들은 **한 번도 실행된 적이 없다** — GNU 러너에서 GNU 절반만 assert 된다. 이 레그가 나머지 절반이 실제로 도는 유일한 지점이다.

**`env -i PATH=/usr/bin:/bin` 를 쓰지 않는다.** stock 유저랜드를 강제하는 명백한 방법이고 여기서는 틀렸다 — macOS 에서 `jq` 는 Homebrew 경로에 있고 스위트는 jq 위에 지어져 있어서, 그 형태로 돌리면 **아무것도 시험하지 못한 채 도구 부재로 죽는다.** (Linux 에서는 `/usr/bin/jq` 가 있어 통과하므로, 로컬에서만 확인했으면 그대로 올라갔을 것이다.)

대신 PATH 를 그대로 두어 jq 를 살리고, **이 레그가 존재하는 이유인 도구들이 정말 BSD 빌드인지 assert** 한다. GNU 빌드는 `--version` 에 답하고 BSD 는 거부하므로, `--version` 이 **성공하면** Homebrew coreutils 가 시스템 도구를 가린 것이고 이 레그는 ubuntu job 이 이미 하는 GNU 절반을 재시험하는 셈이다 — 시끄럽게 실패시킨다. 아무것도 증명하지 못한 green 보다 낫다.

스위트는 `bash` 가 아니라 **`/bin/bash`** 로 돌린다. 러너 이미지가 Homebrew bash 5 를 PATH 앞에 둘 수 있고, 실제 Mac 사용자의 `/bin/bash` 는 3.2 다. 5 로 돌리면 bash-4 전용 구문이 여기서 통과하고 사용자에게서 깨진다.

assert 로직은 **판별력이 있음을 확인했다** — GNU Linux 에서 실행하면 `sed`/`date`/`stat` 을 GNU 로 감지하고 exit 1 한다(= BSD 에서만 통과).

## 3. `measure-skills.mjs` (#180 잔여)

- **dotfile 필터** — `walkDepth` 가 `references/` 하위 전 파일을 `ref_files` 로 셌다. `.DS_Store` 는 gitignore 라 diff 에는 안 보이지만 이 스크립트는 워킹트리를 걷는다. `.DS_Store` 를 만들어 넣고 출력 해시가 동일함을 확인했다.
- **결정적 타이브레이크** — `lines` 동률이 `readdirSync` 순서를 유지했고 그건 ext4 와 APFS 가 다르다. 커밋된 CSV 에 실제 동률이 3개 있어 macOS 재생성 시 내용 변화 없이 diff 가 났다. plugin+skill 바이트 비교로 고정했다 — `localeCompare` 는 파일시스템 의존을 ICU 의존으로 바꿀 뿐이다.

---

## 감사 항목 하나는 무효다

감사의 "구조적 갭 F" 는 `.llmwiki/` lore 에서 `macOS` 문자열이 일괄 치환 사고로 손상됐다고 보고했다 (`"in / BSD sort"`, `"runs on in"`, `"a in-26 compatibility audit"`).

**저장소에 그런 문자열이 없다.** 지목된 두 파일은 `macOS` 를 정상적으로 포함한다 — `stock-userland-verification.md:12` 의 `"this script runs on macOS"`, `:56` 의 `"macOS-26 compatibility audit"`. 감사 에이전트가 자기 요약에서 누락된 텍스트를 원문의 손상으로 착각한 것으로 보인다. 고칠 것이 없어 고치지 않았고, 이 세션에서 감사가 근거 없이 제기한 유일한 항목이다.

---

## 검증

| 검사 | 결과 |
|---|---|
| `sync-codex-manifests.mjs --check` | up to date (24 manifests) |
| `sync-hermes-manifests.mjs --check` | up to date (14 adapter files, 7 plugins) |
| `check-doc-consistency.mjs` | OK — 24 plugins, Codex 23, Hermes 7 |
| `check-skill-tool-portability.mjs --check` | OK |
| **`check-shell-portability.mjs`** | **OK — 245 files, 0 findings** |
| `mock-load-hermes.py` | OK — 7 adapters |
| `cr-fix/tests/run-tests.sh` | 90 passed, 0 failed |
| `run-tests.sh` under `env -i PATH=/usr/bin:/bin` | 90 passed, 0 failed |
| workflow YAML | valid — `check` (ubuntu, 10 steps) + `macos` (macos-latest, 4 steps) |

플러그인 버전 범프 없음 — 이 PR 은 루트 문서·CI·`scripts/`·`docs/audit/` 만 건드리므로 `AGENTS.md` 규칙상 플러그인 콘텐츠가 아니다.

**macOS 레그의 실제 동작은 이 PR 의 CI 실행이 첫 증거가 된다.** 그 전까지는 `unverified` 다 — 로컬 검증은 assert 로직의 판별력(Linux 에서 exit 1)과 YAML 유효성까지다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cross-platform shell compatibility checks to prevent failures on macOS and other BSD-based environments.
  - Made skill measurement results more reliable by ignoring hidden system files and ensuring consistent ordering across platforms.

- **Chores**
  - Expanded automated validation with dedicated macOS checks and portability safeguards.
  - Updated project guidance and documentation to reflect the broader validation coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->