### PR TITLE
fix(llm-wiki): run Codex hooks on Windows

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Personal Claude Code plugin collection with 14 specialized plugins. Codex 0.135 + Hermes Agent native — generated `.agents/plugins/marketplace.json` + per-plugin `.codex-plugin/plugin.json` (`scripts/sync-codex-manifests.mjs`) and Hermes `plugin.yaml` + `__init__.py` adapters (`scripts/sync-hermes-manifests.mjs`).",
-    "version": "2.26.0"
+    "version": "2.27.0"
   },
   "plugins": [
     {
@@ -68,7 +68,7 @@
       "name": "llm-wiki",
       "source": "./plugins/llm-wiki",
       "description": "Karpathy LLM-Wiki 3-layer (insight + wiki + raw under neutral .llmwiki/): 5 skills (query/ingest/lint/bootstrap/migrate) + 5 hooks + bootstrap templates. Three soft hints plus an auto-capture/ingest path: a Stop hook mechanically captures ingest candidates to <root>/.staging/ and the next session's SessionStart drain hook surfaces them for ingest-finding curation (capture and curation split). Post-merge wiki ingest is a mandatory, force-logged step inside github-dev:post-merge (the standalone post-merge-wiki skill was removed — breaking, hence the 2.0.0 major bump). Promoted cross-agent rules graduate to .llmwiki/insight/ (via core-config prompt-inject hook), not .claude/rules/. Resolves .llmwiki/wiki -> legacy .claude/wiki -> .codex/wiki. Agent-facing wiki conventions deduped into references/wiki-conventions.md. Also ships plaud-note-taking, which corrects PLAUD voice-recorder Whisper transcripts against a project terminology dictionary and writes the result under .llmwiki/raw/transcripts/.",
-      "version": "2.7.1",
+      "version": "2.7.2",
       "category": "memory"
     },
     {

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -26,6 +26,10 @@ if command -v node >/dev/null 2>&1; then
   # at byte 0. All are invisible from the Claude Code side. Runs its own RED/GREEN
   # fixtures first, so a detector that stopped detecting fails here too.
   node "$repo_root/scripts/check-skill-contract.mjs"
+  # On Windows this runs every llm-wiki commandWindows entry through the real
+  # PowerShell -> Git Bash boundary. Other platforms report a deliberate skip;
+  # the Windows CI leg always exercises it.
+  node "$repo_root/scripts/windows-codex-hooks.test.mjs"
   # Skill-prose progressive-disclosure smell detector — INFORMATIONAL ONLY. It exits 0
   # regardless, but the `|| true` keeps it non-blocking even if node itself errors.
   node "$repo_root/scripts/check-skill-prose.mjs" || true

--- a/.github/workflows/validate-codex.yml
+++ b/.github/workflows/validate-codex.yml
@@ -112,3 +112,18 @@ jobs:
         run: /bin/bash plugins/github-dev/skills/cr-fix/tests/run-tests.sh
       - name: convene suite under /bin/bash (3.2) + BSD tools
         run: /bin/bash plugins/council/skills/convene/tests/run-tests.sh
+
+  # commandWindows is interpreted by PowerShell, not cmd.exe. This leg executes the
+  # descriptor's real command strings through powershell.exe and Git Bash so quoting,
+  # executable invocation, and PLUGIN_ROOT expansion cannot regress silently.
+  windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '20'
+      - name: execute bundled Codex hooks through PowerShell
+        run: node scripts/windows-codex-hooks.test.mjs

--- a/plugins/llm-wiki/.claude-plugin/plugin.json
+++ b/plugins/llm-wiki/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "llm-wiki",
-  "version": "2.7.1",
+  "version": "2.7.2",
   "description": "Karpathy LLM-Wiki 3-layer (insight + wiki + raw under neutral .llmwiki/): 5 skills (query/ingest/lint/bootstrap/migrate) + 5 hooks + bootstrap templates. Three soft hints plus an auto-capture/ingest path: a Stop hook mechanically captures ingest candidates to <root>/.staging/ and the next session's SessionStart drain hook surfaces them for ingest-finding curation (capture and curation split). Post-merge wiki ingest is a mandatory, force-logged step inside github-dev:post-merge (the standalone post-merge-wiki skill was removed — breaking, hence the 2.0.0 major bump). Promoted cross-agent rules graduate to .llmwiki/insight/ (via core-config prompt-inject hook), not .claude/rules/. Resolves .llmwiki/wiki -> legacy .claude/wiki -> .codex/wiki. Agent-facing wiki conventions deduped into references/wiki-conventions.md. Also ships plaud-note-taking, which corrects PLAUD voice-recorder Whisper transcripts against a project terminology dictionary and writes the result under .llmwiki/raw/transcripts/.",
   "hooks": {
     "UserPromptSubmit": [

--- a/plugins/llm-wiki/.codex-plugin/plugin.json
+++ b/plugins/llm-wiki/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "llm-wiki",
-  "version": "2.7.1",
+  "version": "2.7.2",
   "description": "Karpathy LLM-Wiki 3-layer (insight + wiki + raw under neutral .llmwiki/): 5 skills (query/ingest/lint/bootstrap/migrate) + 5 hooks + bootstrap templates. Three soft hints plus an auto-capture/ingest path: a Stop hook mechanically captures ingest candidates to <root>/.staging/ and the next session's SessionStart drain hook surfaces them for ingest-finding curation (capture and curation split). Post-merge wiki ingest is a mandatory, force-logged step inside github-dev:post-merge (the standalone post-merge-wiki skill was removed — breaking, hence the 2.0.0 major bump). Promoted cross-agent rules graduate to .llmwiki/insight/ (via core-config prompt-inject hook), not .claude/rules/. Resolves .llmwiki/wiki -> legacy .claude/wiki -> .codex/wiki. Agent-facing wiki conventions deduped into references/wiki-conventions.md. Also ships plaud-note-taking, which corrects PLAUD voice-recorder Whisper transcripts against a project terminology dictionary and writes the result under .llmwiki/raw/transcripts/.",
   "author": {
     "name": "YoungjaeDev"

--- a/plugins/llm-wiki/hooks/codex-hooks.json
+++ b/plugins/llm-wiki/hooks/codex-hooks.json
@@ -6,7 +6,7 @@
           {
             "type": "command",
             "command": "bash \"${PLUGIN_ROOT}/hooks/wiki_stale_check.sh\" codex",
-            "commandWindows": "& 'C:\\Program Files\\Git\\bin\\bash.exe' \"$env:PLUGIN_ROOT/hooks/wiki_stale_check.sh\" codex",
+            "commandWindows": "$git = Get-Command git.exe -CommandType Application -ErrorAction Stop; $bash = Join-Path (Split-Path (Split-Path $git.Source -Parent) -Parent) 'bin\\bash.exe'; if (-not (Test-Path -LiteralPath $bash)) { throw 'Git Bash not found beside git.exe' }; & $bash \"$env:PLUGIN_ROOT/hooks/wiki_stale_check.sh\" codex",
             "timeout": 5
           }
         ]
@@ -18,13 +18,13 @@
           {
             "type": "command",
             "command": "bash \"${PLUGIN_ROOT}/hooks/wiki_session_start_drain.sh\"",
-            "commandWindows": "& 'C:\\Program Files\\Git\\bin\\bash.exe' \"$env:PLUGIN_ROOT/hooks/wiki_session_start_drain.sh\"",
+            "commandWindows": "$git = Get-Command git.exe -CommandType Application -ErrorAction Stop; $bash = Join-Path (Split-Path (Split-Path $git.Source -Parent) -Parent) 'bin\\bash.exe'; if (-not (Test-Path -LiteralPath $bash)) { throw 'Git Bash not found beside git.exe' }; & $bash \"$env:PLUGIN_ROOT/hooks/wiki_session_start_drain.sh\"",
             "timeout": 5
           },
           {
             "type": "command",
             "command": "bash \"${PLUGIN_ROOT}/hooks/wiki_session_start_lint_hint.sh\"",
-            "commandWindows": "& 'C:\\Program Files\\Git\\bin\\bash.exe' \"$env:PLUGIN_ROOT/hooks/wiki_session_start_lint_hint.sh\"",
+            "commandWindows": "$git = Get-Command git.exe -CommandType Application -ErrorAction Stop; $bash = Join-Path (Split-Path (Split-Path $git.Source -Parent) -Parent) 'bin\\bash.exe'; if (-not (Test-Path -LiteralPath $bash)) { throw 'Git Bash not found beside git.exe' }; & $bash \"$env:PLUGIN_ROOT/hooks/wiki_session_start_lint_hint.sh\"",
             "timeout": 5
           }
         ]
@@ -36,7 +36,7 @@
           {
             "type": "command",
             "command": "bash \"${PLUGIN_ROOT}/hooks/wiki_session_capture.sh\"",
-            "commandWindows": "& 'C:\\Program Files\\Git\\bin\\bash.exe' \"$env:PLUGIN_ROOT/hooks/wiki_session_capture.sh\"",
+            "commandWindows": "$git = Get-Command git.exe -CommandType Application -ErrorAction Stop; $bash = Join-Path (Split-Path (Split-Path $git.Source -Parent) -Parent) 'bin\\bash.exe'; if (-not (Test-Path -LiteralPath $bash)) { throw 'Git Bash not found beside git.exe' }; & $bash \"$env:PLUGIN_ROOT/hooks/wiki_session_capture.sh\"",
             "timeout": 5
           }
         ]
@@ -48,7 +48,7 @@
           {
             "type": "command",
             "command": "bash \"${PLUGIN_ROOT}/hooks/wiki_session_capture.sh\"",
-            "commandWindows": "& 'C:\\Program Files\\Git\\bin\\bash.exe' \"$env:PLUGIN_ROOT/hooks/wiki_session_capture.sh\"",
+            "commandWindows": "$git = Get-Command git.exe -CommandType Application -ErrorAction Stop; $bash = Join-Path (Split-Path (Split-Path $git.Source -Parent) -Parent) 'bin\\bash.exe'; if (-not (Test-Path -LiteralPath $bash)) { throw 'Git Bash not found beside git.exe' }; & $bash \"$env:PLUGIN_ROOT/hooks/wiki_session_capture.sh\"",
             "timeout": 5
           }
         ]
@@ -61,7 +61,7 @@
           {
             "type": "command",
             "command": "bash \"${PLUGIN_ROOT}/hooks/wiki_post_commit_hint.sh\" codex",
-            "commandWindows": "& 'C:\\Program Files\\Git\\bin\\bash.exe' \"$env:PLUGIN_ROOT/hooks/wiki_post_commit_hint.sh\" codex",
+            "commandWindows": "$git = Get-Command git.exe -CommandType Application -ErrorAction Stop; $bash = Join-Path (Split-Path (Split-Path $git.Source -Parent) -Parent) 'bin\\bash.exe'; if (-not (Test-Path -LiteralPath $bash)) { throw 'Git Bash not found beside git.exe' }; & $bash \"$env:PLUGIN_ROOT/hooks/wiki_post_commit_hint.sh\" codex",
             "timeout": 5
           }
         ]

--- a/plugins/llm-wiki/hooks/codex-hooks.json
+++ b/plugins/llm-wiki/hooks/codex-hooks.json
@@ -6,7 +6,7 @@
           {
             "type": "command",
             "command": "bash \"${PLUGIN_ROOT}/hooks/wiki_stale_check.sh\" codex",
-            "commandWindows": "$git = Get-Command git.exe -CommandType Application -ErrorAction Stop; $bash = Join-Path (Split-Path (Split-Path $git.Source -Parent) -Parent) 'bin\\bash.exe'; if (-not (Test-Path -LiteralPath $bash)) { throw 'Git Bash not found beside git.exe' }; & $bash \"$env:PLUGIN_ROOT/hooks/wiki_stale_check.sh\" codex",
+            "commandWindows": "$git = Get-Command git.exe -CommandType Application -ErrorAction Stop | Select-Object -First 1; $bash = Join-Path (Split-Path (Split-Path $git.Source -Parent) -Parent) 'bin\\bash.exe'; if (-not (Test-Path -LiteralPath $bash)) { throw 'Git Bash not found beside git.exe' }; & $bash \"$env:PLUGIN_ROOT/hooks/wiki_stale_check.sh\" codex",
             "timeout": 5
           }
         ]
@@ -18,13 +18,13 @@
           {
             "type": "command",
             "command": "bash \"${PLUGIN_ROOT}/hooks/wiki_session_start_drain.sh\"",
-            "commandWindows": "$git = Get-Command git.exe -CommandType Application -ErrorAction Stop; $bash = Join-Path (Split-Path (Split-Path $git.Source -Parent) -Parent) 'bin\\bash.exe'; if (-not (Test-Path -LiteralPath $bash)) { throw 'Git Bash not found beside git.exe' }; & $bash \"$env:PLUGIN_ROOT/hooks/wiki_session_start_drain.sh\"",
+            "commandWindows": "$git = Get-Command git.exe -CommandType Application -ErrorAction Stop | Select-Object -First 1; $bash = Join-Path (Split-Path (Split-Path $git.Source -Parent) -Parent) 'bin\\bash.exe'; if (-not (Test-Path -LiteralPath $bash)) { throw 'Git Bash not found beside git.exe' }; & $bash \"$env:PLUGIN_ROOT/hooks/wiki_session_start_drain.sh\"",
             "timeout": 5
           },
           {
             "type": "command",
             "command": "bash \"${PLUGIN_ROOT}/hooks/wiki_session_start_lint_hint.sh\"",
-            "commandWindows": "$git = Get-Command git.exe -CommandType Application -ErrorAction Stop; $bash = Join-Path (Split-Path (Split-Path $git.Source -Parent) -Parent) 'bin\\bash.exe'; if (-not (Test-Path -LiteralPath $bash)) { throw 'Git Bash not found beside git.exe' }; & $bash \"$env:PLUGIN_ROOT/hooks/wiki_session_start_lint_hint.sh\"",
+            "commandWindows": "$git = Get-Command git.exe -CommandType Application -ErrorAction Stop | Select-Object -First 1; $bash = Join-Path (Split-Path (Split-Path $git.Source -Parent) -Parent) 'bin\\bash.exe'; if (-not (Test-Path -LiteralPath $bash)) { throw 'Git Bash not found beside git.exe' }; & $bash \"$env:PLUGIN_ROOT/hooks/wiki_session_start_lint_hint.sh\"",
             "timeout": 5
           }
         ]
@@ -36,7 +36,7 @@
           {
             "type": "command",
             "command": "bash \"${PLUGIN_ROOT}/hooks/wiki_session_capture.sh\"",
-            "commandWindows": "$git = Get-Command git.exe -CommandType Application -ErrorAction Stop; $bash = Join-Path (Split-Path (Split-Path $git.Source -Parent) -Parent) 'bin\\bash.exe'; if (-not (Test-Path -LiteralPath $bash)) { throw 'Git Bash not found beside git.exe' }; & $bash \"$env:PLUGIN_ROOT/hooks/wiki_session_capture.sh\"",
+            "commandWindows": "$git = Get-Command git.exe -CommandType Application -ErrorAction Stop | Select-Object -First 1; $bash = Join-Path (Split-Path (Split-Path $git.Source -Parent) -Parent) 'bin\\bash.exe'; if (-not (Test-Path -LiteralPath $bash)) { throw 'Git Bash not found beside git.exe' }; & $bash \"$env:PLUGIN_ROOT/hooks/wiki_session_capture.sh\"",
             "timeout": 5
           }
         ]
@@ -48,7 +48,7 @@
           {
             "type": "command",
             "command": "bash \"${PLUGIN_ROOT}/hooks/wiki_session_capture.sh\"",
-            "commandWindows": "$git = Get-Command git.exe -CommandType Application -ErrorAction Stop; $bash = Join-Path (Split-Path (Split-Path $git.Source -Parent) -Parent) 'bin\\bash.exe'; if (-not (Test-Path -LiteralPath $bash)) { throw 'Git Bash not found beside git.exe' }; & $bash \"$env:PLUGIN_ROOT/hooks/wiki_session_capture.sh\"",
+            "commandWindows": "$git = Get-Command git.exe -CommandType Application -ErrorAction Stop | Select-Object -First 1; $bash = Join-Path (Split-Path (Split-Path $git.Source -Parent) -Parent) 'bin\\bash.exe'; if (-not (Test-Path -LiteralPath $bash)) { throw 'Git Bash not found beside git.exe' }; & $bash \"$env:PLUGIN_ROOT/hooks/wiki_session_capture.sh\"",
             "timeout": 5
           }
         ]
@@ -61,7 +61,7 @@
           {
             "type": "command",
             "command": "bash \"${PLUGIN_ROOT}/hooks/wiki_post_commit_hint.sh\" codex",
-            "commandWindows": "$git = Get-Command git.exe -CommandType Application -ErrorAction Stop; $bash = Join-Path (Split-Path (Split-Path $git.Source -Parent) -Parent) 'bin\\bash.exe'; if (-not (Test-Path -LiteralPath $bash)) { throw 'Git Bash not found beside git.exe' }; & $bash \"$env:PLUGIN_ROOT/hooks/wiki_post_commit_hint.sh\" codex",
+            "commandWindows": "$git = Get-Command git.exe -CommandType Application -ErrorAction Stop | Select-Object -First 1; $bash = Join-Path (Split-Path (Split-Path $git.Source -Parent) -Parent) 'bin\\bash.exe'; if (-not (Test-Path -LiteralPath $bash)) { throw 'Git Bash not found beside git.exe' }; & $bash \"$env:PLUGIN_ROOT/hooks/wiki_post_commit_hint.sh\" codex",
             "timeout": 5
           }
         ]

--- a/plugins/llm-wiki/hooks/codex-hooks.json
+++ b/plugins/llm-wiki/hooks/codex-hooks.json
@@ -6,6 +6,7 @@
           {
             "type": "command",
             "command": "bash \"${PLUGIN_ROOT}/hooks/wiki_stale_check.sh\" codex",
+            "commandWindows": "& 'C:\\Program Files\\Git\\bin\\bash.exe' \"$env:PLUGIN_ROOT/hooks/wiki_stale_check.sh\" codex",
             "timeout": 5
           }
         ]
@@ -17,11 +18,13 @@
           {
             "type": "command",
             "command": "bash \"${PLUGIN_ROOT}/hooks/wiki_session_start_drain.sh\"",
+            "commandWindows": "& 'C:\\Program Files\\Git\\bin\\bash.exe' \"$env:PLUGIN_ROOT/hooks/wiki_session_start_drain.sh\"",
             "timeout": 5
           },
           {
             "type": "command",
             "command": "bash \"${PLUGIN_ROOT}/hooks/wiki_session_start_lint_hint.sh\"",
+            "commandWindows": "& 'C:\\Program Files\\Git\\bin\\bash.exe' \"$env:PLUGIN_ROOT/hooks/wiki_session_start_lint_hint.sh\"",
             "timeout": 5
           }
         ]
@@ -33,6 +36,7 @@
           {
             "type": "command",
             "command": "bash \"${PLUGIN_ROOT}/hooks/wiki_session_capture.sh\"",
+            "commandWindows": "& 'C:\\Program Files\\Git\\bin\\bash.exe' \"$env:PLUGIN_ROOT/hooks/wiki_session_capture.sh\"",
             "timeout": 5
           }
         ]
@@ -44,6 +48,7 @@
           {
             "type": "command",
             "command": "bash \"${PLUGIN_ROOT}/hooks/wiki_session_capture.sh\"",
+            "commandWindows": "& 'C:\\Program Files\\Git\\bin\\bash.exe' \"$env:PLUGIN_ROOT/hooks/wiki_session_capture.sh\"",
             "timeout": 5
           }
         ]
@@ -56,6 +61,7 @@
           {
             "type": "command",
             "command": "bash \"${PLUGIN_ROOT}/hooks/wiki_post_commit_hint.sh\" codex",
+            "commandWindows": "& 'C:\\Program Files\\Git\\bin\\bash.exe' \"$env:PLUGIN_ROOT/hooks/wiki_post_commit_hint.sh\" codex",
             "timeout": 5
           }
         ]

--- a/plugins/llm-wiki/hooks/codex-hooks.json
+++ b/plugins/llm-wiki/hooks/codex-hooks.json
@@ -6,7 +6,7 @@
           {
             "type": "command",
             "command": "bash \"${PLUGIN_ROOT}/hooks/wiki_stale_check.sh\" codex",
-            "commandWindows": "$bash = Get-Command git.exe -All -CommandType Application -ErrorAction Stop | ForEach-Object { $dir = Split-Path $_.Source -Parent; while ($dir) { $candidate = Join-Path $dir 'bin\\bash.exe'; if (Test-Path -LiteralPath $candidate) { $candidate; break }; $parent = Split-Path $dir -Parent; if ($parent -eq $dir) { break }; $dir = $parent } } | Select-Object -First 1; if (-not $bash) { throw 'Git Bash not found near git.exe on PATH' }; & $bash \"$env:PLUGIN_ROOT/hooks/wiki_stale_check.sh\" codex",
+            "commandWindows": "$bash = Get-Command git -All -CommandType Application -ErrorAction Stop | ForEach-Object { $gitPath = $_.Source; $seeds = @((Split-Path $gitPath -Parent)); $execPath = & $gitPath --exec-path 2>$null; if ($LASTEXITCODE -eq 0 -and $execPath) { $seeds += $execPath }; foreach ($seed in $seeds) { $dir = $seed; while ($dir) { $candidate = Join-Path $dir 'bin\\bash.exe'; if (Test-Path -LiteralPath $candidate) { $candidate; break }; $parent = Split-Path $dir -Parent; if ($parent -eq $dir) { break }; $dir = $parent } } } | Select-Object -First 1; if (-not $bash) { throw 'Git Bash not found through git on PATH' }; & $bash \"$env:PLUGIN_ROOT/hooks/wiki_stale_check.sh\" codex",
             "timeout": 5
           }
         ]
@@ -18,13 +18,13 @@
           {
             "type": "command",
             "command": "bash \"${PLUGIN_ROOT}/hooks/wiki_session_start_drain.sh\"",
-            "commandWindows": "$bash = Get-Command git.exe -All -CommandType Application -ErrorAction Stop | ForEach-Object { $dir = Split-Path $_.Source -Parent; while ($dir) { $candidate = Join-Path $dir 'bin\\bash.exe'; if (Test-Path -LiteralPath $candidate) { $candidate; break }; $parent = Split-Path $dir -Parent; if ($parent -eq $dir) { break }; $dir = $parent } } | Select-Object -First 1; if (-not $bash) { throw 'Git Bash not found near git.exe on PATH' }; & $bash \"$env:PLUGIN_ROOT/hooks/wiki_session_start_drain.sh\"",
+            "commandWindows": "$bash = Get-Command git -All -CommandType Application -ErrorAction Stop | ForEach-Object { $gitPath = $_.Source; $seeds = @((Split-Path $gitPath -Parent)); $execPath = & $gitPath --exec-path 2>$null; if ($LASTEXITCODE -eq 0 -and $execPath) { $seeds += $execPath }; foreach ($seed in $seeds) { $dir = $seed; while ($dir) { $candidate = Join-Path $dir 'bin\\bash.exe'; if (Test-Path -LiteralPath $candidate) { $candidate; break }; $parent = Split-Path $dir -Parent; if ($parent -eq $dir) { break }; $dir = $parent } } } | Select-Object -First 1; if (-not $bash) { throw 'Git Bash not found through git on PATH' }; & $bash \"$env:PLUGIN_ROOT/hooks/wiki_session_start_drain.sh\"",
             "timeout": 5
           },
           {
             "type": "command",
             "command": "bash \"${PLUGIN_ROOT}/hooks/wiki_session_start_lint_hint.sh\"",
-            "commandWindows": "$bash = Get-Command git.exe -All -CommandType Application -ErrorAction Stop | ForEach-Object { $dir = Split-Path $_.Source -Parent; while ($dir) { $candidate = Join-Path $dir 'bin\\bash.exe'; if (Test-Path -LiteralPath $candidate) { $candidate; break }; $parent = Split-Path $dir -Parent; if ($parent -eq $dir) { break }; $dir = $parent } } | Select-Object -First 1; if (-not $bash) { throw 'Git Bash not found near git.exe on PATH' }; & $bash \"$env:PLUGIN_ROOT/hooks/wiki_session_start_lint_hint.sh\"",
+            "commandWindows": "$bash = Get-Command git -All -CommandType Application -ErrorAction Stop | ForEach-Object { $gitPath = $_.Source; $seeds = @((Split-Path $gitPath -Parent)); $execPath = & $gitPath --exec-path 2>$null; if ($LASTEXITCODE -eq 0 -and $execPath) { $seeds += $execPath }; foreach ($seed in $seeds) { $dir = $seed; while ($dir) { $candidate = Join-Path $dir 'bin\\bash.exe'; if (Test-Path -LiteralPath $candidate) { $candidate; break }; $parent = Split-Path $dir -Parent; if ($parent -eq $dir) { break }; $dir = $parent } } } | Select-Object -First 1; if (-not $bash) { throw 'Git Bash not found through git on PATH' }; & $bash \"$env:PLUGIN_ROOT/hooks/wiki_session_start_lint_hint.sh\"",
             "timeout": 5
           }
         ]
@@ -36,7 +36,7 @@
           {
             "type": "command",
             "command": "bash \"${PLUGIN_ROOT}/hooks/wiki_session_capture.sh\"",
-            "commandWindows": "$bash = Get-Command git.exe -All -CommandType Application -ErrorAction Stop | ForEach-Object { $dir = Split-Path $_.Source -Parent; while ($dir) { $candidate = Join-Path $dir 'bin\\bash.exe'; if (Test-Path -LiteralPath $candidate) { $candidate; break }; $parent = Split-Path $dir -Parent; if ($parent -eq $dir) { break }; $dir = $parent } } | Select-Object -First 1; if (-not $bash) { throw 'Git Bash not found near git.exe on PATH' }; & $bash \"$env:PLUGIN_ROOT/hooks/wiki_session_capture.sh\"",
+            "commandWindows": "$bash = Get-Command git -All -CommandType Application -ErrorAction Stop | ForEach-Object { $gitPath = $_.Source; $seeds = @((Split-Path $gitPath -Parent)); $execPath = & $gitPath --exec-path 2>$null; if ($LASTEXITCODE -eq 0 -and $execPath) { $seeds += $execPath }; foreach ($seed in $seeds) { $dir = $seed; while ($dir) { $candidate = Join-Path $dir 'bin\\bash.exe'; if (Test-Path -LiteralPath $candidate) { $candidate; break }; $parent = Split-Path $dir -Parent; if ($parent -eq $dir) { break }; $dir = $parent } } } | Select-Object -First 1; if (-not $bash) { throw 'Git Bash not found through git on PATH' }; & $bash \"$env:PLUGIN_ROOT/hooks/wiki_session_capture.sh\"",
             "timeout": 5
           }
         ]
@@ -48,7 +48,7 @@
           {
             "type": "command",
             "command": "bash \"${PLUGIN_ROOT}/hooks/wiki_session_capture.sh\"",
-            "commandWindows": "$bash = Get-Command git.exe -All -CommandType Application -ErrorAction Stop | ForEach-Object { $dir = Split-Path $_.Source -Parent; while ($dir) { $candidate = Join-Path $dir 'bin\\bash.exe'; if (Test-Path -LiteralPath $candidate) { $candidate; break }; $parent = Split-Path $dir -Parent; if ($parent -eq $dir) { break }; $dir = $parent } } | Select-Object -First 1; if (-not $bash) { throw 'Git Bash not found near git.exe on PATH' }; & $bash \"$env:PLUGIN_ROOT/hooks/wiki_session_capture.sh\"",
+            "commandWindows": "$bash = Get-Command git -All -CommandType Application -ErrorAction Stop | ForEach-Object { $gitPath = $_.Source; $seeds = @((Split-Path $gitPath -Parent)); $execPath = & $gitPath --exec-path 2>$null; if ($LASTEXITCODE -eq 0 -and $execPath) { $seeds += $execPath }; foreach ($seed in $seeds) { $dir = $seed; while ($dir) { $candidate = Join-Path $dir 'bin\\bash.exe'; if (Test-Path -LiteralPath $candidate) { $candidate; break }; $parent = Split-Path $dir -Parent; if ($parent -eq $dir) { break }; $dir = $parent } } } | Select-Object -First 1; if (-not $bash) { throw 'Git Bash not found through git on PATH' }; & $bash \"$env:PLUGIN_ROOT/hooks/wiki_session_capture.sh\"",
             "timeout": 5
           }
         ]
@@ -61,7 +61,7 @@
           {
             "type": "command",
             "command": "bash \"${PLUGIN_ROOT}/hooks/wiki_post_commit_hint.sh\" codex",
-            "commandWindows": "$bash = Get-Command git.exe -All -CommandType Application -ErrorAction Stop | ForEach-Object { $dir = Split-Path $_.Source -Parent; while ($dir) { $candidate = Join-Path $dir 'bin\\bash.exe'; if (Test-Path -LiteralPath $candidate) { $candidate; break }; $parent = Split-Path $dir -Parent; if ($parent -eq $dir) { break }; $dir = $parent } } | Select-Object -First 1; if (-not $bash) { throw 'Git Bash not found near git.exe on PATH' }; & $bash \"$env:PLUGIN_ROOT/hooks/wiki_post_commit_hint.sh\" codex",
+            "commandWindows": "$bash = Get-Command git -All -CommandType Application -ErrorAction Stop | ForEach-Object { $gitPath = $_.Source; $seeds = @((Split-Path $gitPath -Parent)); $execPath = & $gitPath --exec-path 2>$null; if ($LASTEXITCODE -eq 0 -and $execPath) { $seeds += $execPath }; foreach ($seed in $seeds) { $dir = $seed; while ($dir) { $candidate = Join-Path $dir 'bin\\bash.exe'; if (Test-Path -LiteralPath $candidate) { $candidate; break }; $parent = Split-Path $dir -Parent; if ($parent -eq $dir) { break }; $dir = $parent } } } | Select-Object -First 1; if (-not $bash) { throw 'Git Bash not found through git on PATH' }; & $bash \"$env:PLUGIN_ROOT/hooks/wiki_post_commit_hint.sh\" codex",
             "timeout": 5
           }
         ]

--- a/plugins/llm-wiki/hooks/codex-hooks.json
+++ b/plugins/llm-wiki/hooks/codex-hooks.json
@@ -6,7 +6,7 @@
           {
             "type": "command",
             "command": "bash \"${PLUGIN_ROOT}/hooks/wiki_stale_check.sh\" codex",
-            "commandWindows": "$git = Get-Command git.exe -CommandType Application -ErrorAction Stop | Select-Object -First 1; $bash = Join-Path (Split-Path (Split-Path $git.Source -Parent) -Parent) 'bin\\bash.exe'; if (-not (Test-Path -LiteralPath $bash)) { throw 'Git Bash not found beside git.exe' }; & $bash \"$env:PLUGIN_ROOT/hooks/wiki_stale_check.sh\" codex",
+            "commandWindows": "$bash = Get-Command git.exe -All -CommandType Application -ErrorAction Stop | ForEach-Object { $dir = Split-Path $_.Source -Parent; while ($dir) { $candidate = Join-Path $dir 'bin\\bash.exe'; if (Test-Path -LiteralPath $candidate) { $candidate; break }; $parent = Split-Path $dir -Parent; if ($parent -eq $dir) { break }; $dir = $parent } } | Select-Object -First 1; if (-not $bash) { throw 'Git Bash not found near git.exe on PATH' }; & $bash \"$env:PLUGIN_ROOT/hooks/wiki_stale_check.sh\" codex",
             "timeout": 5
           }
         ]
@@ -18,13 +18,13 @@
           {
             "type": "command",
             "command": "bash \"${PLUGIN_ROOT}/hooks/wiki_session_start_drain.sh\"",
-            "commandWindows": "$git = Get-Command git.exe -CommandType Application -ErrorAction Stop | Select-Object -First 1; $bash = Join-Path (Split-Path (Split-Path $git.Source -Parent) -Parent) 'bin\\bash.exe'; if (-not (Test-Path -LiteralPath $bash)) { throw 'Git Bash not found beside git.exe' }; & $bash \"$env:PLUGIN_ROOT/hooks/wiki_session_start_drain.sh\"",
+            "commandWindows": "$bash = Get-Command git.exe -All -CommandType Application -ErrorAction Stop | ForEach-Object { $dir = Split-Path $_.Source -Parent; while ($dir) { $candidate = Join-Path $dir 'bin\\bash.exe'; if (Test-Path -LiteralPath $candidate) { $candidate; break }; $parent = Split-Path $dir -Parent; if ($parent -eq $dir) { break }; $dir = $parent } } | Select-Object -First 1; if (-not $bash) { throw 'Git Bash not found near git.exe on PATH' }; & $bash \"$env:PLUGIN_ROOT/hooks/wiki_session_start_drain.sh\"",
             "timeout": 5
           },
           {
             "type": "command",
             "command": "bash \"${PLUGIN_ROOT}/hooks/wiki_session_start_lint_hint.sh\"",
-            "commandWindows": "$git = Get-Command git.exe -CommandType Application -ErrorAction Stop | Select-Object -First 1; $bash = Join-Path (Split-Path (Split-Path $git.Source -Parent) -Parent) 'bin\\bash.exe'; if (-not (Test-Path -LiteralPath $bash)) { throw 'Git Bash not found beside git.exe' }; & $bash \"$env:PLUGIN_ROOT/hooks/wiki_session_start_lint_hint.sh\"",
+            "commandWindows": "$bash = Get-Command git.exe -All -CommandType Application -ErrorAction Stop | ForEach-Object { $dir = Split-Path $_.Source -Parent; while ($dir) { $candidate = Join-Path $dir 'bin\\bash.exe'; if (Test-Path -LiteralPath $candidate) { $candidate; break }; $parent = Split-Path $dir -Parent; if ($parent -eq $dir) { break }; $dir = $parent } } | Select-Object -First 1; if (-not $bash) { throw 'Git Bash not found near git.exe on PATH' }; & $bash \"$env:PLUGIN_ROOT/hooks/wiki_session_start_lint_hint.sh\"",
             "timeout": 5
           }
         ]
@@ -36,7 +36,7 @@
           {
             "type": "command",
             "command": "bash \"${PLUGIN_ROOT}/hooks/wiki_session_capture.sh\"",
-            "commandWindows": "$git = Get-Command git.exe -CommandType Application -ErrorAction Stop | Select-Object -First 1; $bash = Join-Path (Split-Path (Split-Path $git.Source -Parent) -Parent) 'bin\\bash.exe'; if (-not (Test-Path -LiteralPath $bash)) { throw 'Git Bash not found beside git.exe' }; & $bash \"$env:PLUGIN_ROOT/hooks/wiki_session_capture.sh\"",
+            "commandWindows": "$bash = Get-Command git.exe -All -CommandType Application -ErrorAction Stop | ForEach-Object { $dir = Split-Path $_.Source -Parent; while ($dir) { $candidate = Join-Path $dir 'bin\\bash.exe'; if (Test-Path -LiteralPath $candidate) { $candidate; break }; $parent = Split-Path $dir -Parent; if ($parent -eq $dir) { break }; $dir = $parent } } | Select-Object -First 1; if (-not $bash) { throw 'Git Bash not found near git.exe on PATH' }; & $bash \"$env:PLUGIN_ROOT/hooks/wiki_session_capture.sh\"",
             "timeout": 5
           }
         ]
@@ -48,7 +48,7 @@
           {
             "type": "command",
             "command": "bash \"${PLUGIN_ROOT}/hooks/wiki_session_capture.sh\"",
-            "commandWindows": "$git = Get-Command git.exe -CommandType Application -ErrorAction Stop | Select-Object -First 1; $bash = Join-Path (Split-Path (Split-Path $git.Source -Parent) -Parent) 'bin\\bash.exe'; if (-not (Test-Path -LiteralPath $bash)) { throw 'Git Bash not found beside git.exe' }; & $bash \"$env:PLUGIN_ROOT/hooks/wiki_session_capture.sh\"",
+            "commandWindows": "$bash = Get-Command git.exe -All -CommandType Application -ErrorAction Stop | ForEach-Object { $dir = Split-Path $_.Source -Parent; while ($dir) { $candidate = Join-Path $dir 'bin\\bash.exe'; if (Test-Path -LiteralPath $candidate) { $candidate; break }; $parent = Split-Path $dir -Parent; if ($parent -eq $dir) { break }; $dir = $parent } } | Select-Object -First 1; if (-not $bash) { throw 'Git Bash not found near git.exe on PATH' }; & $bash \"$env:PLUGIN_ROOT/hooks/wiki_session_capture.sh\"",
             "timeout": 5
           }
         ]
@@ -61,7 +61,7 @@
           {
             "type": "command",
             "command": "bash \"${PLUGIN_ROOT}/hooks/wiki_post_commit_hint.sh\" codex",
-            "commandWindows": "$git = Get-Command git.exe -CommandType Application -ErrorAction Stop | Select-Object -First 1; $bash = Join-Path (Split-Path (Split-Path $git.Source -Parent) -Parent) 'bin\\bash.exe'; if (-not (Test-Path -LiteralPath $bash)) { throw 'Git Bash not found beside git.exe' }; & $bash \"$env:PLUGIN_ROOT/hooks/wiki_post_commit_hint.sh\" codex",
+            "commandWindows": "$bash = Get-Command git.exe -All -CommandType Application -ErrorAction Stop | ForEach-Object { $dir = Split-Path $_.Source -Parent; while ($dir) { $candidate = Join-Path $dir 'bin\\bash.exe'; if (Test-Path -LiteralPath $candidate) { $candidate; break }; $parent = Split-Path $dir -Parent; if ($parent -eq $dir) { break }; $dir = $parent } } | Select-Object -First 1; if (-not $bash) { throw 'Git Bash not found near git.exe on PATH' }; & $bash \"$env:PLUGIN_ROOT/hooks/wiki_post_commit_hint.sh\" codex",
             "timeout": 5
           }
         ]

--- a/scripts/windows-codex-hooks.test.mjs
+++ b/scripts/windows-codex-hooks.test.mjs
@@ -20,7 +20,7 @@ const probeScript = '#!/usr/bin/env bash\nprintf \'CODEX_HOOK_PROBE:%s\\n\' "$*"
 const gitLookup = spawnSync('where.exe', ['git.exe'], { encoding: 'utf8' });
 assert.equal(gitLookup.status, 0, `git.exe must be on PATH: ${gitLookup.stderr || gitLookup.error || ''}`);
 const gitRoot = dirname(dirname(gitLookup.stdout.trim().split(/\r?\n/)[0]));
-const probePath = [join(gitRoot, 'cmd'), join(gitRoot, 'mingw64', 'bin'), process.env.PATH].join(';');
+const probePath = [join(gitRoot, 'mingw64', 'bin'), join(gitRoot, 'cmd'), process.env.PATH].join(';');
 
 try {
   let checked = 0;

--- a/scripts/windows-codex-hooks.test.mjs
+++ b/scripts/windows-codex-hooks.test.mjs
@@ -17,6 +17,10 @@ const descriptorPath = join(root, 'plugins', 'llm-wiki', 'hooks', 'codex-hooks.j
 const descriptor = JSON.parse(readFileSync(descriptorPath, 'utf8'));
 const probeRoot = mkdtempSync(join(tmpdir(), 'llm-wiki-codex-hooks-'));
 const probeScript = '#!/usr/bin/env bash\nprintf \'CODEX_HOOK_PROBE:%s\\n\' "$*"\n';
+const gitLookup = spawnSync('where.exe', ['git.exe'], { encoding: 'utf8' });
+assert.equal(gitLookup.status, 0, `git.exe must be on PATH: ${gitLookup.stderr || gitLookup.error || ''}`);
+const gitRoot = dirname(dirname(gitLookup.stdout.trim().split(/\r?\n/)[0]));
+const probePath = [join(gitRoot, 'cmd'), join(gitRoot, 'mingw64', 'bin'), process.env.PATH].join(';');
 
 try {
   let checked = 0;
@@ -42,16 +46,16 @@ try {
 
         const scriptMatch = hook.command.match(/\$\{PLUGIN_ROOT\}\/([^"']+\.sh)/);
         assert.ok(scriptMatch, `${label} must reference a PLUGIN_ROOT-relative shell script`);
-        const probePath = join(probeRoot, ...scriptMatch[1].split('/'));
-        mkdirSync(dirname(probePath), { recursive: true });
-        writeFileSync(probePath, probeScript);
+        const probeScriptPath = join(probeRoot, ...scriptMatch[1].split('/'));
+        mkdirSync(dirname(probeScriptPath), { recursive: true });
+        writeFileSync(probeScriptPath, probeScript);
 
         const result = spawnSync(
           'powershell.exe',
           ['-NoProfile', '-NonInteractive', '-Command', hook.commandWindows],
           {
             cwd: probeRoot,
-            env: { ...process.env, PLUGIN_ROOT: probeRoot },
+            env: { ...process.env, PATH: probePath, PLUGIN_ROOT: probeRoot },
             encoding: 'utf8',
             input: '{}\n',
           },

--- a/scripts/windows-codex-hooks.test.mjs
+++ b/scripts/windows-codex-hooks.test.mjs
@@ -29,6 +29,16 @@ try {
           'string',
           `${label} must provide a PowerShell-compatible commandWindows override`,
         );
+        assert.doesNotMatch(
+          hook.commandWindows,
+          /Program Files\\Git/i,
+          `${label} must not assume Git Bash is installed in the machine-wide default directory`,
+        );
+        assert.match(
+          hook.commandWindows,
+          /Get-Command git(?:\.exe)?/,
+          `${label} must derive Git Bash from the Git executable on PATH`,
+        );
 
         const scriptMatch = hook.command.match(/\$\{PLUGIN_ROOT\}\/([^"']+\.sh)/);
         assert.ok(scriptMatch, `${label} must reference a PLUGIN_ROOT-relative shell script`);

--- a/scripts/windows-codex-hooks.test.mjs
+++ b/scripts/windows-codex-hooks.test.mjs
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { basename, dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+if (process.platform !== 'win32') {
+  console.log('skip: Windows Codex hook execution test requires powershell.exe');
+  process.exit(0);
+}
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const descriptorPath = join(root, 'plugins', 'llm-wiki', 'hooks', 'codex-hooks.json');
+const descriptor = JSON.parse(readFileSync(descriptorPath, 'utf8'));
+const probeRoot = mkdtempSync(join(tmpdir(), 'llm-wiki-codex-hooks-'));
+const probeScript = '#!/usr/bin/env bash\nprintf \'CODEX_HOOK_PROBE:%s\\n\' "$*"\n';
+
+try {
+  let checked = 0;
+  for (const [event, groups] of Object.entries(descriptor.hooks)) {
+    for (const [groupIndex, group] of groups.entries()) {
+      for (const [hookIndex, hook] of group.hooks.entries()) {
+        const label = `${event}[${groupIndex}].hooks[${hookIndex}]`;
+        assert.equal(
+          typeof hook.commandWindows,
+          'string',
+          `${label} must provide a PowerShell-compatible commandWindows override`,
+        );
+
+        const scriptMatch = hook.command.match(/\$\{PLUGIN_ROOT\}\/([^"']+\.sh)/);
+        assert.ok(scriptMatch, `${label} must reference a PLUGIN_ROOT-relative shell script`);
+        const probePath = join(probeRoot, ...scriptMatch[1].split('/'));
+        mkdirSync(dirname(probePath), { recursive: true });
+        writeFileSync(probePath, probeScript);
+
+        const result = spawnSync(
+          'powershell.exe',
+          ['-NoProfile', '-NonInteractive', '-Command', hook.commandWindows],
+          {
+            cwd: probeRoot,
+            env: { ...process.env, PLUGIN_ROOT: probeRoot },
+            encoding: 'utf8',
+            input: '{}\n',
+          },
+        );
+
+        assert.equal(
+          result.status,
+          0,
+          `${label} failed via PowerShell (${basename(scriptMatch[1])}): ${result.stderr || result.error || ''}`,
+        );
+        assert.match(result.stdout, /CODEX_HOOK_PROBE:/, `${label} did not execute its shell script`);
+        checked++;
+      }
+    }
+  }
+
+  assert.ok(checked > 0, 'descriptor must contain at least one command hook');
+  console.log(`ok: ${checked} llm-wiki Codex hooks execute through PowerShell`);
+} finally {
+  rmSync(probeRoot, { recursive: true, force: true });
+}

--- a/scripts/windows-codex-hooks.test.mjs
+++ b/scripts/windows-codex-hooks.test.mjs
@@ -19,8 +19,15 @@ const probeRoot = mkdtempSync(join(tmpdir(), 'llm-wiki-codex-hooks-'));
 const probeScript = '#!/usr/bin/env bash\nprintf \'CODEX_HOOK_PROBE:%s\\n\' "$*"\n';
 const gitLookup = spawnSync('where.exe', ['git.exe'], { encoding: 'utf8' });
 assert.equal(gitLookup.status, 0, `git.exe must be on PATH: ${gitLookup.stderr || gitLookup.error || ''}`);
-const gitRoot = dirname(dirname(gitLookup.stdout.trim().split(/\r?\n/)[0]));
-const probePath = [join(gitRoot, 'mingw64', 'bin'), join(gitRoot, 'cmd'), process.env.PATH].join(';');
+const gitExecutable = gitLookup.stdout.trim().split(/\r?\n/)[0];
+const shimDir = join(probeRoot, 'git-shim');
+mkdirSync(shimDir, { recursive: true });
+writeFileSync(join(shimDir, 'git.cmd'), `@echo off\r\n"${gitExecutable}" %*\r\n`);
+const probePath = [
+  shimDir,
+  join(process.env.SystemRoot, 'System32'),
+  join(process.env.SystemRoot, 'System32', 'WindowsPowerShell', 'v1.0'),
+].join(';');
 
 try {
   let checked = 0;
@@ -43,6 +50,7 @@ try {
           /Get-Command git(?:\.exe)?/,
           `${label} must derive Git Bash from the Git executable on PATH`,
         );
+        assert.match(hook.commandWindows, /--exec-path/, `${label} must resolve Git installations behind PATH shims`);
 
         const scriptMatch = hook.command.match(/\$\{PLUGIN_ROOT\}\/([^"']+\.sh)/);
         assert.ok(scriptMatch, `${label} must reference a PLUGIN_ROOT-relative shell script`);


### PR DESCRIPTION
## Summary
- add PowerShell-compatible `commandWindows` overrides for all bundled llm-wiki Codex hooks
- add a Windows execution regression test that runs the real descriptor commands through PowerShell and Git Bash
- add a Windows CI leg and bump llm-wiki to 2.7.2 / marketplace to 2.27.0

## Root cause
The Windows overrides used POSIX or cmd-style invocation. Codex executes `commandWindows` with PowerShell, where a quoted executable path requires the call operator and plugin paths must use `$env:PLUGIN_ROOT`.

## Validation
- `node scripts/windows-codex-hooks.test.mjs` (6 hooks executed)
- `node --test scripts/sync-codex-manifests.test.mjs`
- Codex/Hermes manifest checks
- doc, skill portability, shell portability, and skill contract checks
- Hermes adapter mock-load in UTF-8 mode
- council fixture suite

## Issue
No linked issue: this fixes the locally reproduced Windows hook failure reported during plugin runtime cleanup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Windows support for all llm-wiki Codex lifecycle hooks, including Git Bash discovery and execution.

* **Bug Fixes**
  * Improved reliability of hook execution on Windows.

* **Tests**
  * Added integration checks and continuous integration validation for Windows hook commands.

* **Chores**
  * Updated the marketplace and llm-wiki plugin versions.
  * Added automated validation for Windows hook configuration issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->